### PR TITLE
Simplified shipping of shipkit, added release notes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,4 @@ install:
  - true
 
 script:
-  - ./gradlew build -PcheckJava6Compatibility -s -i
-
-after_success:
-  - ./gradlew assertReleaseNeeded && ./gradlew ciReleasePrepare && ./gradlew travisRelease -s
+  - ./gradlew build -PcheckJava6Compatibility -s -i && ./gradlew ciPerformRelease

--- a/build.gradle
+++ b/build.gradle
@@ -5,8 +5,7 @@ buildscript {
         maven { url "https://plugins.gradle.org/m2/" }
     }
     dependencies {
-        classpath "com.gradle.publish:plugin-publish-plugin:0.9.6"
-        classpath "org.shipkit:shipkit:0.8.111"
+        classpath "org.shipkit:shipkit:0.8.118"
         classpath 'ru.vyarus:gradle-animalsniffer-plugin:1.3.0'
     }
 }
@@ -14,14 +13,13 @@ buildscript {
 apply plugin: 'maven'
 apply plugin: 'idea'
 apply plugin: 'groovy'
-apply plugin: 'com.gradle.plugin-publish'
 apply plugin: 'checkstyle'
 apply plugin: 'codenarc'
-apply plugin: 'org.shipkit.gradle-plugin'
-apply plugin: 'org.shipkit.release-needed'
 
 apply from: 'gradle/java6-compatibility.gradle'
 apply from: 'gradle/precommit.gradle'
+
+apply plugin: 'org.shipkit.gradle-plugin'
 
 sourceCompatibility = 1.6
 targetCompatibility = 1.6
@@ -44,6 +42,7 @@ dependencies {
     testCompile("org.spockframework:spock-core:1.1-groovy-2.4") {
         exclude module: "groovy-all"
     }
+
     testCompile "net.bytebuddy:byte-buddy:1.7.1"
     testCompile "org.objenesis:objenesis:2.5"
     testCompile "commons-lang:commons-lang:2.4"
@@ -59,17 +58,6 @@ pluginBundle {
     mavenCoordinates {
         groupId = 'org.shipkit'
         artifactId = 'shipkit'
-    }
-}
-
-task travisRelease {
-    doLast {
-        logger.lifecycle("{} - Publishing to Gradle Plugin Portal...", path)
-        exec {
-            commandLine "./gradlew", "publishPlugins", "performVersionBump",
-                    "-Pgradle.publish.key=${System.getenv('GRADLE_PUBLISH_KEY')}",
-                    "-Pgradle.publish.secret=${System.getenv('GRADLE_PUBLISH_SECRET')}"
-        }
     }
 }
 


### PR DESCRIPTION
Now it uses our spanking new 'org.shipkit.gradle-plugin' plugin. Addresses #255

Tested locally by:

- ```./gradlew releaseNeeded```

```
  Release is needed: false
    - skip by env variable: false
    - skip by commit message: false
    - is pull request build:  false
    - is releasable branch:  false
    - publications changed since previous release:  true

BUILD SUCCESSFUL
```

- ```./gradlew updateReleaseNotes -Ppreview```

```
:updateReleaseNotes
  Building new release notes based on /Users/sfaber/mockito/release/docs/release-notes.md
  Preview of release notes update:
  ----------------
**0.8.119 (2017-07-07)** - [1 commit](https://github.com/mockito/shipkit/compare/v0.8.118...v0.8.119) by [Szczepan Faber](http://github.com/szczepiq) - published to [![Bintray](https://img.shields.io/badge/Bintray-0.8.119-green.svg)](https://plugins.gradle.org/plugin/org.shipkit.java/0.8.119)
 - No pull requests referenced in commit messages.

----------------

BUILD SUCCESSFUL
```

- ```./gradlew testRelease```

```
[./gradlew] Saved working directory and index state WIP on sf: a950e9b Simplified shipping of shipkit
[./gradlew] HEAD is now at a950e9b Simplified shipping of shipkit
[./gradlew] :performGitCommitCleanUp
[./gradlew] 
[./gradlew] BUILD SUCCESSFUL
[./gradlew] 
[./gradlew] Total time: 19.725 secs

BUILD SUCCESSFUL
```

- ```./gradlew ciPerformRelease -m```

```
~/mockito/release$ ./gradlew ciPerformRelease -m
  Building version '0.8.119' (value loaded from 'version.properties' file).
  'git push' does not use GitHub write token because it was not specified.
  Adding 17 discovered Gradle plugins to 'pluginBundle'
:ciPerformRelease SKIPPED

BUILD SUCCESSFUL
```