### PR TITLE
Tweaking output of publicationsComparator task

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,7 @@ dependencies {
 
     compile "com.github.cliftonlabs:json-simple:2.1.2"
     compile 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.7.3'
+    compile 'com.googlecode.java-diff-utils:diffutils:1.3.0'
 
     testCompile("org.spockframework:spock-core:0.7-groovy-2.0") {
         exclude module: "groovy-all"

--- a/src/main/groovy/org/shipkit/gradle/ReleaseNeededTask.java
+++ b/src/main/groovy/org/shipkit/gradle/ReleaseNeededTask.java
@@ -5,6 +5,7 @@ import org.gradle.api.GradleException;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
 import org.gradle.api.tasks.TaskAction;
+import org.shipkit.internal.comparison.diff.Diff;
 import org.shipkit.internal.util.EnvVariables;
 import org.shipkit.internal.comparison.PublicationsComparatorTask;
 import org.shipkit.internal.util.ExposedForTesting;
@@ -126,6 +127,8 @@ public class ReleaseNeededTask extends DefaultTask {
 
         boolean allPublicationsEqual = areAllPublicationsEqual();
 
+       logDifferencesBetweenPublications();
+
         boolean releaseNotNeeded = allPublicationsEqual || skipEnvVariable || skippedByCommitMessage || pullRequest || !releasableBranch;
 
         String message = "  Release is needed: " + !releaseNotNeeded +
@@ -142,6 +145,26 @@ public class ReleaseNeededTask extends DefaultTask {
         }
 
         return !releaseNotNeeded;
+    }
+
+    private void logDifferencesBetweenPublications() {
+        if(publicationsComparators.isEmpty()){
+           return; // no differences to log
+        }
+        LOG.lifecycle("\n  Results of publications comparison:\n");
+        for(PublicationsComparatorTask task : publicationsComparators){
+            for(Diff diff : task.getDifferences()){
+                if(!diff.areFilesEqual()) {
+                    LOG.lifecycle("  Difference between files:\n"
+                                + "  --- {}\n"
+                                + "  +++ {}\n\n{}\n",
+                            diff.getPreviousFile(),
+                            diff.getCurrentFile(),
+                            diff.getDiffOutput());
+                }
+            }
+        }
+
     }
 
     public void addPublicationsComparator(PublicationsComparatorTask task) {

--- a/src/main/groovy/org/shipkit/internal/comparison/FileComparator.java
+++ b/src/main/groovy/org/shipkit/internal/comparison/FileComparator.java
@@ -1,7 +1,0 @@
-package org.shipkit.internal.comparison;
-
-import java.io.File;
-
-interface FileComparator {
-    boolean areEqual(File one, File other);
-}

--- a/src/main/groovy/org/shipkit/internal/comparison/diff/Diff.java
+++ b/src/main/groovy/org/shipkit/internal/comparison/diff/Diff.java
@@ -1,0 +1,42 @@
+package org.shipkit.internal.comparison.diff;
+
+import java.io.File;
+
+public class Diff {
+
+    private final File previousFile;
+    private final File currentFile;
+    private final boolean filesEqual;
+    private final String diffOutput;
+
+    private Diff(File previousFile, File currentFile, boolean filesEqual, String diffOutput) {
+        this.previousFile = previousFile;
+        this.currentFile = currentFile;
+        this.filesEqual = filesEqual;
+        this.diffOutput = diffOutput;
+    }
+
+    public static Diff ofEqualFiles(File previousFile, File currentFile){
+        return new Diff(previousFile, currentFile, true, "");
+    }
+
+    public static Diff ofDifferentFiles(File previousFile, File currentFile, String diffOutput){
+        return new Diff(previousFile, currentFile, false, diffOutput);
+    }
+
+    public File getPreviousFile() {
+        return previousFile;
+    }
+
+    public File getCurrentFile() {
+        return currentFile;
+    }
+
+    public boolean areFilesEqual() {
+        return filesEqual;
+    }
+
+    public String getDiffOutput() {
+        return diffOutput;
+    }
+}

--- a/src/main/groovy/org/shipkit/internal/comparison/diff/DirectoryDiffGenerator.java
+++ b/src/main/groovy/org/shipkit/internal/comparison/diff/DirectoryDiffGenerator.java
@@ -1,0 +1,27 @@
+package org.shipkit.internal.comparison.diff;
+
+import java.util.List;
+
+public class DirectoryDiffGenerator {
+
+    public String generateDiffOutput(List<String> addedFiles, List<String> removedFiles, List<String> changedFiles) {
+        StringBuilder sb = new StringBuilder();
+
+        appendFiles(sb, addedFiles, "Added files", "++");
+        appendFiles(sb, removedFiles, "Removed files", "--");
+        appendFiles(sb, changedFiles, "Modified files", "+-");
+
+        return sb.toString();
+    }
+
+    private void appendFiles(StringBuilder sb, List<String> changedFiles, String fileType, String symbol) {
+        if(changedFiles != null && !changedFiles.isEmpty()){
+            String header = String.format("    %s:\n", fileType);
+            sb.append(header);
+            for(String changed : changedFiles){
+                sb.append(String.format("    %s %s\n", symbol, changed));
+            }
+            sb.append("\n");
+        }
+    }
+}

--- a/src/main/groovy/org/shipkit/internal/comparison/diff/FileDiffGenerator.java
+++ b/src/main/groovy/org/shipkit/internal/comparison/diff/FileDiffGenerator.java
@@ -1,0 +1,41 @@
+package org.shipkit.internal.comparison.diff;
+
+import difflib.DiffUtils;
+import difflib.Patch;
+import org.shipkit.internal.gradle.util.StringUtil;
+
+import java.util.Arrays;
+import java.util.List;
+
+public class FileDiffGenerator {
+
+    private static final String INDENTATION = "    ";
+
+    /**
+     * generates diff between contents of two files in the same format as "git diff"
+     */
+    public String generateDiff(String previousFilePath, String currentFilePath, String previousContent, String currentContent) {
+        List<String> previousLines = breakIntoLines(previousContent);
+        List<String> currentLines = breakIntoLines(currentContent);
+
+        Patch patch = DiffUtils.diff(previousLines, currentLines);
+
+        List<String> unifiedDiff = DiffUtils.generateUnifiedDiff(previousFilePath, currentFilePath, previousLines, patch, 0);
+
+        if(unifiedDiff.size() <= 2){
+            return ""; // no differences found
+        }
+
+        List<String> diffWithoutFileNames = unifiedDiff.subList(2, unifiedDiff.size()); // remove file names
+
+        return INDENTATION + StringUtil.join(diffWithoutFileNames, getLineSeparator() + INDENTATION);
+    }
+
+    private List<String> breakIntoLines(String previousContent) {
+        return Arrays.asList(previousContent.split(getLineSeparator()));
+    }
+
+    private String getLineSeparator(){
+        return System.getProperty("line.separator");
+    }
+}

--- a/src/test/groovy/org/shipkit/internal/comparison/PomComparatorTest.groovy
+++ b/src/test/groovy/org/shipkit/internal/comparison/PomComparatorTest.groovy
@@ -27,7 +27,7 @@ class PomComparatorTest extends Specification {
         remover.filter(rightContent) >> rightParsedContent
 
         expect:
-        pomComparator.areEqual(leftFile, rightFile) == expectedResult
+        pomComparator.areEqual(leftFile, rightFile).areFilesEqual() == expectedResult
 
         where:
         leftParsedContent | rightParsedContent    | expectedResult

--- a/src/test/groovy/org/shipkit/internal/comparison/diff/DirectoryDiffGeneratorTest.groovy
+++ b/src/test/groovy/org/shipkit/internal/comparison/diff/DirectoryDiffGeneratorTest.groovy
@@ -1,0 +1,35 @@
+package org.shipkit.internal.comparison.diff
+
+import spock.lang.Specification
+
+class DirectoryDiffGeneratorTest extends Specification {
+
+    def "handles empty lists correctly"() {
+        expect:
+        new DirectoryDiffGenerator().generateDiffOutput([], [], []) == ""
+    }
+
+    def "handles null lists correctly"() {
+        expect:
+        new DirectoryDiffGenerator().generateDiffOutput(null, null, null) == ""
+    }
+
+    def "generates diffOutput correctly"() {
+        when:
+        def result = new DirectoryDiffGenerator().generateDiffOutput(["6.txt"], ["1.txt", "5.txt"], ["2.txt"])
+
+        then:
+        result ==
+                """    Added files:
+    ++ 6.txt
+
+    Removed files:
+    -- 1.txt
+    -- 5.txt
+
+    Modified files:
+    +- 2.txt
+
+"""
+    }
+}

--- a/src/test/groovy/org/shipkit/internal/comparison/diff/FileDiffGeneratorTest.groovy
+++ b/src/test/groovy/org/shipkit/internal/comparison/diff/FileDiffGeneratorTest.groovy
@@ -1,0 +1,50 @@
+package org.shipkit.internal.comparison.diff
+
+import spock.lang.Specification
+
+class FileDiffGeneratorTest extends Specification {
+
+    def "handles empty files"() {
+        when:
+        def result = new FileDiffGenerator().generateDiff("", "", "", "")
+
+        then:
+        result == ""
+    }
+
+    def "handles different files"() {
+        when:
+        def result = new FileDiffGenerator().generateDiff("a", "b",
+"""
+aa
+bb
+cc
+dd
+ee
+""",
+"""
+ee
+bb
+cc
+ff
+""")
+
+        then:
+        result ==
+"""    @@ -2,1 +2,1 @@
+    -aa
+    +ee
+    @@ -5,2 +5,1 @@
+    -dd
+    -ee
+    +ff"""
+    }
+
+    def "handles same files"() {
+        when:
+        def result = new FileDiffGenerator().generateDiff("a", "b", "aa\nbb", "aa\nbb")
+
+        then:
+        result == ""
+    }
+}


### PR DESCRIPTION
I made a few tweaks. Only differences between poms/zips is displayed now, no contents. I added a small dependency on diffutils. I did a research and this one is the smallest one that does the job, in my opinion. XMLUnit would be also nice for comparing poms but is a few times bigger (136 KB vs 36 KB). Diffutils presents changes in a nice familiar "git diff" way. You can see it below. Maybe we can start with it for version 1.0, and later replace it with our own implementation (or some other one) if we need to.

With these changes output of example looks like that:

```
:impl:comparePublications
:impl:comparePublications - about to compare publications, for versions 0.15.2 and 0.15.11
:impl:comparePublications - pom files equal: false
:impl:comparePublications - source jars equal: false
:assertReleaseNeeded
  Environment variable SKIP_RELEASE present: false
  Commit message to inspect for keyword '[ci skip-release]': <unknown commit message>
  Current branch 'master' matches 'master|release/.+': true

  Results of publications comparison:

  Difference between files:
  --- /Users/wojtekwilk/Projects/mockito-release-tools-example/subprojects/api/build/previous-release-artifacts/api-0.15.2-sources.jar
  +++ /Users/wojtekwilk/Projects/mockito-release-tools-example/subprojects/api/build/libs/api-0.15.11-sources.jar

    Modified files:
    +- org/mockito/releasetools/example/SomeApi.java



  Difference between files:
  --- /Users/wojtekwilk/Projects/mockito-release-tools-example/subprojects/api/build/previous-release-artifacts/api-0.15.2.pom
  +++ /Users/wojtekwilk/Projects/mockito-release-tools-example/subprojects/api/build/publications/javaLibrary/pom-default.xml

    @@ -5,0 +5,8 @@
    +  <dependencies>
    +    <dependency>
    +      <groupId>com.googlecode.java-diff-utils</groupId>
    +      <artifactId>diffutils</artifactId>
    +      <version>1.3.0</version>
    +      <scope>runtime</scope>
    +    </dependency>
    +  </dependencies>
    @@ -8,1 +16,0 @@
    -  <description/>

  Difference between files:
  --- /Users/wojtekwilk/Projects/mockito-release-tools-example/subprojects/impl/build/previous-release-artifacts/impl-0.15.2-sources.jar
  +++ /Users/wojtekwilk/Projects/mockito-release-tools-example/subprojects/impl/build/libs/impl-0.15.11-sources.jar

    Added files:
    ++ Test.java

    Removed files:
    -- Library.java



  Difference between files:
  --- /Users/wojtekwilk/Projects/mockito-release-tools-example/subprojects/impl/build/previous-release-artifacts/impl-0.15.2.pom
  +++ /Users/wojtekwilk/Projects/mockito-release-tools-example/subprojects/impl/build/publications/javaLibrary/pom-default.xml

    @@ -22,1 +22,0 @@
    -  <description/>

  Release is needed: true
    - skip by env variable: false
    - skip by commit message: false
    - is pull request build:  false
    - is releasable branch:  true
    - anything changed in publications since the previous release:  true
```