### PR TITLE
Draft of generating release notes when previousVersion is null

### DIFF
--- a/src/main/groovy/org/shipkit/gradle/ReleaseNotesFetcherTask.java
+++ b/src/main/groovy/org/shipkit/gradle/ReleaseNotesFetcherTask.java
@@ -2,6 +2,7 @@ package org.shipkit.gradle;
 
 import org.gradle.api.DefaultTask;
 import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.Optional;
 import org.gradle.api.tasks.OutputFile;
 import org.gradle.api.tasks.TaskAction;
 import org.shipkit.internal.gradle.util.ReleaseNotesSerializer;
@@ -12,8 +13,10 @@ import org.shipkit.internal.notes.util.IOUtil;
 import org.shipkit.internal.notes.vcs.IgnoredCommit;
 
 import java.io.File;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.List;
 
 import static java.util.Arrays.asList;
 
@@ -22,7 +25,7 @@ import static java.util.Arrays.asList;
  */
 public class ReleaseNotesFetcherTask extends DefaultTask {
 
-    @Input private String previousVersion;
+    @Input @Optional private String previousVersion;
     @Input private String version = getProject().getVersion().toString();
     @Input private String gitHubReadOnlyAuthToken;
     @Input private String gitHubRepository;
@@ -181,8 +184,9 @@ public class ReleaseNotesFetcherTask extends DefaultTask {
         ReleaseNotesGenerator generator = ReleaseNotesGenerators.releaseNotesGenerator(
                 gitWorkDir, gitHubRepository, gitHubReadOnlyAuthToken, new IgnoredCommit(ignoreCommitsContaining));
 
+        List<String> targetVersions = previousVersion == null ? new ArrayList<String>() : asList(previousVersion);
         Collection<ReleaseNotesData> releaseNotes = generator.generateReleaseNotesData(
-                version, asList(previousVersion), tagPrefix, gitHubLabels, onlyPullRequests);
+                version, targetVersions, tagPrefix, gitHubLabels, onlyPullRequests);
 
         ReleaseNotesSerializer releaseNotesSerializer = new ReleaseNotesSerializer();
         final String serializedData = releaseNotesSerializer.serialize(releaseNotes);

--- a/src/main/groovy/org/shipkit/gradle/UpdateReleaseNotesTask.java
+++ b/src/main/groovy/org/shipkit/gradle/UpdateReleaseNotesTask.java
@@ -180,6 +180,7 @@ public class UpdateReleaseNotesTask extends DefaultTask {
      * Previous released version we generate the release notes from.
      */
     @Input
+    @Optional
     public String getPreviousVersion() {
         return previousVersion;
     }

--- a/src/main/groovy/org/shipkit/gradle/UpdateReleaseNotesTask.java
+++ b/src/main/groovy/org/shipkit/gradle/UpdateReleaseNotesTask.java
@@ -330,8 +330,7 @@ public class UpdateReleaseNotesTask extends DefaultTask {
 
             Collection<ReleaseNotesData> data = new ReleaseNotesSerializer().deserialize(IOUtil.readFully(releaseNotesData));
 
-            String vcsCommitTemplate = "https://github.com/" + gitHubRepository + "/compare/"
-                    + tagPrefix + previousVersion + "..." + tagPrefix + version;
+            String vcsCommitTemplate = getVcsCommitTemplate();
 
             ProjectContributorsSet contributorsFromGitHub;
             if(!contributors.isEmpty()) {
@@ -348,6 +347,15 @@ public class UpdateReleaseNotesTask extends DefaultTask {
                     .formatReleaseNotes(data);
 
             return notes + "\n\n";
+        }
+    }
+
+    public String getVcsCommitTemplate() {
+        if(previousVersion != null) {
+            return "https://github.com/" + gitHubRepository + "/compare/"
+                    + tagPrefix + previousVersion + "..." + tagPrefix + version;
+        } else{
+            return "";
         }
     }
 }

--- a/src/main/groovy/org/shipkit/internal/notes/format/DetailedFormatter.java
+++ b/src/main/groovy/org/shipkit/internal/notes/format/DetailedFormatter.java
@@ -1,5 +1,6 @@
 package org.shipkit.internal.notes.format;
 
+import org.shipkit.internal.gradle.util.StringUtil;
 import org.shipkit.internal.util.MultiMap;
 import org.shipkit.internal.notes.internal.DateFormat;
 import org.shipkit.internal.notes.model.*;
@@ -147,7 +148,8 @@ class DetailedFormatter implements MultiReleaseNotesFormatter {
     }
 
     private static String link(String text, String link) {
-        return "[" + text + "](" + link + ")";
+        return StringUtil.isEmpty(link) ? text :
+                "[" + text + "](" + link + ")";
     }
 
     private static String allAuthors(ContributionSet contributions, Map<String, Contributor> contributors) {

--- a/src/main/groovy/org/shipkit/internal/notes/generator/DefaultReleaseNotesGenerator.java
+++ b/src/main/groovy/org/shipkit/internal/notes/generator/DefaultReleaseNotesGenerator.java
@@ -48,7 +48,7 @@ class DefaultReleaseNotesGenerator implements ReleaseNotesGenerator {
         Collection<ReleasedVersion> versions = releasedVersionsProvider.getReleasedVersions(headVersion, new Date(), targetVersions, tagPrefix);
 
         for (ReleasedVersion v : versions) {
-            if (v.getPreviousRev() == null) {
+            if (versions.size() > 1 && v.getPreviousRev() == null) {
                 continue;
             }
             ContributionSet contributions = contributionsProvider.getContributionsBetween(v.getPreviousRev(), v.getRev());

--- a/src/main/groovy/org/shipkit/internal/notes/internal/DefaultReleaseNotesData.java
+++ b/src/main/groovy/org/shipkit/internal/notes/internal/DefaultReleaseNotesData.java
@@ -79,7 +79,7 @@ public class DefaultReleaseNotesData implements ReleaseNotesData {
                 Jsoner.escape(String.valueOf(date.getTime())),
                 contributions.toJson(),
                 improvementsBuilder.toString(),
-                Jsoner.escape(previousVersionTag),
+                Jsoner.escape(previousVersionTag == null ? "" : previousVersionTag),
                 Jsoner.escape(thisVersionTag)
         );
     }

--- a/src/main/groovy/org/shipkit/internal/notes/vcs/DefaultReleasedVersionsProvider.java
+++ b/src/main/groovy/org/shipkit/internal/notes/vcs/DefaultReleasedVersionsProvider.java
@@ -22,7 +22,7 @@ class DefaultReleasedVersionsProvider implements ReleasedVersionsProvider {
         //collect the versions
         if (versions.size() == 0 && headVersion == null) {
             throw new IllegalArgumentException("Not enough versions supplied." +
-                    "\n  I need at least 1 versions." +
+                    "\n  I need at least 1 version." +
                     "\n   - head version: " + headVersion +
                     "\n   - versions: " + versions);
         }

--- a/src/main/groovy/org/shipkit/internal/notes/vcs/DefaultReleasedVersionsProvider.java
+++ b/src/main/groovy/org/shipkit/internal/notes/vcs/DefaultReleasedVersionsProvider.java
@@ -20,9 +20,9 @@ class DefaultReleasedVersionsProvider implements ReleasedVersionsProvider {
     @Override
     public Collection<ReleasedVersion> getReleasedVersions(String headVersion, Date headDate, Collection<String> versions, String tagPrefix) {
         //collect the versions
-        if (versions.size() == 0 || (versions.size() == 1 && headVersion == null)) {
+        if (versions.size() == 0 && headVersion == null) {
             throw new IllegalArgumentException("Not enough versions supplied." +
-                    "\n  I need at least 2 versions." +
+                    "\n  I need at least 1 versions." +
                     "\n   - head version: " + headVersion +
                     "\n   - versions: " + versions);
         }
@@ -42,7 +42,8 @@ class DefaultReleasedVersionsProvider implements ReleasedVersionsProvider {
         }
 
         if (headVersion != null) {
-            DefaultReleasedVersion head = new DefaultReleasedVersion(headVersion, headDate, "HEAD", result.get(0).getRev());
+            String prev = result.isEmpty() ? null : result.get(0).getRev();
+            DefaultReleasedVersion head = new DefaultReleasedVersion(headVersion, headDate, "HEAD", prev);
             result.addFirst(head);
         }
         return result;

--- a/src/main/groovy/org/shipkit/internal/notes/vcs/GitLogProvider.java
+++ b/src/main/groovy/org/shipkit/internal/notes/vcs/GitLogProvider.java
@@ -13,7 +13,7 @@ class GitLogProvider {
     public String getLog(String fromRev, String toRev, String format) {
         String fetch = fromRev == null ? toRev : "+refs/tags/" + fromRev + ":refs/tags/" + fromRev;
         String log = fromRev == null ? toRev : fromRev + ".." + toRev;
-        
+
         runner.run("git", "fetch", "origin", fetch);
         return runner.run("git", "log", format, log);
     }

--- a/src/main/groovy/org/shipkit/internal/notes/vcs/GitLogProvider.java
+++ b/src/main/groovy/org/shipkit/internal/notes/vcs/GitLogProvider.java
@@ -11,12 +11,10 @@ class GitLogProvider {
     }
 
     public String getLog(String fromRev, String toRev, String format) {
-        if(fromRev != null) {
-            runner.run("git", "fetch", "origin", "+refs/tags/" + fromRev + ":refs/tags/" + fromRev);
-            return runner.run("git", "log", format, fromRev + ".." + toRev);
-        } else{
-            runner.run("git", "fetch", "origin", toRev);
-            return runner.run("git", "log", format, toRev);
-        }
+        String fetch = fromRev == null ? toRev : "+refs/tags/" + fromRev + ":refs/tags/" + fromRev;
+        String log = fromRev == null ? toRev : fromRev + ".." + toRev;
+        
+        runner.run("git", "fetch", "origin", fetch);
+        return runner.run("git", "log", format, log);
     }
 }

--- a/src/main/groovy/org/shipkit/internal/notes/vcs/GitLogProvider.java
+++ b/src/main/groovy/org/shipkit/internal/notes/vcs/GitLogProvider.java
@@ -11,7 +11,12 @@ class GitLogProvider {
     }
 
     public String getLog(String fromRev, String toRev, String format) {
-        runner.run("git", "fetch", "origin", "+refs/tags/" + fromRev + ":refs/tags/" + fromRev);
-        return runner.run("git", "log", format, fromRev + ".." + toRev);
+        if(fromRev != null) {
+            runner.run("git", "fetch", "origin", "+refs/tags/" + fromRev + ":refs/tags/" + fromRev);
+            return runner.run("git", "log", format, fromRev + ".." + toRev);
+        } else{
+            runner.run("git", "fetch", "origin", toRev);
+            return runner.run("git", "log", format, toRev);
+        }
     }
 }

--- a/src/test/groovy/org/shipkit/internal/notes/vcs/DefaultReleasedVersionsProviderTest.groovy
+++ b/src/test/groovy/org/shipkit/internal/notes/vcs/DefaultReleasedVersionsProviderTest.groovy
@@ -26,8 +26,6 @@ class DefaultReleasedVersionsProviderTest extends Specification {
             { new DefaultReleasedVersionsProvider(Stub(ProcessRunner))
                     .getReleasedVersions(null, new Date(), ['1.0'], "v") },
             { new DefaultReleasedVersionsProvider(Stub(ProcessRunner))
-                    .getReleasedVersions('1.0', new Date(), [], "v") },
-            { new DefaultReleasedVersionsProvider(Stub(ProcessRunner))
                     .getReleasedVersions('1.0', null, ['1.1'], "v") }
         ]
     }


### PR DESCRIPTION
This is a draft, just to see what others think of this idea and to show what kind of changes would be needed. 

I would like to have an opportunity to generate release notes when previousVersion is null. It's especially needed when initializing shipkit in a project. Currently it throws exception when you try to do that because previousVersion is @Input in some tasks. 

With these changes if you have (version = v0.16.0, previousVersion=null) you get output: 

```
**0.16.0 (2017-06-06)** - [163 commits](https://github.com/mockito/mockito-release-tools-example/compare/vnull...v0.16.0) by 6 authors - published to [![Bintray](https://img.shields.io/badge/Bintray-0.16.0-green.svg)](https://bintray.com/shipkit/examples/basic/0.16.0)
 - Commits: [Szczepan Faber](http://github.com/szczepiq) (139), Mockito Release Tools (8), [Marcin Stachniuk](http://github.com/mstachniuk) (7), [Erhard Pointl](https://github.com/epeee) (4), [Wojtek Wilk](http://github.com/wwilk) (4), mkuster (1)
 - Renamed MockitoReleaseTools dependency to Shipkit [(#49)](https://github.com/mockito/mockito-release-tools-example/pull/49)
 - Clean up shipkit Gradle plugin names [(#44)](https://github.com/mockito/mockito-release-tools-example/pull/44)
 - Gradle extension name changed from 'releasing' to 'shipkit' [(#42)](https://github.com/mockito/mockito-release-tools-example/pull/42)
 - Bumped version of tools [(#37)](https://github.com/mockito/mockito-release-tools-example/pull/37)
 - Bump release tools version to 0.8.32 [(#35)](https://github.com/mockito/mockito-release-tools-example/pull/35)
 - Change mockito-release-tools for easier bump by e2e tests [(#33)](https://github.com/mockito/mockito-release-tools-example/pull/33)
 - Bumped release tools to 0.8.4 - concise release notes [(#32)](https://github.com/mockito/mockito-release-tools-example/pull/32)
 - Bumped version of tools [(#30)](https://github.com/mockito/mockito-release-tools-example/pull/30)
 - Picked up new version of tools [(#29)](https://github.com/mockito/mockito-release-tools-example/pull/29)
 - make use of mockito-release-tools v0.7.5 and configure commit message [(#28)](https://github.com/mockito/mockito-release-tools-example/pull/28)
 - Pulled new version of tools [(#27)](https://github.com/mockito/mockito-release-tools-example/pull/27)
 - Fixed the release [(#26)](https://github.com/mockito/mockito-release-tools-example/pull/26)
 - Publishing notable versions to separate Bintray package instead of Bintray repo [(#25)](https://github.com/mockito/mockito-release-tools-example/pull/25)
 - Picked up new version of tools [(#24)](https://github.com/mockito/mockito-release-tools-example/pull/24)
 - Picked up latest release tools [(#23)](https://github.com/mockito/mockito-release-tools-example/pull/23)
 - Notable release support [(#22)](https://github.com/mockito/mockito-release-tools-example/pull/22)
 - Reduced the complexity [(#21)](https://github.com/mockito/mockito-release-tools-example/pull/21)
 - Started using brand new continuous delivery plugin [(#20)](https://github.com/mockito/mockito-release-tools-example/pull/20)
 - Picked up a new version of release tools [(#19)](https://github.com/mockito/mockito-release-tools-example/pull/19)
 - Moved the pom customization logic to external plugin [(#18)](https://github.com/mockito/mockito-release-tools-example/pull/18)
 - Fixed problem with publication to notable repository [(#17)](https://github.com/mockito/mockito-release-tools-example/pull/17)
 - Pom customization based on Mockito project [(#16)](https://github.com/mockito/mockito-release-tools-example/pull/16)
 - Javadoc and source publishing [(#15)](https://github.com/mockito/mockito-release-tools-example/pull/15)
 - Made it possible to publish to notable repo [(#14)](https://github.com/mockito/mockito-release-tools-example/pull/14)
 - Fixed problem with Bintray publications [(#13)](https://github.com/mockito/mockito-release-tools-example/pull/13)
 - Improved the release notes [(#12)](https://github.com/mockito/mockito-release-tools-example/pull/12)
 - Improved logging and made the build safer [(#11)](https://github.com/mockito/mockito-release-tools-example/pull/11)
 - Fixed problem with git user in Travis CI [(#10)](https://github.com/mockito/mockito-release-tools-example/pull/10)
 - Fixed various Travis CI configuration issues [(#9)](https://github.com/mockito/mockito-release-tools-example/pull/9)
 - Extracted release automation to script plugin [(#8)](https://github.com/mockito/mockito-release-tools-example/pull/8)
 - Set up release automation [(#7)](https://github.com/mockito/mockito-release-tools-example/pull/7)
 - Example project publishes to Bintray and has version management [(#6)](https://github.com/mockito/mockito-release-tools-example/pull/6)
 - Configured release notes repository [(#4)](https://github.com/mockito/mockito-release-tools-example/pull/4)
 - Automated release notes generation [(#3)](https://github.com/mockito/mockito-release-tools-example/pull/3)
 - Initial check-in of sample set of libraries for testing releases [(#1)](https://github.com/mockito/mockito-release-tools-example/pull/1)
```

So it takes all commits before HEAD. There is a problem with:
https://github.com/mockito/mockito-release-tools-example/compare/vnull...v0.16.0

Not sure what link would be better in this case. 

