### PR TITLE
Removed hardcoded commitMessagePostfix from TravisPlugin

### DIFF
--- a/src/main/groovy/org/shipkit/internal/gradle/TravisPlugin.java
+++ b/src/main/groovy/org/shipkit/internal/gradle/TravisPlugin.java
@@ -22,12 +22,6 @@ public class TravisPlugin implements Plugin<Project> {
     @Override
     public void apply(final Project project) {
         project.getPlugins().apply(GitSetupPlugin.class);
-        ReleaseConfiguration conf = project.getPlugins().apply(ReleaseConfigurationPlugin.class).getConfiguration();
-
-        String buildNo = System.getenv("TRAVIS_BUILD_NUMBER");
-        if (buildNo != null) {
-            conf.getGit().setCommitMessagePostfix("by Travis CI build " + buildNo + " [ci skip]");
-        }
 
         String pr = System.getenv("TRAVIS_PULL_REQUEST");
         final boolean isPullRequest = pr != null && !pr.trim().isEmpty() && !pr.equals("false");


### PR DESCRIPTION
In TravisPlugin we had hardcoded commitMessagePostfix that overrides value defined in config file. I've removed it.
Fixes https://github.com/mockito/shipkit/issues/180