### PR TITLE
run animal sniffer only in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ install:
  - true
 
 script:
-  - ./gradlew build -s -i
+  - ./gradlew build -PcheckJava6Compatibility -s -i
 
 after_success:
   - ./gradlew assertReleaseNeeded && ./gradlew ciReleasePrepare && ./gradlew travisRelease -s

--- a/gradle/java6-compatibility.gradle
+++ b/gradle/java6-compatibility.gradle
@@ -1,8 +1,10 @@
-allprojects { p ->
-    plugins.withId('java') {
-        p.apply plugin :'ru.vyarus.animalsniffer'
-        p.dependencies {
-            signature 'org.codehaus.mojo.signature:java16:1.1@signature'
+if (project.hasProperty('checkJava6Compatibility')) {
+    allprojects { p ->
+        plugins.withId('java') {
+            p.apply plugin: 'ru.vyarus.animalsniffer'
+            p.dependencies {
+                signature 'org.codehaus.mojo.signature:java16:1.1@signature'
+            }
         }
     }
 }


### PR DESCRIPTION
fixes #266

One can also pass `-PcheckJava6Compatibility` to the build locally in order to run animal sniffer.
In CI we are passing the property mentioned to the build by default.