### PR TITLE
Fixed Travis CI git branch handling

### DIFF
--- a/src/main/groovy/org/shipkit/internal/gradle/GitSetupPlugin.java
+++ b/src/main/groovy/org/shipkit/internal/gradle/GitSetupPlugin.java
@@ -17,11 +17,14 @@ import org.shipkit.internal.gradle.util.TaskMaker;
  * Adds following tasks:
  * <ul>
  *     <li>
- *         'gitUnshallow' - performs 'git unshallow' to get sufficient amount of commits,
- *         useful for release notes automation</li>
+ *         'gitUnshallow' - performs 'git unshallow' to get sufficient amount of commits.
+ *         Needed for CI workflows, where the clone is typically shallow.
+ *         We need good number of commits to generate release notes for.</li>
  *     <li>
- *         'checkOutBranch' - checks out specific branch,
- *         useful when CI server checks out a rev hash that is not any committable branch</li>
+ *         'gitCheckout' ({@link GitCheckOutTask}) - checks out specific branch.
+ *         Needed for CI workflows, where CI server automatically checks out rev hash of the commit, detaching from HEAD.
+ *         In detached HEAD, all commits are lost. We need to make commits for version bumps and release notes/changelog.
+ *         Therefore we need to checkout real branch like "master"</li>
  *     <li>
  *         'setGitUserName' - sets generic user name so that CI server can commit code as neatly described robot,
  *         uses value from {@link ReleaseConfiguration.Git#getUser()}
@@ -32,7 +35,7 @@ import org.shipkit.internal.gradle.util.TaskMaker;
  *     </li>
  *     <li>
  *         'ciReleasePrepare' - prepares for release from CI,
- *         depends on unshallow, set branch, set generic git user and email.
+ *         depends on most other tasks (unshallow, git checkout branch, set generic git user and email).
  *     </li>
  * </ul>
  */
@@ -41,7 +44,7 @@ public class GitSetupPlugin implements Plugin<Project> {
     private static final Logger LOG = Logging.getLogger(GitSetupPlugin.class);
 
     private static final String UNSHALLOW_TASK = "gitUnshallow";
-    static final String CHECKOUT_BRANCH_TASK = "checkOutBranch";
+    static final String CHECKOUT_TASK = "gitCheckout";
     private static final String SET_USER_TASK = "setGitUserName";
     private static final String SET_EMAIL_TASK = "setGitUserEmail";
     public static final String CI_RELEASE_PREPARE_TASK = "ciReleasePrepare";
@@ -69,7 +72,7 @@ public class GitSetupPlugin implements Plugin<Project> {
             }
         });
 
