### PR TITLE
Improved bootstrapping

### DIFF
--- a/src/main/groovy/org/shipkit/gradle/ReleaseConfiguration.java
+++ b/src/main/groovy/org/shipkit/gradle/ReleaseConfiguration.java
@@ -38,7 +38,7 @@ public class ReleaseConfiguration {
         git.setTagPrefix("v"); //so that tags are "v1.0", "v2.3.4"
         git.setReleasableBranchRegex("master|release/.+");  // matches 'master', 'release/2.x', 'release/3.x', etc.
         git.setCommitMessagePostfix("[ci skip]");
-        git.setUser("Shipkit");
+        git.setUser("shipkit-org");
         git.setEmail("<shipkit.org@gmail.com>");
 
         releaseNotes.setFile("docs/release-notes.md");

--- a/src/main/groovy/org/shipkit/internal/gradle/InitConfigFileTask.java
+++ b/src/main/groovy/org/shipkit/internal/gradle/InitConfigFileTask.java
@@ -40,15 +40,16 @@ public class InitConfigFileTask extends DefaultTask{
         String content =
                 new TemplateResolver(DEFAULT_SHIPKIT_CONFIG_FILE_CONTENT)
                         .withProperty("gitHub.repository", defaultGitRepo)
-                        .withProperty("gitHub.writeAuthUser", "shipkit")
-                        .withProperty("gitHub.readOnlyAuthToken", "e7fe8fcfd6ffedac384c8c4c71b2a48e646ed1ab")
+                        .withProperty("gitHub.writeAuthUser", "shipkit-org")
+                        .withProperty("gitHub.readOnlyAuthToken", "76826c9ec886612f504d12fd4268b16721c4f85d")
 
-                        .withProperty("bintray.pkg.repo", "examples")
-                        .withProperty("bintray.pkg.user", "szczepiq")
-                        .withProperty("bintray.pkg.userOrg", "shipkit")
-                        .withProperty("bintray.pkg.name", "basic")
+                        .withProperty("bintray.key", "7ea297848ca948adb7d3ee92a83292112d7ae989")
+                        .withProperty("bintray.pkg.repo", "bootstrap")
+                        .withProperty("bintray.pkg.user", "shipkit-bootstrap-bot")
+                        .withProperty("bintray.pkg.userOrg", "shipkit-bootstrap")
+                        .withProperty("bintray.pkg.name", "maven")
                         .withProperty("bintray.pkg.licenses", "['MIT']")
-                        .withProperty("bintray.pkg.labels", "['continuous delivery', 'release automation', 'mockito']")
+                        .withProperty("bintray.pkg.labels", "['continuous delivery', 'release automation', 'shipkit']")
 
                         .resolve();
 
@@ -83,12 +84,14 @@ public class InitConfigFileTask extends DefaultTask{
                     "shipkit {\n"+
                     "   gitHub.repository = \"@gitHub.repository@\"\n"+
                     "   gitHub.readOnlyAuthToken = \"@gitHub.readOnlyAuthToken@\"\n"+
+                    //TODO gitHub.writeAuthUser is potentially not needed, see https://github.com/mockito/shipkit/issues/227
                     "   gitHub.writeAuthUser = \"@gitHub.writeAuthUser@\"\n"+
                     "}\n"+
                     "\n"+
                     "allprojects {\n"+
                     "   plugins.withId(\"org.shipkit.bintray\") {\n"+
                     "       bintray {\n"+
+                    "           key = '@bintray.key@'\n"+
                     "           pkg {\n"+
                     "               repo = '@bintray.pkg.repo@'\n"+
                     "               user = '@bintray.pkg.user@'\n"+

--- a/src/test/groovy/org/shipkit/internal/gradle/InitConfigFileTaskTest.groovy
+++ b/src/test/groovy/org/shipkit/internal/gradle/InitConfigFileTaskTest.groovy
@@ -57,20 +57,21 @@ class InitConfigFileTaskTest extends Specification {
                 """//This file was created automatically and is intended to be checked-in.
 shipkit {
    gitHub.repository = \"mockito/mockito\"
-   gitHub.readOnlyAuthToken = \"e7fe8fcfd6ffedac384c8c4c71b2a48e646ed1ab\"
-   gitHub.writeAuthUser = \"shipkit\"
+   gitHub.readOnlyAuthToken = \"76826c9ec886612f504d12fd4268b16721c4f85d\"
+   gitHub.writeAuthUser = \"shipkit-org\"
 }
 
 allprojects {
    plugins.withId(\"org.shipkit.bintray\") {
        bintray {
+           key = '7ea297848ca948adb7d3ee92a83292112d7ae989'
            pkg {
-               repo = 'examples'
-               user = 'szczepiq'
-               userOrg = 'shipkit'
-               name = 'basic'
+               repo = 'bootstrap'
+               user = 'shipkit-bootstrap-bot'
+               userOrg = 'shipkit-bootstrap'
+               name = 'maven'
                licenses = ['MIT']
-               labels = ['continuous delivery', 'release automation', 'mockito']
+               labels = ['continuous delivery', 'release automation', 'shipkit']
            }
        }
    }


### PR DESCRIPTION
For 1.0 I'm testing bootstrapping scenarios so that it's super easy to demo / experiment.

Added Bintray key that we will share for bootstrapping. It is safe because this only has permissions to ship to "shipkit-bootstrap" organization. This will streamline demos / experimentation because one can just for repo and start pushing binaries with zero configuration :P

I have second thoughts about "shipkit-org" name. Perhaps we should call the user "shipkit-bot".

1.0 is coming! Bootstrapping is key, documentation is key :)