### PR TITLE
GitCommitTask works when version.properties is not tracked by git yet

### DIFF
--- a/src/main/groovy/org/shipkit/internal/gradle/GitCommitTask.java
+++ b/src/main/groovy/org/shipkit/internal/gradle/GitCommitTask.java
@@ -1,7 +1,7 @@
 package org.shipkit.internal.gradle;
 
 import org.gradle.api.Task;
-import org.gradle.api.tasks.Exec;
+import org.shipkit.gradle.exec.CompositeExecTask;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -11,7 +11,7 @@ import java.util.List;
  * Commits all changes registered with {@link GitCommitTask#addChange} method
  * Commit message is concatenated from all descriptions of registered changes
  */
-public class GitCommitTask extends Exec{
+public class GitCommitTask extends CompositeExecTask{
 
     private List<File> filesToCommit = new ArrayList<File>();
     private List<String> descriptions = new ArrayList<String>();

--- a/src/main/groovy/org/shipkit/internal/gradle/GitPlugin.java
+++ b/src/main/groovy/org/shipkit/internal/gradle/GitPlugin.java
@@ -57,6 +57,8 @@ public class GitPlugin implements Plugin<Project> {
             public void execute(final GitCommitTask t) {
                 t.setDescription("Commits all changed files using generic --author and aggregated commit message");
                 //TODO WW create unit tests
+                //doFirst used so that commit operation can reflect changes added by other plugins configurations
+                //see GitCommitTask#addChange
                 t.doFirst(new Action<Task>() {
                     @Override
                     public void execute(Task task) {


### PR DESCRIPTION
"git commit" with a list of files to commit doesn't work when at least one of these files is not tracked by git yet. It is important for bootstraping - "ciPerformRelease" fails when run for the first time. It works if we use "git add" first, with the new CompositeExecTask we can do it in one task, without duplication of configuration. 