### PR TITLE
Removed configuration logic that I think we don't really need

### DIFF
--- a/src/main/groovy/org/shipkit/gradle/ReleaseConfiguration.java
+++ b/src/main/groovy/org/shipkit/gradle/ReleaseConfiguration.java
@@ -1,7 +1,6 @@
 package org.shipkit.gradle;
 
 import org.gradle.api.GradleException;
-import org.shipkit.internal.version.VersionInfo;
 
 import java.util.Collection;
 import java.util.Collections;
@@ -122,8 +121,7 @@ public class ReleaseConfiguration {
     }
 
     /**
-     * Return last previously released version number
-     * See {@link VersionInfo#getPreviousVersion()}
+     * Return last previously released version number.
      */
     public String getPreviousReleaseVersion() {
         return previousReleaseVersion;

--- a/src/main/groovy/org/shipkit/gradle/ReleaseConfiguration.java
+++ b/src/main/groovy/org/shipkit/gradle/ReleaseConfiguration.java
@@ -64,7 +64,6 @@ public class ReleaseConfiguration {
     //TODO currently it's not clear when to use class fields and when to use the 'configuration' map
     //Let's make it clear in the docs
     private boolean dryRun;
-    private boolean publishAllJavaSubprojects = true;
 
     /**
      * See {@link #isDryRun()}
@@ -80,21 +79,6 @@ public class ReleaseConfiguration {
      */
     public boolean isDryRun() {
         return dryRun;
-    }
-
-    /**
-     * See {@link #isPublishAllJavaSubprojects()}}
-     */
-    public void setPublishAllJavaSubprojects(boolean publishAllJavaSubprojects) {
-        this.publishAllJavaSubprojects = publishAllJavaSubprojects;
-    }
-
-    /**
-     * org.shipkit.java-library plugin will be applied to every java subproject (project that applies Gradle's 'java'
-     * plugin) if this boolean is <code>true</code>.
-     */
-    public boolean isPublishAllJavaSubprojects() {
-        return publishAllJavaSubprojects;
     }
 
     public GitHub getGitHub() {

--- a/src/main/groovy/org/shipkit/internal/gradle/ShipkitJavaPlugin.java
+++ b/src/main/groovy/org/shipkit/internal/gradle/ShipkitJavaPlugin.java
@@ -1,5 +1,6 @@
 package org.shipkit.internal.gradle;
 
+import org.gradle.api.Action;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.shipkit.internal.gradle.release.CiReleasePlugin;
@@ -7,12 +8,18 @@ import org.shipkit.internal.gradle.release.JavaReleasePlugin;
 
 /**
  * Adds plugins and tasks to setup automated releasing for a typical Java project.
+ * Will apply some configuration and plugins to all Java subprojects in a multi-project Gradle build.
  * Applies following plugins:
  *
  * <ul>
  *     <li>{@link JavaReleasePlugin}</li>
  *     <li>{@link TravisPlugin}</li>
  *     <li>{@link CiReleasePlugin}</li>
+ * </ul>
+ *
+ * Applies following plugins to all subprojects that apply Gradle's "java" plugin:
+ * <ul>
+ *     <li>{@link JavaLibraryPlugin}</li>
  * </ul>
  */
 public class ShipkitJavaPlugin implements Plugin<Project> {
@@ -21,5 +28,16 @@ public class ShipkitJavaPlugin implements Plugin<Project> {
         project.getPlugins().apply(JavaReleasePlugin.class);
         project.getPlugins().apply(TravisPlugin.class);
         project.getPlugins().apply(CiReleasePlugin.class);
+
+        project.allprojects(new Action<Project>() {
+            public void execute(final Project subproject) {
+                subproject.getPlugins().withId("java", new Action<Plugin>() {
+                    @Override
+                    public void execute(Plugin plugin) {
+                        subproject.getPlugins().apply(JavaLibraryPlugin.class);
+                    }
+                });
+            }
+        });
     }
 }

--- a/src/main/groovy/org/shipkit/internal/gradle/release/JavaReleasePlugin.java
+++ b/src/main/groovy/org/shipkit/internal/gradle/release/JavaReleasePlugin.java
@@ -5,7 +5,6 @@ import org.gradle.api.Action;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.Task;
-import org.shipkit.gradle.ReleaseConfiguration;
 import org.shipkit.gradle.UpdateReleaseNotesTask;
 import org.shipkit.internal.gradle.*;
 import org.shipkit.internal.gradle.util.BintrayUtil;
@@ -16,16 +15,6 @@ import static org.shipkit.internal.gradle.configuration.DeferredConfiguration.de
 /**
  * Configures Java project for automated releases.
  * Applies some configuration to subprojects, too.
- *
- * <p>
- *
- * Applies following plugins to all Java submodules, and preconfigures tasks provided by those plugins:
- *
- * <ul>
- *     <li>{@link JavaLibraryPlugin}</li>
- * </ul>
- *
- * <p>
  *
  * Applies following plugins:
  *
@@ -38,8 +27,6 @@ import static org.shipkit.internal.gradle.configuration.DeferredConfiguration.de
 public class JavaReleasePlugin implements Plugin<Project> {
 
     public void apply(final Project project) {
-        final ReleaseConfiguration conf = project.getPlugins().apply(ReleaseConfigurationPlugin.class).getConfiguration();
-
         project.getPlugins().apply(GitPlugin.class);
         project.getPlugins().apply(PomContributorsPlugin.class);
         project.getPlugins().apply(ReleasePlugin.class);
@@ -47,15 +34,6 @@ public class JavaReleasePlugin implements Plugin<Project> {
         project.allprojects(new Action<Project>() {
             @Override
             public void execute(final Project subproject) {
-                if (conf.isPublishAllJavaSubprojects()) {
-                    subproject.getPlugins().withId("java", new Action<Plugin>() {
-                        @Override
-                        public void execute(Plugin plugin) {
-                            subproject.getPlugins().apply(JavaLibraryPlugin.class);
-                        }
-                    });
-                }
-
                 subproject.getPlugins().withType(JavaLibraryPlugin.class, new Action<JavaLibraryPlugin>() {
                     public void execute(JavaLibraryPlugin plugin) {
                         Task bintrayUpload = subproject.getTasks().getByName(BintrayPlugin.BINTRAY_UPLOAD_TASK);


### PR DESCRIPTION
- I'm trying to simplify the public API as much as possible before 1.0.
- I don't think we really need the configuration option for publishing all java subprojects. I suspect that we can have simpler implementation and still be able to satisfy the use case.
- If someone does not want to publish all java subprojects, he can apply a different set of plugins, instead of applying opinionated "org.shipkit.java". He can also disable bintray upload task to avoid publications. E.g. instead of us providing configuration option, we can relay on standard Gradle techniques to avoid publishing of some modules.