### PR TITLE
TRAVIS_BRANCH only used when it's available + decreased logging level

### DIFF
--- a/src/main/groovy/org/shipkit/internal/gradle/TravisPlugin.java
+++ b/src/main/groovy/org/shipkit/internal/gradle/TravisPlugin.java
@@ -1,5 +1,6 @@
 package org.shipkit.internal.gradle;
 
+import org.apache.commons.lang.StringUtils;
 import org.gradle.api.Action;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
@@ -40,7 +41,9 @@ public class TravisPlugin implements Plugin<Project> {
             @Override
             public void execute(GitBranchPlugin p) {
                 IdentifyGitBranchTask identifyBranch = (IdentifyGitBranchTask) project.getTasks().getByName(IDENTIFY_GIT_BRANCH);
-                identifyBranch.setBranch(branch);
+                if(StringUtils.isNotEmpty(branch)) {
+                    identifyBranch.setBranch(branch);
+                }
             }
         });
 

--- a/src/main/groovy/org/shipkit/internal/gradle/TravisPlugin.java
+++ b/src/main/groovy/org/shipkit/internal/gradle/TravisPlugin.java
@@ -1,6 +1,5 @@
 package org.shipkit.internal.gradle;
 
-import org.apache.commons.lang.StringUtils;
 import org.gradle.api.Action;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
@@ -11,6 +10,7 @@ import org.shipkit.gradle.git.IdentifyGitBranchTask;
 import org.shipkit.internal.gradle.configuration.BasicValidator;
 import org.shipkit.internal.gradle.configuration.LazyConfiguration;
 import org.shipkit.internal.gradle.git.GitBranchPlugin;
+import org.shipkit.internal.gradle.util.StringUtil;
 
 import static org.shipkit.internal.gradle.GitSetupPlugin.CHECKOUT_TASK;
 import static org.shipkit.internal.gradle.git.GitBranchPlugin.IDENTIFY_GIT_BRANCH;
@@ -41,7 +41,7 @@ public class TravisPlugin implements Plugin<Project> {
             @Override
             public void execute(GitBranchPlugin p) {
                 IdentifyGitBranchTask identifyBranch = (IdentifyGitBranchTask) project.getTasks().getByName(IDENTIFY_GIT_BRANCH);
-                if(StringUtils.isNotEmpty(branch)) {
+                if(!StringUtil.isEmpty(branch)) {
                     identifyBranch.setBranch(branch);
                 }
             }

--- a/src/main/groovy/org/shipkit/internal/notes/contributors/AllContributorsSerializer.java
+++ b/src/main/groovy/org/shipkit/internal/notes/contributors/AllContributorsSerializer.java
@@ -16,14 +16,14 @@ public class AllContributorsSerializer {
     public String serialize(ProjectContributorsSet contributorsSet) {
         Collection<ProjectContributor> allContributors = contributorsSet.getAllContributors();
         String json = Jsoner.serialize(allContributors);
-        LOG.info("Serialize contributors to: {}", json);
+        LOG.debug("Serialize contributors to: {}", json);
         return json;
     }
 
     public ProjectContributorsSet deserialize(String json) {
         ProjectContributorsSet set = new DefaultProjectContributorsSet();
         try {
-            LOG.info("Deserialize project contributors from: {}", json);
+            LOG.debug("Deserialize project contributors from: {}", json);
             JsonArray array = (JsonArray) Jsoner.deserialize(json);
             for (Object object : array) {
                 JsonObject jsonObject = (JsonObject) object;


### PR DESCRIPTION
When run locally and without TRAVIS_BRANCH env var set, branch in IdentifyGitBranch task will be incorrect. I would set it only if TRAVIS_BRANCH is set which always happen on Travis.

About logging in AllContributorsSerializer - I think this information is not needed on info level, especially that for projects with a lot of contributors it will obfuscate the log, see example from Mockito below: 
<img width="1440" alt="screen shot 2017-07-02 at 19 39 04" src="https://user-images.githubusercontent.com/3420667/27772235-41ef0398-5f5e-11e7-83a6-1e87796c6fb9.png">
