### PR TITLE
Intuitive behavior of 'dryRun', reduced logging noise

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -54,7 +54,7 @@ dependencies {
 pluginBundle {
     website = 'http://shipkit.org/'
     vcsUrl = 'https://github.com/mockito/shipkit'
-    description = 'Release tools and Gradle plugins that automate Mockito continuous delivery.'
+    description = 'Shipkit - toolkit for shipping it. Enables continuous delivery with automated version bumps, release notes and many more.'
     tags = ['shipkit', 'continuous delivery', 'release']
 
     mavenCoordinates {
@@ -68,7 +68,7 @@ task travisRelease {
         logger.lifecycle("{} - Publishing to Gradle Plugin Portal...", path)
         exec {
             commandLine "./gradlew", "publishPlugins", "performVersionBump",
-                    "-Pshipkit.dryRun=false",
+                    "-Pshipkit.dryRun=false", //TODO remove when #236 is fixed
                     "-Pgradle.publish.key=${System.getenv('GRADLE_PUBLISH_KEY')}",
                     "-Pgradle.publish.secret=${System.getenv('GRADLE_PUBLISH_SECRET')}"
         }

--- a/src/main/groovy/org/shipkit/gradle/ReleaseConfiguration.java
+++ b/src/main/groovy/org/shipkit/gradle/ReleaseConfiguration.java
@@ -65,7 +65,7 @@ public class ReleaseConfiguration {
 
     //TODO currently it's not clear when to use class fields and when to use the 'configuration' map
     //Let's make it clear in the docs
-    private boolean dryRun = true;
+    private boolean dryRun;
     private boolean publishAllJavaSubprojects = true;
 
     /**

--- a/src/main/groovy/org/shipkit/internal/gradle/PluginDiscoveryPlugin.java
+++ b/src/main/groovy/org/shipkit/internal/gradle/PluginDiscoveryPlugin.java
@@ -6,6 +6,8 @@ import org.gradle.api.Action;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.file.FileTree;
+import org.gradle.api.logging.Logger;
+import org.gradle.api.logging.Logging;
 import org.gradle.api.plugins.JavaPluginConvention;
 import org.gradle.api.tasks.util.PatternSet;
 
@@ -25,6 +27,7 @@ import java.util.Set;
  */
 public class PluginDiscoveryPlugin implements Plugin<Project> {
 
+    private static Logger LOG = Logging.getLogger(PluginDiscoveryPlugin.class);
     private static final String DOT_PROPERTIES = ".properties";
 
     @Override
@@ -35,11 +38,12 @@ public class PluginDiscoveryPlugin implements Plugin<Project> {
                 PluginBundleExtension extension = project.getExtensions().findByType(PluginBundleExtension.class);
 
                 Set<File> pluginPropertyFiles = discoverGradlePluginPropertyFiles(project);
+                LOG.lifecycle("  Adding {} discovered Gradle plugins to 'pluginBundle'", pluginPropertyFiles.size());
                 for (File pluginPropertyFile : pluginPropertyFiles) {
                     PluginConfig config = new PluginConfig(generatePluginName(pluginPropertyFile.getName()));
                     config.setId(pluginPropertyFile.getName().substring(0, pluginPropertyFile.getName().lastIndexOf(DOT_PROPERTIES)));
                     config.setDisplayName(getImplementationClass(pluginPropertyFile));
-                    project.getLogger().lifecycle("Adding autodiscovered plugin " + config);
+                    LOG.info("Discovered plugin " + config);
                     extension.getPlugins().add(config);
                 }
             }

--- a/src/main/groovy/org/shipkit/internal/gradle/ReleaseConfigurationPlugin.java
+++ b/src/main/groovy/org/shipkit/internal/gradle/ReleaseConfigurationPlugin.java
@@ -52,9 +52,9 @@ public class ReleaseConfigurationPlugin implements Plugin<Project> {
             loadConfigFromFile(project.getRootProject(), configFile);
 
             if (project.hasProperty("shipkit.dryRun")) {
-                Object value = project.getProperties().get("shipkit.dryRun");
-                configuration.setDryRun(!"false".equals(value));
-                //TODO we can actually implement it so that we automatically preconfigure everything by command line parameters
+                //TODO document that we only check for presence of this property
+                configuration.setDryRun(true);
+                //TODO (maybe) we can actually implement it so that we automatically preconfigure everything by command line parameters
                 //e.g. shipkit.gitHub.repository is also a property
             }
 

--- a/src/main/groovy/org/shipkit/internal/gradle/ReleaseConfigurationPlugin.java
+++ b/src/main/groovy/org/shipkit/internal/gradle/ReleaseConfigurationPlugin.java
@@ -52,6 +52,7 @@ public class ReleaseConfigurationPlugin implements Plugin<Project> {
             loadConfigFromFile(project.getRootProject(), configFile);
 
             if (project.hasProperty("shipkit.dryRun")) {
+                //TODO rename to 'dryRun' and expose constant
                 //TODO document that we only check for presence of this property
                 configuration.setDryRun(true);
                 //TODO (maybe) we can actually implement it so that we automatically preconfigure everything by command line parameters

--- a/src/main/groovy/org/shipkit/internal/gradle/ReleaseNeededPlugin.java
+++ b/src/main/groovy/org/shipkit/internal/gradle/ReleaseNeededPlugin.java
@@ -30,6 +30,7 @@ import org.shipkit.internal.gradle.util.TaskMaker;
 public class ReleaseNeededPlugin implements Plugin<Project> {
 
     public final static String ASSERT_RELEASE_NEEDED_TASK = "assertReleaseNeeded";
+    public final static String RELEASE_NEEDED = "releaseNeeded";
 
     @Override
     public void apply(Project project) {
@@ -44,7 +45,7 @@ public class ReleaseNeededPlugin implements Plugin<Project> {
 
         //Below task is useful for testing. It will not throw an exception but will run the code that check is release is needed
         //and it will print the information to the console.
-        releaseNeededTask(project, "releaseNeeded", conf)
+        releaseNeededTask(project, RELEASE_NEEDED, conf)
                 .setExplosive(false)
                 .setDescription("Checks and prints to the console if criteria for the release are met.");
     }

--- a/src/main/groovy/org/shipkit/internal/gradle/release/CiReleasePlugin.java
+++ b/src/main/groovy/org/shipkit/internal/gradle/release/CiReleasePlugin.java
@@ -43,7 +43,7 @@ public class CiReleasePlugin implements Plugin<Project> {
                 task.setDescription("Checks if release is needed. If so it will prepare for ci release and perform release.");
                 task.getExecCommands().add(new ExecCommand(asList("./gradlew", ASSERT_RELEASE_NEEDED_TASK), stopExecution()));
                 task.getExecCommands().add(new ExecCommand(asList("./gradlew", CI_RELEASE_PREPARE_TASK)));
-                task.getExecCommands().add(new ExecCommand(asList("./gradlew", PERFORM_RELEASE_TASK, "-Pshipkit.dryRun=false")));
+                task.getExecCommands().add(new ExecCommand(asList("./gradlew", PERFORM_RELEASE_TASK)));
             }
         });
     }

--- a/src/main/groovy/org/shipkit/internal/gradle/release/ReleasePlugin.java
+++ b/src/main/groovy/org/shipkit/internal/gradle/release/ReleasePlugin.java
@@ -55,6 +55,7 @@ public class ReleasePlugin implements Plugin<Project> {
         });
 
         TaskMaker.task(project, TEST_RELEASE_TASK, CompositeExecTask.class, new Action<CompositeExecTask>() {
+            //TODO rename CompositeExecTask because it can have one action
             public void execute(CompositeExecTask task) {
                 task.setDescription("Tests the release procedure and cleans up. Safe to be invoked multiple times.");
                 //releaseCleanUp is already set up to run all his "subtasks" after performRelease is performed

--- a/src/main/groovy/org/shipkit/internal/gradle/release/ReleasePlugin.java
+++ b/src/main/groovy/org/shipkit/internal/gradle/release/ReleasePlugin.java
@@ -1,20 +1,24 @@
 package org.shipkit.internal.gradle.release;
 
-import org.gradle.api.*;
-import org.shipkit.gradle.ReleaseConfiguration;
+import org.gradle.api.Action;
+import org.gradle.api.Plugin;
+import org.gradle.api.Project;
+import org.gradle.api.Task;
+import org.shipkit.gradle.exec.CompositeExecTask;
+import org.shipkit.gradle.exec.ExecCommand;
 import org.shipkit.internal.gradle.GitPlugin;
-import org.shipkit.internal.gradle.ReleaseConfigurationPlugin;
+import org.shipkit.internal.gradle.ReleaseNeededPlugin;
 import org.shipkit.internal.gradle.ReleaseNotesPlugin;
 import org.shipkit.internal.gradle.VersioningPlugin;
 import org.shipkit.internal.gradle.util.TaskMaker;
 
+import static java.util.Arrays.asList;
+import static org.shipkit.internal.gradle.ReleaseNeededPlugin.RELEASE_NEEDED;
 import static org.shipkit.internal.gradle.ReleaseNotesPlugin.UPDATE_NOTES_TASK;
-import static org.shipkit.internal.gradle.configuration.LazyConfiguration.lazyConfiguration;
 
 /**
  * Applies plugins:
  * <ul>
- *     <li>{@link ReleaseConfigurationPlugin}</li>
  *     <li>{@link ReleaseNotesPlugin}</li>
  *     <li>{@link VersioningPlugin}</li>
  *     <li>{@link GitPlugin}</li>
@@ -35,42 +39,28 @@ public class ReleasePlugin implements Plugin<Project> {
 
     @Override
     public void apply(Project project) {
-        final ReleaseConfiguration conf = project.getPlugins().apply(ReleaseConfigurationPlugin.class).getConfiguration();
-
         project.getPlugins().apply(ReleaseNotesPlugin.class);
         project.getPlugins().apply(VersioningPlugin.class);
         project.getPlugins().apply(GitPlugin.class);
+        project.getPlugins().apply(ReleaseNeededPlugin.class);
 
         TaskMaker.task(project, PERFORM_RELEASE_TASK, new Action<Task>() {
             public void execute(final Task t) {
                 t.setDescription("Performs release. " +
-                        "Ship with: './gradlew performRelease -Pshipkit.dryRun=false'. " +
-                        "Test with: './gradlew testRelease'");
+                        "For testing, use: './gradlew testRelease'");
 
                 t.dependsOn(VersioningPlugin.BUMP_VERSION_FILE_TASK, UPDATE_NOTES_TASK);
                 t.dependsOn(GitPlugin.PERFORM_GIT_PUSH_TASK);
             }
         });
 
-        TaskMaker.task(project, TEST_RELEASE_TASK, new Action<Task>() {
-            @Override
-            public void execute(final Task t) {
-                t.setDescription("Tests the release procedure and cleans up. Safe to be invoked multiple times.");
+        TaskMaker.task(project, TEST_RELEASE_TASK, CompositeExecTask.class, new Action<CompositeExecTask>() {
+            public void execute(CompositeExecTask task) {
+                task.setDescription("Tests the release procedure and cleans up. Safe to be invoked multiple times.");
                 //releaseCleanUp is already set up to run all his "subtasks" after performRelease is performed
                 //releaseNeeded is used here only to execute the code paths in the release needed task (extra testing)
-                t.dependsOn("releaseNeeded", "performRelease", "releaseCleanUp");
-
-                //Ensure that when 'testRelease' is invoked we must be using 'dryRun'
-                //This is to avoid unintentional releases during testing
-                lazyConfiguration(t, new Runnable() {
-                    public void run() {
-                        if (!conf.isDryRun()) {
-                            throw new GradleException("When '" + t.getName() + "' task is executed" +
-                                    " 'shipkit.dryRun' must be set to 'true'.\n" +
-                                    "See Javadoc for ReleaseConfigurationPlugin.");
-                        }
-                    }
-                });
+                task.getExecCommands().add(new ExecCommand(asList(
+                    "./gradlew", RELEASE_NEEDED, PERFORM_RELEASE_TASK, RELEASE_CLEAN_UP_TASK, "-Pshipkit.dryRun")));
             }
         });
 

--- a/src/test/groovy/org/shipkit/internal/gradle/ReleaseConfigurationPluginTest.groovy
+++ b/src/test/groovy/org/shipkit/internal/gradle/ReleaseConfigurationPluginTest.groovy
@@ -25,25 +25,17 @@ class ReleaseConfigurationPluginTest extends PluginSpecification {
         subproject.plugins.apply(ReleaseConfigurationPlugin).configuration == root.plugins.apply(ReleaseConfigurationPlugin).configuration
     }
 
-    def "dry run on by default"() {
+    def "dry run off by default"() {
         expect:
-        root.plugins.apply(ReleaseConfigurationPlugin).configuration.dryRun
+        !root.plugins.apply(ReleaseConfigurationPlugin).configuration.dryRun
     }
 
-    @Unroll
-    def "configures dry run to #setting when project property is #property"() {
+    def "configures dry run based on project property"() {
         when:
-        root.ext.'shipkit.dryRun' = property
+        root.ext.'shipkit.dryRun' = ''
 
         then:
-        root.plugins.apply(ReleaseConfigurationPlugin).configuration.dryRun == setting
-
-        where:
-        property | setting
-        "false"  | false
-        "true"   | true
-        ""       | true
-        null     | true
+        root.plugins.apply(ReleaseConfigurationPlugin).configuration.dryRun
     }
 
     def "configures initConfigFile task correctly"() {

--- a/src/test/groovy/org/shipkit/internal/gradle/ReleaseConfigurationPluginTest.groovy
+++ b/src/test/groovy/org/shipkit/internal/gradle/ReleaseConfigurationPluginTest.groovy
@@ -2,7 +2,6 @@ package org.shipkit.internal.gradle
 
 import org.gradle.api.Project
 import org.gradle.testfixtures.ProjectBuilder
-import spock.lang.Unroll
 import testutil.PluginSpecification
 
 class ReleaseConfigurationPluginTest extends PluginSpecification {


### PR DESCRIPTION
- Intuitive behavior of 'dryRun' - dryRyn 'on' by default is counter intuitive (see #236). Simplified 'testRelease' task, now it uses CompositeExecTask.
- Reduced logging noise in the plugin discovery code. Started logging summary information at the 'lifecycle' level, pushed down less important information to 'info' level.

Tested:
- Ran './gradlew testRelease' in example project, the output was good.

Pending:
- CompositeExecTask needs to be renamed (composite is not it's most important characteristic)
- It also needs to improve logging!