### PR TITLE
Avoid git reset --hard when cleaning up commits

### DIFF
--- a/src/main/groovy/org/shipkit/internal/gradle/GitPlugin.java
+++ b/src/main/groovy/org/shipkit/internal/gradle/GitPlugin.java
@@ -28,12 +28,14 @@ import static org.shipkit.internal.gradle.util.GitUtil.getTag;
  *     <li>performGitPush</li>
  *
  *     <li>gitCommitCleanUp</li>
+ *     <li>gitResetCommit</li>
  *     <li>gitTagCleanUp</li>
  * </ul>
  */
 public class GitPlugin implements Plugin<Project> {
 
     static final String COMMIT_CLEANUP_TASK = "gitCommitCleanUp";
+    static final String RESET_COMMIT_TASK = "gitResetCommit";
     static final String TAG_CLEANUP_TASK = "gitTagCleanUp";
     static final String GIT_TAG_TASK = "gitTag";
     static final String GIT_PUSH_TASK = "gitPush";
@@ -111,9 +113,16 @@ public class GitPlugin implements Plugin<Project> {
 
         TaskMaker.execTask(project, COMMIT_CLEANUP_TASK, new Action<Exec>() {
             public void execute(final Exec t) {
-                t.setDescription("Removes last commit, using 'reset --hard HEAD~'");
-                //TODO replace with combination of 'git reset --soft HEAD~ && git stash' so that we don't lose commits
-                t.commandLine("git", "reset", "--hard", "HEAD~");
+                t.setDescription("Stashes current changes");
+                t.commandLine("git", "stash");
+                t.dependsOn(RESET_COMMIT_TASK);
+            }
+        });
+
+        TaskMaker.execTask(project, RESET_COMMIT_TASK, new Action<Exec>() {
+            public void execute(final Exec t) {
+                t.setDescription("Removes last commit, using 'reset --soft HEAD~'");
+                t.commandLine("git", "reset", "--soft", "HEAD~");
             }
         });
 

--- a/src/main/groovy/org/shipkit/internal/gradle/GitPlugin.java
+++ b/src/main/groovy/org/shipkit/internal/gradle/GitPlugin.java
@@ -27,15 +27,17 @@ import static org.shipkit.internal.gradle.util.GitUtil.getTag;
  *     <li>gitPush</li>
  *     <li>performGitPush</li>
  *
- *     <li>gitCommitCleanUp</li>
- *     <li>gitResetCommit</li>
+ *     <li>performGitCommitCleanUp</li>
+ *     <li>gitSoftResetCommit</li>
+ *     <li>gitStash</li>
  *     <li>gitTagCleanUp</li>
  * </ul>
  */
 public class GitPlugin implements Plugin<Project> {
 
-    static final String COMMIT_CLEANUP_TASK = "gitCommitCleanUp";
-    static final String RESET_COMMIT_TASK = "gitResetCommit";
+    static final String PERFORM_GIT_COMMIT_CLEANUP_TASK = "performGitCommitCleanUp";
+    static final String GIT_STASH_TASK = "gitStash";
+    static final String SOFT_RESET_COMMIT_TASK = "gitSoftResetCommit";
     static final String TAG_CLEANUP_TASK = "gitTagCleanUp";
     static final String GIT_TAG_TASK = "gitTag";
     static final String GIT_PUSH_TASK = "gitPush";
@@ -111,15 +113,22 @@ public class GitPlugin implements Plugin<Project> {
             }
         });
 
-        TaskMaker.execTask(project, COMMIT_CLEANUP_TASK, new Action<Exec>() {
-            public void execute(final Exec t) {
-                t.setDescription("Stashes current changes");
-                t.commandLine("git", "stash");
-                t.dependsOn(RESET_COMMIT_TASK);
+        TaskMaker.task(project, PERFORM_GIT_COMMIT_CLEANUP_TASK, Task.class, new Action<Task>() {
+            public void execute(final Task t) {
+                t.setDescription("Performs " + SOFT_RESET_COMMIT_TASK + " and " + GIT_STASH_TASK + " tasks.");
+                t.dependsOn(SOFT_RESET_COMMIT_TASK, GIT_STASH_TASK);
             }
         });
 
-        TaskMaker.execTask(project, RESET_COMMIT_TASK, new Action<Exec>() {
+        TaskMaker.execTask(project, GIT_STASH_TASK, new Action<Exec>() {
+            public void execute(final Exec t) {
+                t.setDescription("Stashes current changes");
+                t.commandLine("git", "stash");
+                t.mustRunAfter(SOFT_RESET_COMMIT_TASK);
+            }
+        });
+
+        TaskMaker.execTask(project, SOFT_RESET_COMMIT_TASK, new Action<Exec>() {
             public void execute(final Exec t) {
                 t.setDescription("Removes last commit, using 'reset --soft HEAD~'");
                 t.commandLine("git", "reset", "--soft", "HEAD~");

--- a/src/main/groovy/org/shipkit/internal/gradle/ShipkitJavaPlugin.java
+++ b/src/main/groovy/org/shipkit/internal/gradle/ShipkitJavaPlugin.java
@@ -87,7 +87,7 @@ public class ShipkitJavaPlugin implements Plugin<Project> {
                 t.dependsOn(VersioningPlugin.BUMP_VERSION_FILE_TASK, "updateReleaseNotes");
                 t.dependsOn(GitPlugin.PERFORM_GIT_PUSH_TASK);
 
-                project.getTasks().getByName(GitPlugin.COMMIT_CLEANUP_TASK).mustRunAfter(t);
+                project.getTasks().getByName(GitPlugin.PERFORM_GIT_COMMIT_CLEANUP_TASK).mustRunAfter(t);
                 project.getTasks().getByName(GitPlugin.TAG_CLEANUP_TASK).mustRunAfter(t);
             }
         });
@@ -151,7 +151,7 @@ public class ShipkitJavaPlugin implements Plugin<Project> {
                 t.setDescription("Cleans up the working copy, useful after dry running the release");
 
                 //using finalizedBy so that all clean up tasks run, even if one of them fails
-                t.finalizedBy(GitPlugin.COMMIT_CLEANUP_TASK);
+                t.finalizedBy(GitPlugin.PERFORM_GIT_COMMIT_CLEANUP_TASK);
                 t.finalizedBy(GitPlugin.TAG_CLEANUP_TASK);
             }
         });


### PR DESCRIPTION
fixes #221 

introduced `gitResetCommit` task, using git reset --soft now + git stash now

