### PR TITLE
New 'ciPerformRelease' task and significant modularization of plugins

### DIFF
--- a/src/main/groovy/org/shipkit/gradle/exec/CompositeExecTask.java
+++ b/src/main/groovy/org/shipkit/gradle/exec/CompositeExecTask.java
@@ -1,0 +1,59 @@
+package org.shipkit.gradle.exec;
+
+import org.gradle.api.Action;
+import org.gradle.api.DefaultTask;
+import org.gradle.api.logging.Logger;
+import org.gradle.api.logging.Logging;
+import org.gradle.api.tasks.TaskAction;
+import org.gradle.process.ExecResult;
+import org.gradle.process.ExecSpec;
+import org.shipkit.internal.gradle.util.StringUtil;
+
+import java.util.Collection;
+import java.util.LinkedList;
+
+/**
+ * Generic Gradle task that allows composing multiple executable command line invocations.
+ * Very useful for scenarios where we cannot easily use multiple Gradle Exec tasks.
+ */
+public class CompositeExecTask extends DefaultTask {
+
+    private Collection<ExecCommand> execCommands = new LinkedList<ExecCommand>();
+    private final static Logger LOG = Logging.getLogger(CompositeExecTask.class);
+
+    /**
+     * Sequence of command line executions.
+     * Will be executed sequentially in given order.
+     */
+    public Collection<ExecCommand> getExecCommands() {
+        return execCommands;
+    }
+
+    /**
+     * See {@link #getExecCommands()}
+     */
+    public void setExecCommands(Collection<ExecCommand> execCommands) {
+        this.execCommands = execCommands;
+    }
+
+    @TaskAction public void execCommands() {
+        for (final ExecCommand execCommand : execCommands) {
+            ExecResult result = getProject().exec(new Action<ExecSpec>() {
+                @Override
+                public void execute(ExecSpec spec) {
+                    //TODO add better logging, we should capture the output from external process
+                    //and prefix it with [./gradlew]
+                    //TODO we should expose 'description' on exec command and write it to console before forking process
+                    //TODO figure out a clean way of adding unit test coverage for it
+
+                    spec.setIgnoreExitValue(true);
+                    spec.commandLine(execCommand.getCommandLine());
+                    execCommand.getSetupAction().execute(spec);
+
+                    LOG.lifecycle("  Executing:\n    " + StringUtil.join(execCommand.getCommandLine(), " "));
+                }
+            });
+            execCommand.getResultAction().execute(result);
+        }
+    }
+}

--- a/src/main/groovy/org/shipkit/gradle/exec/ExecCommand.java
+++ b/src/main/groovy/org/shipkit/gradle/exec/ExecCommand.java
@@ -1,0 +1,81 @@
+package org.shipkit.gradle.exec;
+
+import org.gradle.api.Action;
+import org.gradle.process.ExecResult;
+import org.gradle.process.ExecSpec;
+
+import java.util.Collection;
+
+/**
+ * Object that contains information about the executable command line.
+ * It has: the command line arguments, action that configures the execution,
+ * action that is triggered when the execution is complete.
+ */
+public class ExecCommand {
+
+    private final static Action NO_OP_ACTION = new Action() {
+        public void execute(Object o) {}
+    };
+
+    private final static Action ENSURE_SUCCEEDED_ACTION = new Action<ExecResult>() {
+        public void execute(ExecResult result) {
+            //TODO offer cleaner exception than the one by default offered by Gradle
+            result.assertNormalExitValue();
+        }
+    };
+
+    private final Collection<String> commandLine;
+    private final Action<ExecSpec> setupAction;
+    private final Action<ExecResult> resultAction;
+
+    /**
+     * Generic command line to be executed
+     *
+     * @param commandLine command line to be executed
+     * @param setupAction action that configures the command line execution
+     * @param resultAction action that is triggered after the command line was executed
+     */
+    public ExecCommand(Collection<String> commandLine, Action<ExecSpec> setupAction, Action<ExecResult> resultAction) {
+        this.commandLine = commandLine;
+        this.setupAction = setupAction;
+        this.resultAction = resultAction;
+    }
+
+    /**
+     * Exec command that will throw the exception when the command line fails.
+     * This is the most typical kind of exec command.
+     */
+    public ExecCommand(Collection<String> commandLine) {
+        this(commandLine, NO_OP_ACTION, ENSURE_SUCCEEDED_ACTION);
+    }
+
+    /**
+     * Exec command with custom result action.
+     * Useful if the user needs custom behavior when command line finishes executing.
+     * For example, we can ignore the failure.
+     */
+    public ExecCommand(Collection<String> commandLine, Action<ExecResult> resultAction) {
+        this(commandLine, NO_OP_ACTION, resultAction);
+    }
+
+    /**
+     * Command line to be executed.
+     */
+    public Collection<String> getCommandLine() {
+        return commandLine;
+    }
+
+    /**
+     * The action that configures the execution of command line
+     */
+    public Action<ExecSpec> getSetupAction() {
+        return setupAction;
+    }
+
+    /**
+     * The action that takes place after the command line is executed
+     */
+    public Action<ExecResult> getResultAction() {
+        return resultAction;
+    }
+}

