### PR TITLE
added animalsniffer plugin (Java6 compatibility validation)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,6 +7,7 @@ buildscript {
     dependencies {
         classpath "com.gradle.publish:plugin-publish-plugin:0.9.6"
         classpath "gradle.plugin.org.shipkit:shipkit:0.8.82"
+        classpath 'ru.vyarus:gradle-animalsniffer-plugin:1.3.0'
     }
 }
 
@@ -19,6 +20,7 @@ apply plugin: 'codenarc'
 apply plugin: 'org.shipkit.gradle-plugin-releasing'
 apply plugin: 'org.shipkit.release-needed'
 
+apply from: 'gradle/java6-compatibility.gradle'
 apply from: 'gradle/precommit.gradle'
 
 sourceCompatibility = 1.6

--- a/gradle/java6-compatibility.gradle
+++ b/gradle/java6-compatibility.gradle
@@ -1,0 +1,8 @@
+allprojects { p ->
+    plugins.withId('java') {
+        p.apply plugin :'ru.vyarus.animalsniffer'
+        p.dependencies {
+            signature 'org.codehaus.mojo.signature:java16:1.1@signature'
+        }
+    }
+}


### PR DESCRIPTION
fixes #222 

Currently, animalsniffer plugin is always applied (in mockito project it is just applied if a certain property is passed or if release is skipped).
What do you think about executing animalsniffer plugin with every build.
If it does not take a lot if time I'd prefer to execute it with every build because of fail fast.