### PR TITLE
Added init task to generate .travis.yml file

### DIFF
--- a/src/main/groovy/org/shipkit/gradle/InitTravisTask.java
+++ b/src/main/groovy/org/shipkit/gradle/InitTravisTask.java
@@ -1,0 +1,40 @@
+package org.shipkit.gradle;
+
+import org.gradle.api.DefaultTask;
+import org.gradle.api.logging.Logger;
+import org.gradle.api.logging.Logging;
+import org.gradle.api.tasks.OutputFile;
+import org.gradle.api.tasks.TaskAction;
+import org.shipkit.internal.notes.util.IOUtil;
+
+import java.io.File;
+import java.io.InputStream;
+
+/**
+ * Creates .travis.yml file for shipping with Shipkit
+ */
+public class InitTravisTask extends DefaultTask {
+
+    private final static Logger LOG = Logging.getLogger(InitTravisTask.class);
+
+    @OutputFile private File outputFile;
+
+    @TaskAction public void initTravis() {
+        if (outputFile.exists()) {
+            LOG.lifecycle("  {} - file exists, skipping generation of '{}'.", this.getPath(), outputFile.getName());
+            return;
+        }
+        InputStream resource = this.getClass().getClassLoader().getResourceAsStream("template.travis.yml");
+        String template = IOUtil.readFully(resource);
+        IOUtil.writeFile(outputFile, template);
+        LOG.lifecycle("  {} - generated default '{}', don't forget to check it in to your source control!", this.getPath(), outputFile.getName());
+    }
+
+    public File getOutputFile() {
+        return outputFile;
+    }
+
+    public void setOutputFile(File outputFile) {
+        this.outputFile = outputFile;
+    }
+}

--- a/src/main/groovy/org/shipkit/gradle/InitTravisTask.java
+++ b/src/main/groovy/org/shipkit/gradle/InitTravisTask.java
@@ -11,7 +11,7 @@ import java.io.File;
 import java.io.InputStream;
 
 /**
- * Creates .travis.yml file for shipping with Shipkit
+ * Creates default '.travis.yml' file for shipping with Shipkit
  */
 public class InitTravisTask extends DefaultTask {
 

--- a/src/main/groovy/org/shipkit/internal/gradle/InitPlugin.java
+++ b/src/main/groovy/org/shipkit/internal/gradle/InitPlugin.java
@@ -11,7 +11,12 @@ import java.io.File;
 
 /**
  * Creates task initShipkit that all other init tasks should depend on
- * so that running it would create all configuration needed to start Shipkit
+ * so that running it would create all configuration needed to start Shipkit.
+ *
+ * Adds tasks:
+ * <ul>
+ *     <li>'initTravis' - of type {@link InitTravisTask} - generates '.travis.yml' file</li>
+ * </ul>
  */
 public class InitPlugin implements Plugin<Project> {
 

--- a/src/main/groovy/org/shipkit/internal/gradle/InitPlugin.java
+++ b/src/main/groovy/org/shipkit/internal/gradle/InitPlugin.java
@@ -4,7 +4,10 @@ import org.gradle.api.Action;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.Task;
+import org.shipkit.gradle.InitTravisTask;
 import org.shipkit.internal.gradle.util.TaskMaker;
+
+import java.io.File;
 
 /**
  * Creates task initShipkit that all other init tasks should depend on
@@ -13,15 +16,23 @@ import org.shipkit.internal.gradle.util.TaskMaker;
 public class InitPlugin implements Plugin<Project> {
 
     public static final String INIT_SHIPKIT_TASK = "initShipkit";
+    public static final String INIT_TRAVIS_TASK = "initTravis";
 
     @Override
     public void apply(final Project project) {
-
-        TaskMaker.task(project, INIT_SHIPKIT_TASK, new Action<Task>() {
-            @Override
-            public void execute(Task t) {
-                t.setDescription("Initializes Shipkit");
+        TaskMaker.task(project, INIT_TRAVIS_TASK, InitTravisTask.class, new Action<InitTravisTask>() {
+            public void execute(InitTravisTask t) {
+                t.setDescription("Creates '.travis.yml' file if not already present.");
+                t.setOutputFile(new File(project.getRootDir(), ".travis.yml"));
             }
         });
+
+        TaskMaker.task(project, INIT_SHIPKIT_TASK, new Action<Task>() {
+            public void execute(Task t) {
+                t.setDescription("Initializes Shipkit");
+                t.dependsOn(INIT_TRAVIS_TASK);
+            }
+        });
+
     }
 }

--- a/src/main/resources/template.travis.yml
+++ b/src/main/resources/template.travis.yml
@@ -1,0 +1,26 @@
+# More details on how to configure the Travis build
+# https://docs.travis-ci.com/user/customizing-the-build/
+
+# Speed up build with travis caches
+cache:
+  directories:
+    - $HOME/.gradle/caches/
+    - $HOME/.gradle/wrapper/
+
+language: java
+
+jdk:
+  - oraclejdk8
+
+#don't build tags
+branches:
+  except:
+  - /^v\d/
+
+#build and test the release logic
+script:
+  - ./gradlew build testRelease -s -i
+
+#check release criteria and make release if criteria are met!
+after_success:
+  - ./gradlew assertReleaseNeeded && ./gradlew ciReleasePrepare && ./gradlew travisRelease

--- a/src/test/groovy/org/shipkit/internal/gradle/InitPluginTest.groovy
+++ b/src/test/groovy/org/shipkit/internal/gradle/InitPluginTest.groovy
@@ -1,0 +1,33 @@
+package org.shipkit.internal.gradle
+
+import org.gradle.testfixtures.ProjectBuilder
+import spock.lang.Specification
+
+import static org.shipkit.internal.gradle.InitPlugin.INIT_TRAVIS_TASK
+
+class InitPluginTest extends Specification {
+
+    def project = new ProjectBuilder().build()
+
+    def "initializes .travis.yml file"() {
+        project.plugins.apply(InitPlugin)
+        assert !project.file(".travis.yml").exists()
+
+        when:
+        project.tasks[INIT_TRAVIS_TASK].execute()
+
+        then:
+        project.file(".travis.yml").isFile()
+    }
+
+    def "does not initialize .travis.yml file when already present"() {
+        project.plugins.apply(InitPlugin)
+        project.file(".travis.yml") << "foo"
+
+        when:
+        project.tasks[INIT_TRAVIS_TASK].execute()
+
+        then:
+        project.file(".travis.yml").text == "foo"
+    }
+}


### PR DESCRIPTION
Some users have Java code that needs to be shipped. Running "initShipkit" task should get them fully working continuous delivery setup. This will be also handy for doing demos.

I was thinking a lot about bootstrapping scenarios to make them as simple as possible. I'm thinking about changing the bootstrap project a bit so that it requires "initShipkit" step. Potential workflow:

1. clone bootstrap project
2. run initShipkit
3. ./gradlew performRelease

The last step has 2 gotchas:
 - bintray api key - we work around by using "shipkit-bootstrap-bot" user that has the key checked in (implemented)
 - github write token - we work around by not doing the final "push"


