### PR TITLE
Cleaner output from processes forked from Gradle

### DIFF
--- a/src/main/groovy/org/shipkit/gradle/exec/CompositeExecTask.java
+++ b/src/main/groovy/org/shipkit/gradle/exec/CompositeExecTask.java
@@ -7,6 +7,7 @@ import org.gradle.api.logging.Logging;
 import org.gradle.api.tasks.TaskAction;
 import org.gradle.process.ExecResult;
 import org.gradle.process.ExecSpec;
+import org.shipkit.internal.exec.ExternalProcessStream;
 import org.shipkit.internal.gradle.util.StringUtil;
 
 import java.util.Collection;
@@ -41,13 +42,16 @@ public class CompositeExecTask extends DefaultTask {
             ExecResult result = getProject().exec(new Action<ExecSpec>() {
                 @Override
                 public void execute(ExecSpec spec) {
-                    //TODO add better logging, we should capture the output from external process
-                    //and prefix it with [./gradlew]
                     //TODO we should expose 'description' on exec command and write it to console before forking process
                     //TODO figure out a clean way of adding unit test coverage for it
 
                     spec.setIgnoreExitValue(true);
                     spec.commandLine(execCommand.getCommandLine());
+                    //TODO move prefix onto the ExecCommand with default
+                    String firstArg = execCommand.getCommandLine().iterator().next();
+                    spec.setStandardOutput(new ExternalProcessStream(firstArg, System.out));
+                    spec.setErrorOutput(new ExternalProcessStream(firstArg, System.err));
+
                     execCommand.getSetupAction().execute(spec);
 
                     LOG.lifecycle("  Executing:\n    " + StringUtil.join(execCommand.getCommandLine(), " "));

--- a/src/main/groovy/org/shipkit/internal/exec/ExternalProcessStream.java
+++ b/src/main/groovy/org/shipkit/internal/exec/ExternalProcessStream.java
@@ -1,0 +1,58 @@
+package org.shipkit.internal.exec;
+
+import org.shipkit.internal.util.ArgumentValidation;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.PrintStream;
+
+/**
+ * On top of standard output stream, this implementation adds prefixing of the output.
+ * It is super useful to make the log output clear.
+ */
+public class ExternalProcessStream extends OutputStream {
+
+    private final PrintStream output;
+    private final String outputPrefix;
+
+    private StringBuilder line = new StringBuilder();
+    private boolean writePrefix = true;
+
+    /**
+     * @param outputPrefix the prefix to be used
+     * @param output
+     */
+    public ExternalProcessStream(String outputPrefix, PrintStream output) {
+        ArgumentValidation.notNull(outputPrefix, "outputPrefix", output, "output");
+        this.outputPrefix = outputPrefix;
+        this.output = output;
+    }
+
+    @Override
+    public void write(int b) throws IOException {
+        //keep building the line
+        line.append((char) b);
+        //maybe write to output
+        maybeOutput(b);
+
+        if (b == '\n') {
+            //clear the line
+            line = new StringBuilder();
+            //next time, before anything is printed to output, print the prefix
+            writePrefix = true;
+        }
+    }
+
+    private void maybeOutput(int b) {
+        //optionally write prefix so that terminal looks clean
+        if (writePrefix) {
+            output.print('[');
+            output.print(outputPrefix);
+            output.print(']');
+            output.print(' ');
+            writePrefix = false;
+        }
+        //write to output
+        output.write(b);
+    }
+}

--- a/src/test/groovy/org/shipkit/internal/exec/ExternalProcessStreamTest.groovy
+++ b/src/test/groovy/org/shipkit/internal/exec/ExternalProcessStreamTest.groovy
@@ -1,0 +1,18 @@
+package org.shipkit.internal.exec
+
+import spock.lang.Specification
+
+class ExternalProcessStreamTest extends Specification {
+
+    def output = new ByteArrayOutputStream()
+
+    def "decorates output"() {
+        def s = new ExternalProcessStream("./gradlew", new PrintStream(output))
+        when:
+        s.write('hey\nbuddy'.bytes)
+
+        then:
+        output.toString() == """[./gradlew] hey
+[./gradlew] buddy"""
+    }
+}


### PR DESCRIPTION
This helps understanding what's going on when we shell out Gradle build from Gradle build. We need to do it for certain scenarios unfortunately. This change makes the view much cleaner.

Example, notice the "[]" prefix:

```
:testRelease
  Executing:
    ./gradlew releaseNeeded performRelease releaseCleanUp -Pshipkit.dryRun
[./gradlew] Starting a Gradle Daemon, 1 busy Daemon could not be reused, use --status for details
[./gradlew]   Building version '0.16.4' (value loaded from 'version.properties' file).
[./gradlew]   'git push' does not use GitHub write token because it was not specified.
```

More output tidy-ups are pending. This is a good 1st step.