### PR TITLE
Force release again

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
     dependencies {
         classpath "com.gradle.publish:plugin-publish-plugin:0.9.6"
-        classpath "org.shipkit:shipkit:0.8.109"
+        classpath "org.shipkit:shipkit:0.8.111"
         classpath 'ru.vyarus:gradle-animalsniffer-plugin:1.3.0'
     }
 }
@@ -67,7 +67,6 @@ task travisRelease {
         logger.lifecycle("{} - Publishing to Gradle Plugin Portal...", path)
         exec {
             commandLine "./gradlew", "publishPlugins", "performVersionBump",
-                    "-Pshipkit.dryRun=false", //TODO remove when #236 is fixed
                     "-Pgradle.publish.key=${System.getenv('GRADLE_PUBLISH_KEY')}",
                     "-Pgradle.publish.secret=${System.getenv('GRADLE_PUBLISH_SECRET')}"
         }

--- a/version.properties
+++ b/version.properties
@@ -1,6 +1,6 @@
 #Version of the produced binaries. This file is intended to be checked-in.
 #It will be automatically bumped by release automation.
-version=0.8.111
+version=0.8.112
 
 #Last previous release version
-previousVersion=0.8.110
+previousVersion=0.8.111


### PR DESCRIPTION
- Fixing the problem with automated releases of shipkit. We had an issue with dryRun during travis releases.
- Bumped latest version of shipkit

Tested by running gitPush task locally. On CI machine, the task [was executed in dryRun](https://travis-ci.org/mockito/shipkit/builds/250060400#L1789). With this PR, I can see this on my local (no dry run):

```
  Executing:
    git push https://github.com/mockito/shipkit.git v0.8.112 sf3
```

This should fix automated releases of Shipkit.