### PR TITLE
Simplify Shipkit's own shipkit configuration

### DIFF
--- a/gradle/shipkit.gradle
+++ b/gradle/shipkit.gradle
@@ -1,17 +1,8 @@
 shipkit {
     gitHub.repository = "mockito/shipkit"
-    gitHub.writeAuthUser = "mockito"
-    gitHub.writeAuthToken = System.getenv("GH_WRITE_TOKEN")
+    gitHub.writeAuthUser = "dummy" //TODO remove this line after we start consuming newer version
     gitHub.readOnlyAuthToken = "e7fe8fcdd6ffed5c38498c4c79b2a68e6f6ed1bb"
 
-    git.user = "Shipkit"
-    git.email = "<shipkit.org@gmail.com>"
-    git.releasableBranchRegex = "master|release/.+" // matches 'master', 'release/2.x', 'release/3.x', etc.
-
-    def buildNo = System.getenv("TRAVIS_BUILD_NUMBER")
-    git.commitMessagePostfix = buildNo? " by CI build $buildNo [ci skip-release]" : " [ci skip-release]"
-
-
-    team.developers = ['szczepiq:Szczepan Faber']
-    team.contributors = ['mstachniuk:Marcin Stachniuk', 'wwilk:Wojtek Wilk']
+    team.developers = ['szczepiq:Szczepan Faber', 'mstachniuk:Marcin Stachniuk',
+                       'wwilk:Wojtek Wilk', 'epeee:Erhard Pointl', 'NagRock:Maciej Kuster']
 }

--- a/src/main/groovy/org/shipkit/gradle/ReleaseConfiguration.java
+++ b/src/main/groovy/org/shipkit/gradle/ReleaseConfiguration.java
@@ -44,6 +44,9 @@ public class ReleaseConfiguration {
         gitHub.setUrl("https://github.com");
         gitHub.setApiUrl("https://api.github.com");
 
+        //It does not seem that write auth user is used by GitHub in any way
+        gitHub.setWriteAuthUser("dummy");
+
         releaseNotes.setFile("docs/release-notes.md");
         releaseNotes.setIgnoreCommitsContaining(asList("[ci skip]"));
         releaseNotes.setLabelMapping(Collections.<String, String>emptyMap());

--- a/src/main/resources/template.travis.yml
+++ b/src/main/resources/template.travis.yml
@@ -19,7 +19,7 @@ branches:
 
 #build and test the release logic
 script:
-  - ./gradlew build testRelease -s -i
+  - ./gradlew build -s -i
 
 #check release criteria and make release if criteria are met!
 after_success:


### PR DESCRIPTION
 - fixed small bug with travis template file (thanks wwilk for reporting!)
 - Removed github user from the shipkit file - I don't think that the user is needed for git pushes. We have used "mockito" user for quite some time now and it is not a valid user. I asked GitHub support for it, we will see what they say. Fixes #227 
- Cleaned up some other things from the configuration - to make it as simple as possible.
- Added all team members!