### PR TITLE
Release needed task - made comparing publications safe

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -83,4 +83,5 @@ task fastInstall { Task t ->
             tasks.groovydoc.enabled = false
         }
     }
+    t.doLast { println "  Shipkit $version installed to local maven repo" }
 }

--- a/src/main/groovy/org/shipkit/gradle/java/ComparePublicationsTask.java
+++ b/src/main/groovy/org/shipkit/gradle/java/ComparePublicationsTask.java
@@ -24,16 +24,20 @@ import java.io.File;
  */
 public class ComparePublicationsTask extends DefaultTask {
 
+    @OutputFile private File comparisonResult;
+
     @Input private String projectGroup;
     @Input private String currentVersion;
     @Input @Optional private String previousVersion;
     @InputFiles private Jar sourcesJar;
+
     @Input private String pomTaskName;
 
-    @InputFile private File previousPom;
-    @InputFile private File previousSourcesJar;
-
-    @OutputFile private File comparisonResult;
+    //Not using @InputFile annotation on purpose below. @InputFile makes Gradle fail early
+    // when the file path specified but file does not exist (@Optional does not help).
+    // Using @Input is enough for this use case
+    @Input @Optional private File previousPom;
+    @Input @Optional private File previousSourcesJar;
 
     /**
      * File that stores text result of the comparison.

--- a/src/main/groovy/org/shipkit/internal/gradle/java/tasks/ComparePublications.java
+++ b/src/main/groovy/org/shipkit/internal/gradle/java/tasks/ComparePublications.java
@@ -17,10 +17,14 @@ public class ComparePublications {
 
     private final static Logger LOG = Logging.getLogger(ComparePublications.class);
 
-    public Boolean comparePublications(ComparePublicationsTask task) {
+    public void comparePublications(ComparePublicationsTask task) {
         if (task.getPreviousVersion() == null) {
-            LOG.lifecycle("{} - previousVersion is not set, nothing to compare", task.getPath());
-            return false;
+            LOG.lifecycle("{} - previousVersion is not set, nothing to compare, skipping", task.getPath());
+            return;
+        }
+        if (!task.getPreviousPom().exists() || !task.getPreviousSourcesJar().exists()) {
+            LOG.lifecycle("{} - previous publications not found, nothing to compare, skipping", task.getPath());
+            return;
         }
 
         GenerateMavenPom pomTask = (GenerateMavenPom) task.getProject().getTasks().getByName(task.getPomTaskName());
@@ -58,7 +62,5 @@ public class ComparePublications {
         }
 
         IOUtil.writeFile(task.getComparisonResult(), comparisonResult.toString());
-
-        return jarsDiff.areFilesEqual() && pomsDiff.areFilesEqual();
     }
 }

--- a/src/main/groovy/org/shipkit/internal/gradle/java/tasks/DownloadPreviousPublications.java
+++ b/src/main/groovy/org/shipkit/internal/gradle/java/tasks/DownloadPreviousPublications.java
@@ -21,6 +21,11 @@ public class DownloadPreviousPublications {
                 "  - from {}\n" +
                 "  - and saving it to {}", remoteUrl, localFile);
 
-        IOUtil.downloadToFile(remoteUrl, localFile);
+        try {
+            IOUtil.downloadToFile(remoteUrl, localFile);
+        } catch (Exception e) {
+            LOG.lifecycle("Unable to download {}. Ignoring and moving on. Run with '-d' to see stack trace.", remoteUrl);
+            LOG.debug("Unable to download", e);
+        }
     }
 }

--- a/src/main/groovy/org/shipkit/internal/gradle/java/tasks/DownloadPreviousPublications.java
+++ b/src/main/groovy/org/shipkit/internal/gradle/java/tasks/DownloadPreviousPublications.java
@@ -17,15 +17,15 @@ public class DownloadPreviousPublications {
     }
 
     private void downloadRemoteFile(String remoteUrl, File localFile) {
-        LOG.lifecycle("Downloading remote artifact\n" +
+        LOG.lifecycle("  Downloading remote artifact\n" +
                 "  - from {}\n" +
                 "  - and saving it to {}", remoteUrl, localFile);
 
         try {
             IOUtil.downloadToFile(remoteUrl, localFile);
         } catch (Exception e) {
-            LOG.lifecycle("Unable to download {}. Ignoring and moving on. Run with '-d' to see stack trace.", remoteUrl);
-            LOG.debug("Unable to download", e);
+            LOG.lifecycle("  Unable to download, ignoring. Run with '-d' for stack trace. Url: {}", remoteUrl);
+            LOG.debug("Unable to download, ignoring", e);
         }
     }
 }

--- a/src/test/groovy/org/shipkit/internal/gradle/VersioningPluginTest.groovy
+++ b/src/test/groovy/org/shipkit/internal/gradle/VersioningPluginTest.groovy
@@ -71,7 +71,7 @@ class VersioningPluginTest extends PluginSpecification {
     }
 
     @Override
-    void configureReleaseConfigurationDefaults(){
+    void createReleaseConfiguration(){
         // ReleaseConfiguration is not needed in this test
     }
 }

--- a/src/test/groovy/org/shipkit/internal/gradle/configuration/ReleaseConfigurationPluginTest.groovy
+++ b/src/test/groovy/org/shipkit/internal/gradle/configuration/ReleaseConfigurationPluginTest.groovy
@@ -62,7 +62,7 @@ class ReleaseConfigurationPluginTest extends PluginSpecification {
     }
 
     @Override
-    void configureReleaseConfigurationDefaults(){
+    void createReleaseConfiguration(){
         // default are not needed in this test
     }
 

--- a/src/test/groovy/org/shipkit/internal/gradle/java/ComparePublicationsPluginTest.groovy
+++ b/src/test/groovy/org/shipkit/internal/gradle/java/ComparePublicationsPluginTest.groovy
@@ -2,8 +2,8 @@ package org.shipkit.internal.gradle.java
 
 import com.jfrog.bintray.gradle.BintrayExtension
 import org.gradle.testfixtures.ProjectBuilder
-import org.shipkit.gradle.java.ComparePublicationsTask
 import org.shipkit.gradle.ReleaseConfiguration
+import org.shipkit.gradle.java.ComparePublicationsTask
 import org.shipkit.gradle.java.DownloadPreviousPublicationsTask
 import org.shipkit.internal.gradle.ShipkitBintrayPlugin
 import org.shipkit.internal.gradle.VersioningPlugin
@@ -127,5 +127,32 @@ class ComparePublicationsPluginTest extends PluginSpecification {
 
         comparisonTask.previousPom == expectedPom
         comparisonTask.previousSourcesJar == expectedSourcesJar
+    }
+
+    def "failures to download artifact are ignored"() {
+        given:
+        project.plugins.apply(ComparePublicationsPlugin)
+        project.plugins.apply(ShipkitBintrayPlugin)
+        project.evaluate()
+
+        when:
+        project.tasks[ComparePublicationsPlugin.DOWNLOAD_PUBLICATIONS_TASK].execute()
+
+        then:
+        noExceptionThrown()
+    }
+
+    def "when no previous artifacts are supplied comparison is skipped"() {
+        given:
+        conf.previousReleaseVersion = "0.0.1"
+        project.plugins.apply(ComparePublicationsPlugin)
+        project.plugins.apply(ShipkitBintrayPlugin)
+        project.evaluate()
+
+        when:
+        project.tasks[ComparePublicationsPlugin.COMPARE_PUBLICATIONS_TASK].execute()
+
+        then:
+        noExceptionThrown()
     }
 }

--- a/src/test/groovy/org/shipkit/internal/gradle/java/ComparePublicationsPluginTest.groovy
+++ b/src/test/groovy/org/shipkit/internal/gradle/java/ComparePublicationsPluginTest.groovy
@@ -76,7 +76,7 @@ class ComparePublicationsPluginTest extends PluginSpecification {
 
         then:
         DownloadPreviousPublicationsTask task = child.getTasks()
-                .getByName(ComparePublicationsPlugin.DOWNLOAD_PREVIOUS_RELEASE_ARTIFACTS_TASK);
+                .getByName(ComparePublicationsPlugin.DOWNLOAD_PUBLICATIONS_TASK);
 
         task.previousPomUrl.contains("bintray.com")
         task.previousSourcesJarUrl.contains("bintray.com")
@@ -93,7 +93,7 @@ class ComparePublicationsPluginTest extends PluginSpecification {
 
         then:
         DownloadPreviousPublicationsTask task = child.getTasks()
-                .getByName(ComparePublicationsPlugin.DOWNLOAD_PREVIOUS_RELEASE_ARTIFACTS_TASK);
+                .getByName(ComparePublicationsPlugin.DOWNLOAD_PUBLICATIONS_TASK);
 
         task.previousPomUrl == null
         task.previousSourcesJarUrl == null
@@ -114,7 +114,7 @@ class ComparePublicationsPluginTest extends PluginSpecification {
 
         then:
         DownloadPreviousPublicationsTask downloadTask = child.getTasks()
-                .getByName(ComparePublicationsPlugin.DOWNLOAD_PREVIOUS_RELEASE_ARTIFACTS_TASK)
+                .getByName(ComparePublicationsPlugin.DOWNLOAD_PUBLICATIONS_TASK)
         ComparePublicationsTask comparisonTask = child.getTasks()
                 .getByName(ComparePublicationsPlugin.COMPARE_PUBLICATIONS_TASK)
 

--- a/src/test/groovy/testutil/PluginSpecification.groovy
+++ b/src/test/groovy/testutil/PluginSpecification.groovy
@@ -21,11 +21,12 @@ class PluginSpecification extends Specification{
     TemporaryFolder tmp = new TemporaryFolder()
 
     Project project
+    ReleaseConfiguration conf
 
     void setup(){
         initProject()
         createConfigFile()
-        configureReleaseConfigurationDefaults()
+        createReleaseConfiguration()
     }
 
     void initProject() {
@@ -43,9 +44,9 @@ class PluginSpecification extends Specification{
         return project.plugins.apply(ReleaseConfigurationPlugin).configuration
     }
 
-    void configureReleaseConfigurationDefaults(){
-        def conf = applyReleaseConfiguration()
-        conf.gitHub.readOnlyAuthToken = "token"
-        conf.gitHub.repository = "repo"
+    void createReleaseConfiguration(){
+        conf = applyReleaseConfiguration()
+        this.conf.gitHub.readOnlyAuthToken = "token"
+        this.conf.gitHub.repository = "repo"
     }
 }


### PR DESCRIPTION
Fixes issue #280

- when downloading of previous publications fails we will not stop the build
- there are legit use cases where there are no previous publications - on initial bootstrap of shipkit, when previous release failed for some reason
- added unit tests for new functionality, refactored the code a bit to make testing easier