### PR TITLE
Remove os-specific code from test classes

### DIFF
--- a/src/test/groovy/org/shipkit/internal/gradle/GitCommitTaskTest.groovy
+++ b/src/test/groovy/org/shipkit/internal/gradle/GitCommitTaskTest.groovy
@@ -6,17 +6,19 @@ import org.gradle.api.Task
 import org.gradle.testfixtures.ProjectBuilder
 import spock.lang.Specification
 
+import static java.io.File.separator
+
 class GitCommitTaskTest extends Specification {
 
     def tasksContainer = new ProjectBuilder().build().tasks
     def gitCommitTask = tasksContainer.create("gitCommitTask", GitCommitTask)
 
-    def "aggregated commit message is empty when no changes registered"(){
+    def "aggregated commit message is empty when no changes registered"() {
         expect:
         gitCommitTask.aggregatedCommitMessage == ""
     }
 
-    def "list of files is empty when no changes registered"(){
+    def "list of files is empty when no changes registered"() {
         expect:
         gitCommitTask.files.isEmpty()
     }
@@ -38,10 +40,12 @@ class GitCommitTaskTest extends Specification {
         gitCommitTask.addChange([new File("test3")], "", anyTask())
 
         then:
-        gitCommitTask.files == [basePath + "/test", basePath + "/test2", basePath + "/test3"]
+        gitCommitTask.files == [basePath + separator + "test",
+                                basePath + separator + "test2",
+                                basePath + separator + "test3"]
     }
 
-    Task anyTask(){
+    Task anyTask() {
         return tasksContainer.create(RandomStringUtils.random(15), DefaultTask)
     }
 }

--- a/src/test/groovy/testutil/GradleSpecification.groovy
+++ b/src/test/groovy/testutil/GradleSpecification.groovy
@@ -20,15 +20,15 @@ class GradleSpecification extends Specification {
     File buildFile
     File settingsFile
 
-    private final static File CLASSES_DIR = findClassesDir();
-    private final static File RESOURCES_DIR = findResourcesDir();
+    private static final String CLASSES_DIR = findClassesDir();
+    private static final String RESOURCES_DIR = findResourcesDir();
 
     void setup() {
         buildFile = projectDir.newFile('build.gradle')
         buildFile << """buildscript {
             dependencies {
-                classpath files("${CLASSES_DIR.absolutePath}")
-                classpath files("${RESOURCES_DIR.absolutePath}")
+                classpath files("${CLASSES_DIR}")
+                classpath files("${RESOURCES_DIR}")
                 classpath "com.github.cliftonlabs:json-simple:2.1.2"
                 classpath "com.jfrog.bintray.gradle:gradle-bintray-plugin:1.7.3"
             }
@@ -71,24 +71,23 @@ class GradleSpecification extends Specification {
         }
     }
 
-    private static File findClassesDir() {
+    private static String findClassesDir() {
         //Using one of the production classes to find directory where IDE or the build system outputs compiled production code
         def bearing = ShipkitJavaPlugin.class.name.replaceAll("\\.", "/") + ".class"
         return findDir(bearing)
     }
 
-    private static File findResourcesDir() {
+    private static String findResourcesDir() {
         //Using standard location of gradle plugins to find where production resources are outputted by IDE or build system
         def bearing = "META-INF/gradle-plugins"
         return findDir(bearing)
     }
 
-    private static File findDir(String bearing) {
+    private static String findDir(String bearing) {
         //Based on a bearing resource, we're finding root directory in the classpath
         def gradlePluginsDir = GradleSpecification.classLoader.getResource(bearing).file
         def classesDir = gradlePluginsDir - bearing
-        def result = new File(classesDir)
-        assert result.isDirectory()
-        return result
+        assert new File(classesDir).isDirectory()
+        return classesDir
     }
 }


### PR DESCRIPTION
There are few tests failing on one specific OS. To fix them:

1) Add os-agnostic path separator to fix test `GitCommitTaskTest`

```
Condition not satisfied:

gitCommitTask.files == [basePath + "/test", basePath + "/test2", basePath + "/test3"]
|             |     |   |        |          |        |           |        |
|             |     |   |        |          |        |           |        C:\Dev\java\shipkit/test3
|             |     |   |        |          |        |           C:\Dev\java\shipkit
|             |     |   |        |          |        C:\Dev\java\shipkit/test2
|             |     |   |        |          C:\Dev\java\shipkit
|             |     |   |        C:\Dev\java\shipkit/test
|             |     |   C:\Dev\java\shipkit
|             |     false
|             [C:\Dev\java\shipkit\test, C:\Dev\java\shipkit\test2, C:\Dev\java\shipkit\test3]
task ':gitCommitTask'

	at org.shipkit.internal.gradle.GitCommitTaskTest.aggregates files correctly(GitCommitTaskTest.groovy:41)
```

2) Store `classes` and `resources` paths in `String` instead of `File` to fix `ShipkitJavaPluginIntegTest`

```
...
Could not compile build file 'C:\Users\xxx\AppData\Local\Temp\junit7728224442025547811\build.gradle'.
> startup failed:
  build file 'C:\Users\xxx\AppData\Local\Temp\junit7728224442025547811\build.gradle': 3: unexpected char: '\' @ line 3, column 36.
...
...