-        TaskMaker.task(project, CHECKOUT_BRANCH_TASK, GitCheckOutTask.class, new Action<GitCheckOutTask>() {
+        TaskMaker.task(project, CHECKOUT_TASK, GitCheckOutTask.class, new Action<GitCheckOutTask>() {
             public void execute(final GitCheckOutTask t) {
                 t.setDescription("Checks out the branch that can be committed. CI systems often check out revision that is not committable.");
             }
@@ -104,7 +107,7 @@ public class GitSetupPlugin implements Plugin<Project> {
         TaskMaker.task(project, CI_RELEASE_PREPARE_TASK, new Action<Task>() {
             public void execute(Task t) {
                 t.setDescription("Prepares the working copy for releasing from CI build");
-                t.dependsOn(UNSHALLOW_TASK, CHECKOUT_BRANCH_TASK, SET_USER_TASK, SET_EMAIL_TASK);
+                t.dependsOn(UNSHALLOW_TASK, CHECKOUT_TASK, SET_USER_TASK, SET_EMAIL_TASK);
             }
         });
     }

--- a/src/main/groovy/org/shipkit/internal/gradle/TravisPlugin.java
+++ b/src/main/groovy/org/shipkit/internal/gradle/TravisPlugin.java
@@ -9,7 +9,7 @@ import org.shipkit.internal.gradle.configuration.BasicValidator;
 import org.shipkit.internal.gradle.configuration.LazyConfiguration;
 import org.shipkit.internal.gradle.git.GitBranchPlugin;
 
-import static org.shipkit.internal.gradle.GitSetupPlugin.CHECKOUT_BRANCH_TASK;
+import static org.shipkit.internal.gradle.GitSetupPlugin.CHECKOUT_TASK;
 import static org.shipkit.internal.gradle.git.GitBranchPlugin.IDENTIFY_GIT_BRANCH;
 
 /**
@@ -41,7 +41,7 @@ public class TravisPlugin implements Plugin<Project> {
         project.getPlugins().withType(GitSetupPlugin.class, new Action<GitSetupPlugin>() {
             @Override
             public void execute(GitSetupPlugin p) {
-                final GitCheckOutTask checkout = (GitCheckOutTask) project.getTasks().getByName(CHECKOUT_BRANCH_TASK);
+                final GitCheckOutTask checkout = (GitCheckOutTask) project.getTasks().getByName(CHECKOUT_TASK);
                 checkout.setRev(branch);
                 LazyConfiguration.lazyConfiguration(checkout, new Runnable() {
                     public void run() {

--- a/src/main/groovy/org/shipkit/internal/gradle/TravisPlugin.java
+++ b/src/main/groovy/org/shipkit/internal/gradle/TravisPlugin.java
@@ -3,6 +3,8 @@ package org.shipkit.internal.gradle;
 import org.gradle.api.Action;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
+import org.gradle.api.logging.Logger;
+import org.gradle.api.logging.Logging;
 import org.shipkit.gradle.ReleaseNeededTask;
 import org.shipkit.gradle.git.IdentifyGitBranchTask;
 import org.shipkit.internal.gradle.configuration.BasicValidator;
@@ -25,11 +27,15 @@ import static org.shipkit.internal.gradle.git.GitBranchPlugin.IDENTIFY_GIT_BRANC
  */
 public class TravisPlugin implements Plugin<Project> {
 
+    private final static Logger LOG = Logging.getLogger(TravisPlugin.class);
+
     @Override
     public void apply(final Project project) {
         project.getPlugins().apply(GitSetupPlugin.class);
 
         final String branch = System.getenv("TRAVIS_BRANCH");
+        LOG.info("Branch from 'TRAVIS_BRANCH' env variable: {}", branch);
+
         project.getPlugins().withType(GitBranchPlugin.class, new Action<GitBranchPlugin>() {
             @Override
             public void execute(GitBranchPlugin p) {
@@ -56,9 +62,12 @@ public class TravisPlugin implements Plugin<Project> {
         });
 
         project.getPlugins().withType(ReleaseNeededPlugin.class, new Action<ReleaseNeededPlugin>() {
-            String pr = System.getenv("TRAVIS_PULL_REQUEST");
-            final boolean isPullRequest = pr != null && !pr.trim().isEmpty() && !pr.equals("false");
             public void execute(ReleaseNeededPlugin p) {
+                String pr = System.getenv("TRAVIS_PULL_REQUEST");
+                LOG.info("Pull request from 'TRAVIS_PULL_REQUEST' env variable: {}", pr);
+                final boolean isPullRequest = pr != null && !pr.trim().isEmpty() && !pr.equals("false");
+                LOG.info("Pull request build: {}", isPullRequest);
+
                 project.getTasks().withType(ReleaseNeededTask.class, new Action<ReleaseNeededTask>() {
                     public void execute(ReleaseNeededTask t) {
                         t.setCommitMessage(System.getenv("TRAVIS_COMMIT_MESSAGE"));

--- a/src/main/groovy/org/shipkit/internal/gradle/TravisPlugin.java
+++ b/src/main/groovy/org/shipkit/internal/gradle/TravisPlugin.java
@@ -4,16 +4,23 @@ import org.gradle.api.Action;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.shipkit.gradle.ReleaseNeededTask;
+import org.shipkit.gradle.git.IdentifyGitBranchTask;
 import org.shipkit.internal.gradle.configuration.BasicValidator;
 import org.shipkit.internal.gradle.configuration.LazyConfiguration;
+import org.shipkit.internal.gradle.git.GitBranchPlugin;
 
 import static org.shipkit.internal.gradle.GitSetupPlugin.CHECKOUT_BRANCH_TASK;
+import static org.shipkit.internal.gradle.git.GitBranchPlugin.IDENTIFY_GIT_BRANCH;
 
 /**
  * Configures the release automation to be used with Travis CI.
  * <ul>
- * <li>Preconfigures "releasing.build.*" settings based on Travis env variables.</li>
- * <li>Configures {@link GitSetupPlugin#CHECKOUT_BRANCH_TASK} task with value from Travis env variable.</li>
+ * <li>Configures {@link GitBranchPlugin}/{@link IdentifyGitBranchTask}
+ *      so that the branch information is taken from 'TRAVIS_BRANCH' env variable.</li>
+ * <li>Configures {@link GitSetupPlugin}/{@link GitCheckOutTask}
+ *      so that it checks out the branch specified in env variable.</li>
+ * <li>Configures {@link ReleaseNeededPlugin}/{@link ReleaseNeededTask}
+ *      so that it uses information from 'TRAVIS_PULL_REQUEST' and 'TRAVIS_COMMIT_MESSAGE' env variables.</li>
  * </ul>
  */
 public class TravisPlugin implements Plugin<Project> {
@@ -22,25 +29,38 @@ public class TravisPlugin implements Plugin<Project> {
     public void apply(final Project project) {
         project.getPlugins().apply(GitSetupPlugin.class);
 
-        String pr = System.getenv("TRAVIS_PULL_REQUEST");
-        final boolean isPullRequest = pr != null && !pr.trim().isEmpty() && !pr.equals("false");
-
-        final GitCheckOutTask checkout = (GitCheckOutTask) project.getTasks().getByName(CHECKOUT_BRANCH_TASK);
         final String branch = System.getenv("TRAVIS_BRANCH");
-        checkout.setRev(branch);
-        LazyConfiguration.lazyConfiguration(checkout, new Runnable() {
-            public void run() {
-                BasicValidator.notNull(checkout.getRev(),
-                        "Please export 'TRAVIS_BRANCH' environment variable first!\n" +
-                                "Alternatively, configure '" + checkout.getPath() + ".rev' task property.");
+        project.getPlugins().withType(GitBranchPlugin.class, new Action<GitBranchPlugin>() {
+            @Override
+            public void execute(GitBranchPlugin p) {
+                IdentifyGitBranchTask identifyBranch = (IdentifyGitBranchTask) project.getTasks().getByName(IDENTIFY_GIT_BRANCH);
+                identifyBranch.setBranch(branch);
+            }
+        });
+
+        project.getPlugins().withType(GitSetupPlugin.class, new Action<GitSetupPlugin>() {
+            @Override
+            public void execute(GitSetupPlugin p) {
+                final GitCheckOutTask checkout = (GitCheckOutTask) project.getTasks().getByName(CHECKOUT_BRANCH_TASK);
+                checkout.setRev(branch);
+                LazyConfiguration.lazyConfiguration(checkout, new Runnable() {
+                    public void run() {
+                        BasicValidator.notNull(checkout.getRev(),
+                                "Task " + checkout.getPath() + " does not know the target revision to check out.\n" +
+                                        "In Travis CI builds, it is automatically configured from 'TRAVIS_BRANCH' environment variable.\n" +
+                                        "If you are trying to run this task outside Travis, you can export the environment variable.\n" +
+                                        "Alternatively, you can set the task's 'rev' property explicitly.");
+                    }
+                });
             }
         });
 
         project.getPlugins().withType(ReleaseNeededPlugin.class, new Action<ReleaseNeededPlugin>() {
+            String pr = System.getenv("TRAVIS_PULL_REQUEST");
+            final boolean isPullRequest = pr != null && !pr.trim().isEmpty() && !pr.equals("false");
             public void execute(ReleaseNeededPlugin p) {
                 project.getTasks().withType(ReleaseNeededTask.class, new Action<ReleaseNeededTask>() {
                     public void execute(ReleaseNeededTask t) {
-                        t.setBranch(branch);
                         t.setCommitMessage(System.getenv("TRAVIS_COMMIT_MESSAGE"));
                         t.setPullRequest(isPullRequest);
                     }

--- a/src/test/groovy/org/shipkit/gradle/git/IdentifyGitBranchTaskTest.groovy
+++ b/src/test/groovy/org/shipkit/gradle/git/IdentifyGitBranchTaskTest.groovy
@@ -18,6 +18,18 @@ class IdentifyGitBranchTaskTest extends Specification {
         !t.branch.isEmpty()
     }
 
+    def "uses explicitly configured branch"() {
+        def t = project.tasks.create("identify", IdentifyGitBranchTask)
+        t.branch = "master"
+
+
+        when:
+        t.execute()
+
+        then:
+        t.branch == "master"
+    }
+
     def "fails when branch requested too early"() {
         def t = project.tasks.create("identify", IdentifyGitBranchTask)
 

--- a/src/test/groovy/org/shipkit/internal/gradle/TravisPluginTest.groovy
+++ b/src/test/groovy/org/shipkit/internal/gradle/TravisPluginTest.groovy
@@ -1,0 +1,18 @@
+package org.shipkit.internal.gradle
+
+import org.gradle.testfixtures.ProjectBuilder
+import org.shipkit.internal.gradle.git.GitBranchPlugin
+import spock.lang.Specification
+
+class TravisPluginTest extends Specification {
+
+    def project = new ProjectBuilder().build()
+
+    def "applies"() {
+        expect:
+        project.plugins.apply(TravisPlugin)
+        project.plugins.apply(GitBranchPlugin)
+        project.plugins.apply(GitSetupPlugin)
+        project.plugins.apply(ReleaseNeededPlugin)
+    }
+}


### PR DESCRIPTION
- Fixes #264. Reworked TravisPlugin so that it overrides branch on the IdentifyGitBranchTask in Travis CI scenarios
  - I'd rather not hardcode the handling of 'TRAVIS_BRANCH' env variable in the IdentifyGitBranchTask. This env variable handling should be a part of TravisPlugin.
- Renames, logging improvements, Javadoc

Tested by:
 - running ```./gradlew testRelease``` with and w/o 'TRAVIS_BRANCH' env variable exported, checked the build outputs. 
 - running ```./gradlew assertReleaseNeeded```, checked the build outputs.

Thank you for reporting the bug!