--- a/src/main/groovy/org/shipkit/internal/gradle/BaseJavaLibraryPlugin.java
+++ b/src/main/groovy/org/shipkit/internal/gradle/BaseJavaLibraryPlugin.java
@@ -43,7 +43,7 @@ public class BaseJavaLibraryPlugin implements Plugin<Project> {
 
     final static String PUBLICATION_NAME = "javaLibrary";
     final static String POM_TASK = "generatePomFileFor" + StringUtil.capitalize(PUBLICATION_NAME) + "Publication";
-    final static String MAVEN_LOCAL_TASK = "publish" + StringUtil.capitalize(PUBLICATION_NAME) + "PublicationToMavenLocal";
+    public final static String MAVEN_LOCAL_TASK = "publish" + StringUtil.capitalize(PUBLICATION_NAME) + "PublicationToMavenLocal";
     final static String SOURCES_JAR_TASK = "sourcesJar";
 
     public void apply(final Project project) {

--- a/src/main/groovy/org/shipkit/internal/gradle/BintrayPlugin.java
+++ b/src/main/groovy/org/shipkit/internal/gradle/BintrayPlugin.java
@@ -34,7 +34,7 @@ public class BintrayPlugin implements Plugin<Project> {
     /**
      * Name of the task that is configured by this plugin
      */
-    static final String BINTRAY_UPLOAD_TASK = "bintrayUpload";
+    public static final String BINTRAY_UPLOAD_TASK = "bintrayUpload";
 
     private final static Logger LOG = Logging.getLogger(BintrayPlugin.class);
 

--- a/src/main/groovy/org/shipkit/internal/gradle/GitPlugin.java
+++ b/src/main/groovy/org/shipkit/internal/gradle/GitPlugin.java
@@ -47,7 +47,7 @@ public class GitPlugin implements Plugin<Project> {
     static final String SOFT_RESET_COMMIT_TASK = "gitSoftResetCommit";
     public static final String TAG_CLEANUP_TASK = "gitTagCleanUp";
     static final String GIT_TAG_TASK = "gitTag";
-    static final String GIT_PUSH_TASK = "gitPush";
+    public static final String GIT_PUSH_TASK = "gitPush";
     public static final String PERFORM_GIT_PUSH_TASK = "performGitPush";
     static final String WRITE_TOKEN_ENV = "GH_WRITE_TOKEN";
     public static final String GIT_COMMIT_TASK = "gitCommit";

--- a/src/main/groovy/org/shipkit/internal/gradle/GitPlugin.java
+++ b/src/main/groovy/org/shipkit/internal/gradle/GitPlugin.java
@@ -42,13 +42,13 @@ import static org.shipkit.internal.gradle.util.GitUtil.getTag;
  */
 public class GitPlugin implements Plugin<Project> {
 
-    static final String PERFORM_GIT_COMMIT_CLEANUP_TASK = "performGitCommitCleanUp";
+    public static final String PERFORM_GIT_COMMIT_CLEANUP_TASK = "performGitCommitCleanUp";
     static final String GIT_STASH_TASK = "gitStash";
     static final String SOFT_RESET_COMMIT_TASK = "gitSoftResetCommit";
-    static final String TAG_CLEANUP_TASK = "gitTagCleanUp";
+    public static final String TAG_CLEANUP_TASK = "gitTagCleanUp";
     static final String GIT_TAG_TASK = "gitTag";
     static final String GIT_PUSH_TASK = "gitPush";
-    static final String PERFORM_GIT_PUSH_TASK = "performGitPush";
+    public static final String PERFORM_GIT_PUSH_TASK = "performGitPush";
     static final String WRITE_TOKEN_ENV = "GH_WRITE_TOKEN";
     public static final String GIT_COMMIT_TASK = "gitCommit";
 

--- a/src/main/groovy/org/shipkit/internal/gradle/GitSetupPlugin.java
+++ b/src/main/groovy/org/shipkit/internal/gradle/GitSetupPlugin.java
@@ -8,8 +8,8 @@ import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
 import org.gradle.api.tasks.Exec;
 import org.shipkit.gradle.ReleaseConfiguration;
-import org.shipkit.internal.gradle.util.TaskMaker;
 import org.shipkit.internal.gradle.util.StringUtil;
+import org.shipkit.internal.gradle.util.TaskMaker;
 
 /**
  * Plugin that adds Git tasks commonly used for setting up
@@ -44,7 +44,7 @@ public class GitSetupPlugin implements Plugin<Project> {
     static final String CHECKOUT_BRANCH_TASK = "checkOutBranch";
     private static final String SET_USER_TASK = "setGitUserName";
     private static final String SET_EMAIL_TASK = "setGitUserEmail";
-    private static final String CI_RELEASE_PREPARE_TASK = "ciReleasePrepare";
+    public static final String CI_RELEASE_PREPARE_TASK = "ciReleasePrepare";
 
     @Override
     public void apply(Project project) {

--- a/src/main/groovy/org/shipkit/internal/gradle/InitConfigFileTask.java
+++ b/src/main/groovy/org/shipkit/internal/gradle/InitConfigFileTask.java
@@ -4,10 +4,10 @@ import org.gradle.api.DefaultTask;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
 import org.gradle.api.tasks.TaskAction;
-import org.shipkit.internal.notes.vcs.GitOriginRepoProvider;
 import org.shipkit.internal.exec.DefaultProcessRunner;
 import org.shipkit.internal.exec.ProcessRunner;
 import org.shipkit.internal.notes.util.IOUtil;
+import org.shipkit.internal.notes.vcs.GitOriginRepoProvider;
 import org.shipkit.internal.util.ExposedForTesting;
 
 import java.io.File;
@@ -59,9 +59,11 @@ public class InitConfigFileTask extends DefaultTask{
     private String getOriginGitRepo() {
         try {
             return gitOriginRepoProvider.getOriginGitRepo();
-        } catch(Exception e){
-            LOG.error("Failed to get url of git remote origin. Using fallback '" + FALLBACK_GITHUB_REPO + "' instead.\n" +
-                    "You can change GitHub repository manually in " + configFile, e);
+        } catch (Exception e) {
+            LOG.lifecycle("  Problems getting url of git remote origin (run with --debug to find out more).\n" +
+                    "  Using fallback '" + FALLBACK_GITHUB_REPO + "' instead.\n" +
+                    "  Please update GitHub repository in '" + configFile + "' file.\n");
+            LOG.debug("  Problems getting url of git remote origin", e);
             return FALLBACK_GITHUB_REPO;
         }
     }

--- a/src/main/groovy/org/shipkit/internal/gradle/PomContributorsPlugin.java
+++ b/src/main/groovy/org/shipkit/internal/gradle/PomContributorsPlugin.java
@@ -1,0 +1,40 @@
+package org.shipkit.internal.gradle;
+
+import org.gradle.api.Action;
+import org.gradle.api.Plugin;
+import org.gradle.api.Project;
+import org.gradle.api.Task;
+
+import static org.shipkit.internal.gradle.BaseJavaLibraryPlugin.POM_TASK;
+import static org.shipkit.internal.gradle.ContributorsPlugin.FETCH_ALL_CONTRIBUTORS_TASK;
+import static org.shipkit.internal.gradle.util.Specs.withName;
+
+/**
+ * Ensures that contributors are fetched from GitHub  for the pom file generation in all java subprojects
+ */
+public class PomContributorsPlugin implements Plugin<Project> {
+
+    @Override
+    public void apply(final Project project) {
+        project.getPlugins().apply(ContributorsPlugin.class);
+
+        project.allprojects(new Action<Project>() {
+            @Override
+            public void execute(final Project subproject) {
+                subproject.getPlugins().withType(BaseJavaLibraryPlugin.class, new Action<BaseJavaLibraryPlugin>() {
+                    @Override
+                    public void execute(BaseJavaLibraryPlugin p) {
+                        final Task fetcher = project.getTasks().getByName(FETCH_ALL_CONTRIBUTORS_TASK);
+                        //Because maven-publish plugin uses new configuration model, we cannot get the task directly
+                        //So we use 'matching' technique
+                        subproject.getTasks().matching(withName(POM_TASK)).all(new Action<Task>() {
+                            public void execute(Task t) {
+                                t.dependsOn(fetcher);
+                            }
+                        });
+                    }
+                });
+            }
+        });
+    }
+}

--- a/src/main/groovy/org/shipkit/internal/gradle/ReleaseNeededPlugin.java
+++ b/src/main/groovy/org/shipkit/internal/gradle/ReleaseNeededPlugin.java
@@ -29,6 +29,8 @@ import org.shipkit.internal.gradle.util.TaskMaker;
  */
 public class ReleaseNeededPlugin implements Plugin<Project> {
 
+    public final static String ASSERT_RELEASE_NEEDED_TASK = "assertReleaseNeeded";
+
     @Override
     public void apply(Project project) {
         final ReleaseConfiguration conf = project.getPlugins().apply(ReleaseConfigurationPlugin.class).getConfiguration();
@@ -36,7 +38,7 @@ public class ReleaseNeededPlugin implements Plugin<Project> {
         //Task that throws an exception when release is not needed is very useful for CI workflows
         //Travis CI job will stop executing further commands if assertReleaseNeeded fails.
         //See the example projects how we have set up the 'assertReleaseNeeded' task in CI pipeline.
-        releaseNeededTask(project, "assertReleaseNeeded", conf)
+        releaseNeededTask(project, ASSERT_RELEASE_NEEDED_TASK, conf)
                 .setExplosive(true)
                 .setDescription("Asserts that criteria for the release are met and throws exception if release is not needed.");
 

--- a/src/main/groovy/org/shipkit/internal/gradle/ShipkitJavaPlugin.java
+++ b/src/main/groovy/org/shipkit/internal/gradle/ShipkitJavaPlugin.java
@@ -1,112 +1,25 @@
 package org.shipkit.internal.gradle;
 
-import com.jfrog.bintray.gradle.BintrayExtension;
-import org.gradle.api.Action;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
-import org.gradle.api.Task;
-import org.gradle.api.logging.Logger;
-import org.gradle.api.logging.Logging;
-import org.shipkit.gradle.ReleaseConfiguration;
-import org.shipkit.gradle.UpdateReleaseNotesTask;
 import org.shipkit.internal.gradle.release.CiReleasePlugin;
-import org.shipkit.internal.gradle.release.ReleasePlugin;
-import org.shipkit.internal.gradle.util.BintrayUtil;
-
-import static org.shipkit.internal.gradle.BaseJavaLibraryPlugin.MAVEN_LOCAL_TASK;
-import static org.shipkit.internal.gradle.configuration.DeferredConfiguration.deferredConfiguration;
+import org.shipkit.internal.gradle.release.JavaReleasePlugin;
 
 /**
- * Adds plugins and tasks to setup automated releasing for a Java project
- * Applies following plugins and preconfigures tasks provided by those plugins:
+ * Adds plugins and tasks to setup automated releasing for a Java multi-project.
+ * Applies following plugins:
  *
  * <ul>
- *     <li>{@link ReleaseConfigurationPlugin}</li>
- *     <li>{@link GitPlugin}</li>
+ *     <li>{@link JavaReleasePlugin}</li>
  *     <li>{@link TravisPlugin}</li>
- *     <li>{@link PomContributorsPlugin}</li>
- *     <li>{@link ReleasePlugin}</li>
  *     <li>{@link CiReleasePlugin}</li>
- * </ul>
- *
- * Applies following plugins to all Java submodules:
- *
- * <ul>
- *     <li>{@link JavaLibraryPlugin}</li>
  * </ul>
  */
 public class ShipkitJavaPlugin implements Plugin<Project> {
 
-    private static final Logger LOG = Logging.getLogger(ShipkitJavaPlugin.class);
-
     public void apply(final Project project) {
-        final ReleaseConfiguration conf = project.getPlugins().apply(ReleaseConfigurationPlugin.class).getConfiguration();
-
-        //TODO ShipkitJavaPlugin should have no code but only apply other plugins
-        //This way it will be easy for others to put together setup for other tools / build systems
-
-        project.getPlugins().apply(GitPlugin.class);
+        project.getPlugins().apply(JavaReleasePlugin.class);
         project.getPlugins().apply(TravisPlugin.class);
-        project.getPlugins().apply(PomContributorsPlugin.class);
-        project.getPlugins().apply(ReleasePlugin.class);
         project.getPlugins().apply(CiReleasePlugin.class);
-
-        project.allprojects(new Action<Project>() {
-            @Override
-            public void execute(final Project subproject) {
-                if (conf.isPublishAllJavaSubprojects()) {
-                    subproject.getPlugins().withId("java", new Action<Plugin>() {
-                        @Override
-                        public void execute(Plugin plugin) {
-                            subproject.getPlugins().apply(JavaLibraryPlugin.class);
-                        }
-                    });
-                }
-
-                subproject.getPlugins().withType(JavaLibraryPlugin.class, new Action<JavaLibraryPlugin>() {
-                    public void execute(JavaLibraryPlugin plugin) {
-                        Task bintrayUpload = subproject.getTasks().getByName(BintrayPlugin.BINTRAY_UPLOAD_TASK);
-                        Task performRelease = project.getTasks().getByName(ReleasePlugin.PERFORM_RELEASE_TASK);
-                        performRelease.dependsOn(bintrayUpload);
-
-                        //Making git push run as late as possible because it is an operation that is hard to reverse.
-                        //Git push will be executed after all tasks needed by bintrayUpload
-                        // but before bintrayUpload.
-                        //Using task path as String because the task comes from maven-publish new configuration model
-                        // and we cannot refer to it in a normal way, by task instance.
-                        String mavenLocalTask = subproject.getPath() + ":" + MAVEN_LOCAL_TASK;
-                        Task gitPush = project.getTasks().getByName(GitPlugin.GIT_PUSH_TASK);
-                        gitPush.mustRunAfter(mavenLocalTask);
-                        //bintray upload after git push so that when git push fails we don't publish jars to bintray
-                        //git push is easier to undo than deleting published jars (not possible with Central)
-                        bintrayUpload.mustRunAfter(gitPush);
-
-                        final BintrayExtension bintray = subproject.getExtensions().getByType(BintrayExtension.class);
-                        //TODO clean up below. We don't need 'deferredConfiguration' because at this point
-                        // shipkit file was already loaded and java library plugin applied on the subproject
-                        deferredConfiguration(subproject, new Runnable() {
-                            public void run() {
-                                configurePublicationRepo(project, BintrayUtil.getRepoLink(bintray));
-                            }
-                        });
-                    }
-                });
-            }
-        });
-    }
-
-    private static void configurePublicationRepo(Project project, String bintrayRepo) {
-        //not using 'getTasks().withType()' because I don't want to create too many task configuration rules
-        //TODO add information about it in the development guide
-        for (Task t : project.getTasks()) {
-            if (t instanceof UpdateReleaseNotesTask) {
-                UpdateReleaseNotesTask task = (UpdateReleaseNotesTask) t;
-                if (task.getPublicationRepository() == null) {
-                    LOG.info("Configuring publication repository '{}' on task: {}", bintrayRepo, t.getPath());
-                    task.setPublicationRepository(bintrayRepo);
-                }
-            }
-        }
-        //TODO unit test coverage
     }
 }

--- a/src/main/groovy/org/shipkit/internal/gradle/ShipkitJavaPlugin.java
+++ b/src/main/groovy/org/shipkit/internal/gradle/ShipkitJavaPlugin.java
@@ -9,6 +9,7 @@ import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
 import org.shipkit.gradle.ReleaseConfiguration;
 import org.shipkit.gradle.UpdateReleaseNotesTask;
+import org.shipkit.internal.gradle.release.CiReleasePlugin;
 import org.shipkit.internal.gradle.release.ReleasePlugin;
 import org.shipkit.internal.gradle.util.BintrayUtil;
 
@@ -16,21 +17,22 @@ import static org.shipkit.internal.gradle.BaseJavaLibraryPlugin.MAVEN_LOCAL_TASK
 import static org.shipkit.internal.gradle.configuration.DeferredConfiguration.deferredConfiguration;
 
 /**
- * Opinionated continuous delivery plugin.
+ * Adds plugins and tasks to setup automated releasing for a Java project
  * Applies following plugins and preconfigures tasks provided by those plugins:
  *
  * <ul>
- *     <li>{@link ReleaseNotesPlugin}</li>
- *     <li>{@link VersioningPlugin}</li>
+ *     <li>{@link ReleaseConfigurationPlugin}</li>
  *     <li>{@link GitPlugin}</li>
- *     <li>{@link ContributorsPlugin}</li>
  *     <li>{@link TravisPlugin}</li>
+ *     <li>{@link PomContributorsPlugin}</li>
+ *     <li>{@link ReleasePlugin}</li>
+ *     <li>{@link CiReleasePlugin}</li>
  * </ul>
  *
- * Adds following tasks:
+ * Applies following plugins to all Java submodules:
  *
  * <ul>
- *     <li>TODO document all</li>
+ *     <li>{@link JavaLibraryPlugin}</li>
  * </ul>
  */
 public class ShipkitJavaPlugin implements Plugin<Project> {
@@ -47,6 +49,7 @@ public class ShipkitJavaPlugin implements Plugin<Project> {
         project.getPlugins().apply(TravisPlugin.class);
         project.getPlugins().apply(PomContributorsPlugin.class);
         project.getPlugins().apply(ReleasePlugin.class);
+        project.getPlugins().apply(CiReleasePlugin.class);
 
         project.allprojects(new Action<Project>() {
             @Override

--- a/src/main/groovy/org/shipkit/internal/gradle/VersioningPlugin.java
+++ b/src/main/groovy/org/shipkit/internal/gradle/VersioningPlugin.java
@@ -41,7 +41,7 @@ public class VersioningPlugin implements Plugin<Project> {
 
     public static final String VERSION_FILE_NAME = "version.properties";
 
-    static final String BUMP_VERSION_FILE_TASK = "bumpVersionFile";
+    public static final String BUMP_VERSION_FILE_TASK = "bumpVersionFile";
     static final String INIT_VERSIONING_TASK = "initVersioning";
 
     public void apply(final Project project) {

--- a/src/main/groovy/org/shipkit/internal/gradle/release/CiReleasePlugin.java
+++ b/src/main/groovy/org/shipkit/internal/gradle/release/CiReleasePlugin.java
@@ -1,0 +1,61 @@
+package org.shipkit.internal.gradle.release;
+
+import org.gradle.api.Action;
+import org.gradle.api.Plugin;
+import org.gradle.api.Project;
+import org.gradle.api.tasks.StopExecutionException;
+import org.gradle.process.ExecResult;
+import org.shipkit.gradle.exec.CompositeExecTask;
+import org.shipkit.gradle.exec.ExecCommand;
+import org.shipkit.internal.gradle.GitSetupPlugin;
+import org.shipkit.internal.gradle.ReleaseNeededPlugin;
+import org.shipkit.internal.gradle.util.TaskMaker;
+
+import static java.util.Arrays.asList;
+import static org.shipkit.internal.gradle.GitSetupPlugin.CI_RELEASE_PREPARE_TASK;
+import static org.shipkit.internal.gradle.ReleaseNeededPlugin.ASSERT_RELEASE_NEEDED_TASK;
+import static org.shipkit.internal.gradle.release.ReleasePlugin.PERFORM_RELEASE_TASK;
+
+/**
+ * Adds convenience 'ciPerformRelease' task to execute release using a single Gradle task.
+ */
+public class CiReleasePlugin implements Plugin<Project> {
+
+    @Override
+    public void apply(Project project) {
+        project.getPlugins().apply(ReleasePlugin.class);
+        project.getPlugins().apply(ReleaseNeededPlugin.class);
+        project.getPlugins().apply(GitSetupPlugin.class);
+
+        /*
+        Gradle task model does not make it easy to model releasing scenarios
+          therefore we are forking invocations of Gradle tasks from within Gradle task.
+        More details:
+          We need to stop executing the release if it is not needed. Modelling this using standard task dependencies is not viable.
+          We would have to make all tasks depend on 'release needed', which would cause this task to be executed every time we run any task.
+          That does not make sense: you run "./gradlew clean" and Gradle would trigger 'releaseNeeded' task.
+          Also, when release is not needed, we don't have clean Gradle API to stop the build, without failing it.
+          Hence, we are pragmatic. We are forking Gradle from Gradle which seems hacky but we have no other viable choice.
+        */
+        TaskMaker.task(project, "ciPerformRelease", CompositeExecTask.class, new Action<CompositeExecTask>() {
+            @Override
+            public void execute(CompositeExecTask task) {
+                task.setDescription("Checks if release is needed. If so it will prepare for ci release and perform release.");
+                task.getExecCommands().add(new ExecCommand(asList("./gradlew", ASSERT_RELEASE_NEEDED_TASK), stopExecution()));
+                task.getExecCommands().add(new ExecCommand(asList("./gradlew", CI_RELEASE_PREPARE_TASK)));
+                task.getExecCommands().add(new ExecCommand(asList("./gradlew", PERFORM_RELEASE_TASK, "-Pshipkit.dryRun=false")));
+            }
+        });
+    }
+
+    private Action<ExecResult> stopExecution() {
+        return new Action<ExecResult>() {
+            public void execute(ExecResult exec) {
+                if (exec.getExitValue() != 0) {
+                    //Cleanly stop executing the task, without making the task failed.
+                    throw new StopExecutionException();
+                }
+            }
+        };
+    }
+}

--- a/src/main/groovy/org/shipkit/internal/gradle/release/JavaReleasePlugin.java
+++ b/src/main/groovy/org/shipkit/internal/gradle/release/JavaReleasePlugin.java
@@ -1,0 +1,109 @@
+package org.shipkit.internal.gradle.release;
+
+import com.jfrog.bintray.gradle.BintrayExtension;
+import org.gradle.api.Action;
+import org.gradle.api.Plugin;
+import org.gradle.api.Project;
+import org.gradle.api.Task;
+import org.gradle.api.logging.Logger;
+import org.gradle.api.logging.Logging;
+import org.shipkit.gradle.ReleaseConfiguration;
+import org.shipkit.gradle.UpdateReleaseNotesTask;
+import org.shipkit.internal.gradle.*;
+import org.shipkit.internal.gradle.util.BintrayUtil;
+
+import static org.shipkit.internal.gradle.BaseJavaLibraryPlugin.MAVEN_LOCAL_TASK;
+import static org.shipkit.internal.gradle.configuration.DeferredConfiguration.deferredConfiguration;
+
+/**
+ * Configures Java multi-project for automated releases.
+ * Applies some configuration to subprojects, too.
+ *
+ * <p>
+ *
+ * Applies following plugins to all Java submodules, and preconfigures tasks provided by those plugins:
+ *
+ * <ul>
+ *     <li>{@link JavaLibraryPlugin}</li>
+ * </ul>
+ *
+ * <p>
+ *
+ * Applies following plugins:
+ *
+ * <ul>
+ *     <li>{@link GitPlugin}</li>
+ *     <li>{@link PomContributorsPlugin}</li>
+ *     <li>{@link ReleasePlugin}</li>
+ * </ul>
+ */
+public class JavaReleasePlugin implements Plugin<Project> {
+
+    private static final Logger LOG = Logging.getLogger(ShipkitJavaPlugin.class);
+
+    public void apply(final Project project) {
+        final ReleaseConfiguration conf = project.getPlugins().apply(ReleaseConfigurationPlugin.class).getConfiguration();
+
+        project.getPlugins().apply(GitPlugin.class);
+        project.getPlugins().apply(PomContributorsPlugin.class);
+        project.getPlugins().apply(ReleasePlugin.class);
+
+        project.allprojects(new Action<Project>() {
+            @Override
+            public void execute(final Project subproject) {
+                if (conf.isPublishAllJavaSubprojects()) {
+                    subproject.getPlugins().withId("java", new Action<Plugin>() {
+                        @Override
+                        public void execute(Plugin plugin) {
+                            subproject.getPlugins().apply(JavaLibraryPlugin.class);
+                        }
+                    });
+                }
+
+                subproject.getPlugins().withType(JavaLibraryPlugin.class, new Action<JavaLibraryPlugin>() {
+                    public void execute(JavaLibraryPlugin plugin) {
+                        Task bintrayUpload = subproject.getTasks().getByName(BintrayPlugin.BINTRAY_UPLOAD_TASK);
+                        Task performRelease = project.getTasks().getByName(ReleasePlugin.PERFORM_RELEASE_TASK);
+                        performRelease.dependsOn(bintrayUpload);
+
+                        //Making git push run as late as possible because it is an operation that is hard to reverse.
+                        //Git push will be executed after all tasks needed by bintrayUpload
+                        // but before bintrayUpload.
+                        //Using task path as String because the task comes from maven-publish new configuration model
+                        // and we cannot refer to it in a normal way, by task instance.
+                        String mavenLocalTask = subproject.getPath() + ":" + MAVEN_LOCAL_TASK;
+                        Task gitPush = project.getTasks().getByName(GitPlugin.GIT_PUSH_TASK);
+                        gitPush.mustRunAfter(mavenLocalTask);
+                        //bintray upload after git push so that when git push fails we don't publish jars to bintray
+                        //git push is easier to undo than deleting published jars (not possible with Central)
+                        bintrayUpload.mustRunAfter(gitPush);
+
+                        final BintrayExtension bintray = subproject.getExtensions().getByType(BintrayExtension.class);
+                        //TODO clean up below. We don't need 'deferredConfiguration' because at this point
+                        // shipkit file was already loaded and java library plugin applied on the subproject
+                        deferredConfiguration(subproject, new Runnable() {
+                            public void run() {
+                                configurePublicationRepo(project, BintrayUtil.getRepoLink(bintray));
+                            }
+                        });
+                    }
+                });
+            }
+        });
+    }
+
+    private static void configurePublicationRepo(Project project, String bintrayRepo) {
+        //not using 'getTasks().withType()' because I don't want to create too many task configuration rules
+        //TODO add information about it in the development guide
+        for (Task t : project.getTasks()) {
+            if (t instanceof UpdateReleaseNotesTask) {
+                UpdateReleaseNotesTask task = (UpdateReleaseNotesTask) t;
+                if (task.getPublicationRepository() == null) {
+                    LOG.info("Configuring publication repository '{}' on task: {}", bintrayRepo, t.getPath());
+                    task.setPublicationRepository(bintrayRepo);
+                }
+            }
+        }
+        //TODO unit test coverage
+    }
+}

--- a/src/main/groovy/org/shipkit/internal/gradle/release/ReleasePlugin.java
+++ b/src/main/groovy/org/shipkit/internal/gradle/release/ReleasePlugin.java
@@ -15,6 +15,9 @@ import static org.shipkit.internal.gradle.configuration.LazyConfiguration.lazyCo
  * Applies plugins:
  * <ul>
  *     <li>{@link ReleaseConfigurationPlugin}</li>
+ *     <li>{@link ReleaseNotesPlugin}</li>
+ *     <li>{@link VersioningPlugin}</li>
+ *     <li>{@link GitPlugin}</li>
  * </ul>
  *
  * Adds tasks:

--- a/src/main/groovy/org/shipkit/internal/gradle/release/ReleasePlugin.java
+++ b/src/main/groovy/org/shipkit/internal/gradle/release/ReleasePlugin.java
@@ -1,0 +1,84 @@
+package org.shipkit.internal.gradle.release;
+
+import org.gradle.api.*;
+import org.shipkit.gradle.ReleaseConfiguration;
+import org.shipkit.internal.gradle.GitPlugin;
+import org.shipkit.internal.gradle.ReleaseConfigurationPlugin;
+import org.shipkit.internal.gradle.ReleaseNotesPlugin;
+import org.shipkit.internal.gradle.VersioningPlugin;
+import org.shipkit.internal.gradle.util.TaskMaker;
+
+import static org.shipkit.internal.gradle.ReleaseNotesPlugin.UPDATE_NOTES_TASK;
+import static org.shipkit.internal.gradle.configuration.LazyConfiguration.lazyConfiguration;
+
+/**
+ * Applies plugins:
+ * <ul>
+ *     <li>{@link ReleaseConfigurationPlugin}</li>
+ * </ul>
+ *
+ * Adds tasks:
+ * <ul>
+ *     <li>performRelease</li>
+ *     <li>testRelease</li>
+ *     <li>releaseCleanUp</li>
+ * </ul>
+ */
+public class ReleasePlugin implements Plugin<Project> {
+
+    public static final String PERFORM_RELEASE_TASK = "performRelease";
+    public static final String TEST_RELEASE_TASK = "testRelease";
+    public static final String RELEASE_CLEAN_UP_TASK = "releaseCleanUp";
+
+    @Override
+    public void apply(Project project) {
+        final ReleaseConfiguration conf = project.getPlugins().apply(ReleaseConfigurationPlugin.class).getConfiguration();
+
+        project.getPlugins().apply(ReleaseNotesPlugin.class);
+        project.getPlugins().apply(VersioningPlugin.class);
+        project.getPlugins().apply(GitPlugin.class);
+
+        TaskMaker.task(project, PERFORM_RELEASE_TASK, new Action<Task>() {
+            public void execute(final Task t) {
+                t.setDescription("Performs release. " +
+                        "Ship with: './gradlew performRelease -Pshipkit.dryRun=false'. " +
+                        "Test with: './gradlew testRelease'");
+
+                t.dependsOn(VersioningPlugin.BUMP_VERSION_FILE_TASK, UPDATE_NOTES_TASK);
+                t.dependsOn(GitPlugin.PERFORM_GIT_PUSH_TASK);
+            }
+        });
+
+        TaskMaker.task(project, TEST_RELEASE_TASK, new Action<Task>() {
+            @Override
+            public void execute(final Task t) {
+                t.setDescription("Tests the release procedure and cleans up. Safe to be invoked multiple times.");
+                //releaseCleanUp is already set up to run all his "subtasks" after performRelease is performed
+                //releaseNeeded is used here only to execute the code paths in the release needed task (extra testing)
+                t.dependsOn("releaseNeeded", "performRelease", "releaseCleanUp");
+
+                //Ensure that when 'testRelease' is invoked we must be using 'dryRun'
+                //This is to avoid unintentional releases during testing
+                lazyConfiguration(t, new Runnable() {
+                    public void run() {
+                        if (!conf.isDryRun()) {
+                            throw new GradleException("When '" + t.getName() + "' task is executed" +
+                                    " 'shipkit.dryRun' must be set to 'true'.\n" +
+                                    "See Javadoc for ReleaseConfigurationPlugin.");
+                        }
+                    }
+                });
+            }
+        });
+
+        TaskMaker.task(project, RELEASE_CLEAN_UP_TASK, new Action<Task>() {
+            public void execute(final Task t) {
+                t.setDescription("Cleans up the working copy, useful after dry running the release");
+
+                //using finalizedBy so that all clean up tasks run, even if one of them fails
+                t.finalizedBy(GitPlugin.PERFORM_GIT_COMMIT_CLEANUP_TASK);
+                t.finalizedBy(GitPlugin.TAG_CLEANUP_TASK);
+            }
+        });
+    }
+}

--- a/src/main/groovy/org/shipkit/internal/notes/util/IOUtil.java
+++ b/src/main/groovy/org/shipkit/internal/notes/util/IOUtil.java
@@ -27,6 +27,10 @@ public class IOUtil {
         try {
             return readNow(new FileInputStream(input));
         } catch (Exception e) {
+            //TODO this potentially swallows exceptions
+            //if the file does not exist, we should just use default value
+            //if the file cannot be read, we should write a message to the log that we cannot use the file
+            // + stack trace in debug level
             return defaultValue;
         }
     }

--- a/src/test/groovy/org/shipkit/internal/gradle/PomContributorsPluginTest.groovy
+++ b/src/test/groovy/org/shipkit/internal/gradle/PomContributorsPluginTest.groovy
@@ -1,0 +1,15 @@
+package org.shipkit.internal.gradle
+
+import org.gradle.testfixtures.ProjectBuilder
+import spock.lang.Specification
+
+class PomContributorsPluginTest extends Specification {
+
+    def project = new ProjectBuilder().build()
+
+    def "applies"() {
+        expect:
+        project.plugins.apply(PomContributorsPlugin)
+        project.plugins.apply(BaseJavaLibraryPlugin)
+    }
+}

--- a/src/test/groovy/org/shipkit/internal/gradle/release/CiReleasePluginTest.groovy
+++ b/src/test/groovy/org/shipkit/internal/gradle/release/CiReleasePluginTest.groovy
@@ -1,0 +1,14 @@
+package org.shipkit.internal.gradle.release
+
+import org.gradle.testfixtures.ProjectBuilder
+import spock.lang.Specification
+
+class CiReleasePluginTest extends Specification {
+
+    def project = new ProjectBuilder().build()
+
+    def "applies"() {
+        expect:
+        project.plugins.apply(CiReleasePlugin)
+    }
+}

--- a/src/test/groovy/org/shipkit/internal/gradle/release/JavaReleasePluginTest.groovy
+++ b/src/test/groovy/org/shipkit/internal/gradle/release/JavaReleasePluginTest.groovy
@@ -1,0 +1,16 @@
+package org.shipkit.internal.gradle.release
+
+import org.gradle.testfixtures.ProjectBuilder
+import spock.lang.Specification
+
+class JavaReleasePluginTest extends Specification {
+
+    def project = new ProjectBuilder().build()
+
+    def "applies"() {
+        expect:
+        project.plugins.apply(JavaReleasePlugin)
+        project.plugins.apply("java")
+        project.evaluate()
+    }
+}

--- a/src/test/groovy/org/shipkit/internal/gradle/release/ReleasePluginTest.groovy
+++ b/src/test/groovy/org/shipkit/internal/gradle/release/ReleasePluginTest.groovy
@@ -1,0 +1,14 @@
+package org.shipkit.internal.gradle.release
+
+import org.gradle.testfixtures.ProjectBuilder
+import spock.lang.Specification
+
+class ReleasePluginTest extends Specification {
+
+    def project = new ProjectBuilder().build()
+
+    def "applies"() {
+        expect:
+        project.plugins.apply(ReleasePlugin.class)
+    }
+}


### PR DESCRIPTION
You could try reviewing by commit to make it easier.

- moved the complexity to separate plugins so that our code has better function decomposition (is easier to reuse, more flexible). "org.shipkit.java" plugin has only 3 lines of code :D
- new 'ciPerformRelease'. This task simplifies travis configuration, we will have just one task to run to preform release from ci machine. It will also allow us to fix the problem of "silent failures" from release. See #257.
- Some smaller refactorings and tidy-ups I found on the way (like the error handling / exception messages)

Pending:

- better logging from forked processes in CompositeExecTask, cleaner output
- more unit tests around CompositeExecTask. This however, will be driven by the previous TODO.

Finally:

- it was a lot of fun developing this piece of code. Our Gradle plugins are of great quality!!!