### PR TITLE
Logging tweaks to improve the clarity of the build log

### DIFF
--- a/src/main/groovy/org/shipkit/internal/gradle/exec/ShipkitExec.java
+++ b/src/main/groovy/org/shipkit/internal/gradle/exec/ShipkitExec.java
@@ -31,7 +31,7 @@ public class ShipkitExec {
                     LOG.lifecycle("  " + execCommand.getDescription() + ":\n    " + StringUtil.join(execCommand.getCommandLine(), " "));
                 }
             });
-            LOG.lifecycle("  External process [{}] completed.", execCommand.getLoggingPrefix());
+            LOG.lifecycle("  External process {} completed.", execCommand.getLoggingPrefix().trim());
             execCommand.getResultAction().execute(result);
         }
     }

--- a/src/main/groovy/org/shipkit/internal/gradle/exec/ShipkitExec.java
+++ b/src/main/groovy/org/shipkit/internal/gradle/exec/ShipkitExec.java
@@ -31,6 +31,7 @@ public class ShipkitExec {
                     LOG.lifecycle("  " + execCommand.getDescription() + ":\n    " + StringUtil.join(execCommand.getCommandLine(), " "));
                 }
             });
+            LOG.lifecycle("  External process [{}] completed.", execCommand.getLoggingPrefix());
             execCommand.getResultAction().execute(result);
         }
     }

--- a/src/main/groovy/org/shipkit/internal/gradle/release/CiReleasePlugin.java
+++ b/src/main/groovy/org/shipkit/internal/gradle/release/CiReleasePlugin.java
@@ -3,6 +3,7 @@ package org.shipkit.internal.gradle.release;
 import org.gradle.api.Action;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
+import org.gradle.api.Task;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
 import org.gradle.api.tasks.StopExecutionException;
@@ -58,6 +59,13 @@ public class CiReleasePlugin implements Plugin<Project> {
                         "Preparing working copy for the release", asList("./gradlew", GitSetupPlugin.CI_RELEASE_PREPARE_TASK)));
                 task.getExecCommands().add(execCommand(
                         "Performing the release", asList("./gradlew", ReleasePlugin.PERFORM_RELEASE_TASK)));
+
+                task.doLast(new Action<Task>() {
+                    @Override
+                    public void execute(Task t) {
+                        LOG.lifecycle("  New version was shipped! Thank you for using Shipkit!");
+                    }
+                });
             }
         });
     }

--- a/src/main/groovy/org/shipkit/internal/gradle/release/CiReleasePlugin.java
+++ b/src/main/groovy/org/shipkit/internal/gradle/release/CiReleasePlugin.java
@@ -35,7 +35,7 @@ public class CiReleasePlugin implements Plugin<Project> {
     private final static Logger LOG = Logging.getLogger(CiReleasePlugin.class);
 
     @Override
-    public void apply(Project project) {
+    public void apply(final Project project) {
         project.getPlugins().apply(ReleasePlugin.class);
         project.getPlugins().apply(GitSetupPlugin.class);
 
@@ -60,7 +60,7 @@ public class CiReleasePlugin implements Plugin<Project> {
                 task.getExecCommands().add(execCommand(
                         "Performing the release", asList("./gradlew", ReleasePlugin.PERFORM_RELEASE_TASK)));
 
-                TaskSuccessfulMessage.logOnSuccess(task, "  New version was shipped! Thank you for using Shipkit!");
+                TaskSuccessfulMessage.logOnSuccess(task, "  Release " + project.getVersion() + " was shipped! Thank you for using Shipkit!");
             }
         });
     }

--- a/src/main/groovy/org/shipkit/internal/gradle/release/CiReleasePlugin.java
+++ b/src/main/groovy/org/shipkit/internal/gradle/release/CiReleasePlugin.java
@@ -3,7 +3,6 @@ package org.shipkit.internal.gradle.release;
 import org.gradle.api.Action;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
-import org.gradle.api.Task;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
 import org.gradle.api.tasks.StopExecutionException;
@@ -11,6 +10,7 @@ import org.gradle.process.ExecResult;
 import org.shipkit.gradle.exec.ShipkitExecTask;
 import org.shipkit.internal.gradle.git.GitSetupPlugin;
 import org.shipkit.internal.gradle.util.TaskMaker;
+import org.shipkit.internal.gradle.util.TaskSuccessfulMessage;
 
 import static java.util.Arrays.asList;
 import static org.shipkit.internal.gradle.exec.ExecCommandFactory.execCommand;
@@ -60,12 +60,7 @@ public class CiReleasePlugin implements Plugin<Project> {
                 task.getExecCommands().add(execCommand(
                         "Performing the release", asList("./gradlew", ReleasePlugin.PERFORM_RELEASE_TASK)));
 
-                task.doLast(new Action<Task>() {
-                    @Override
-                    public void execute(Task t) {
-                        LOG.lifecycle("  New version was shipped! Thank you for using Shipkit!");
-                    }
-                });
+                TaskSuccessfulMessage.logOnSuccess(task, "  New version was shipped! Thank you for using Shipkit!");
             }
         });
     }

--- a/src/main/groovy/org/shipkit/internal/gradle/release/ReleasePlugin.java
+++ b/src/main/groovy/org/shipkit/internal/gradle/release/ReleasePlugin.java
@@ -11,6 +11,7 @@ import org.shipkit.internal.gradle.ReleaseNotesPlugin;
 import org.shipkit.internal.gradle.VersioningPlugin;
 import org.shipkit.internal.gradle.git.GitPlugin;
 import org.shipkit.internal.gradle.util.TaskMaker;
+import org.shipkit.internal.gradle.util.TaskSuccessfulMessage;
 
 import static java.util.Arrays.asList;
 import static org.shipkit.internal.gradle.ReleaseNotesPlugin.UPDATE_NOTES_TASK;
@@ -66,12 +67,7 @@ public class ReleasePlugin implements Plugin<Project> {
                 //releaseNeeded is used here only to execute the code paths in the release needed task (extra testing)
                 t.getExecCommands().add(execCommand("Performing relase in dry run, with cleanup"
                         , asList("./gradlew", RELEASE_NEEDED, PERFORM_RELEASE_TASK, RELEASE_CLEAN_UP_TASK, "-PdryRun")));
-                t.doLast(new Action<Task>() {
-                    @Override
-                    public void execute(Task task) {
-                        LOG.lifecycle("  The release test was successful. Ship it!");
-                    }
-                });
+                TaskSuccessfulMessage.logOnSuccess(t, "  The release test was successful. Ship it!");
             }
         });
 

--- a/src/main/groovy/org/shipkit/internal/gradle/release/tasks/ComparisonResults.java
+++ b/src/main/groovy/org/shipkit/internal/gradle/release/tasks/ComparisonResults.java
@@ -32,10 +32,10 @@ class ComparisonResults {
             description = "\n  Compared " + comparisons + " publication(s). Changes since previous release:\n" + sb;
             resultsIdentical = false;
         } else if (comparisons > 0) {
-            description = "\n  Compared " + comparisons + " publication(s). No changes since previous release!";
+            description = "\n  Compared " + comparisons + " publication(s). No changes since previous release!\n";
             resultsIdentical = true;
         } else {
-            description = "\n  Publication comparison was skipped (no comparison result files found).";
+            description = "\n  Publication comparison was skipped (no comparison result files found).\n";
             resultsIdentical = false;
         }
     }

--- a/src/main/groovy/org/shipkit/internal/gradle/release/tasks/ComparisonResults.java
+++ b/src/main/groovy/org/shipkit/internal/gradle/release/tasks/ComparisonResults.java
@@ -1,0 +1,50 @@
+package org.shipkit.internal.gradle.release.tasks;
+
+import org.gradle.api.logging.Logger;
+import org.gradle.api.logging.Logging;
+import org.shipkit.internal.notes.util.IOUtil;
+
+import java.io.File;
+import java.util.List;
+
+class ComparisonResults {
+
+    private final static Logger LOG = Logging.getLogger(ComparisonResults.class);
+
+    private final String description;
+    private final boolean resultsIdentical;
+
+    ComparisonResults(List<File> comparisonResults) {
+        int comparisons = 0;
+        StringBuilder sb = new StringBuilder();
+        for (File result : comparisonResults) {
+            if (result.isFile()) {
+                comparisons++;
+                LOG.info("Looking for diffs in publication comparison result file: " + result);
+                if (result.length() > 0) {
+                    //file contains differences
+                    sb.append(IOUtil.readFully(result));
+                }
+            }
+        }
+
+        if (sb.length() > 0) {
+            description = "\n  Compared " + comparisons + " publication(s). Changes since previous release:\n" + sb;
+            resultsIdentical = false;
+        } else if (comparisons > 0) {
+            description = "\n  Compared " + comparisons + " publication(s). No changes since previous release!";
+            resultsIdentical = true;
+        } else {
+            description = "\n  Publication comparison was skipped (no comparison result files found).";
+            resultsIdentical = false;
+        }
+    }
+
+    boolean areResultsIdentical() {
+        return resultsIdentical;
+    }
+
+    String getDescription() {
+        return description;
+    }
+}

--- a/src/main/groovy/org/shipkit/internal/gradle/util/TaskSuccessfulMessage.java
+++ b/src/main/groovy/org/shipkit/internal/gradle/util/TaskSuccessfulMessage.java
@@ -1,0 +1,24 @@
+package org.shipkit.internal.gradle.util;
+
+import org.gradle.api.Action;
+import org.gradle.api.Task;
+import org.gradle.api.logging.Logger;
+import org.gradle.api.logging.Logging;
+
+public class TaskSuccessfulMessage {
+
+    private final static Logger LOG = Logging.getLogger(TaskSuccessfulMessage.class);
+
+    /**
+     * Writes message to the console when task completes successfully.
+     * Basically adds 'doLast' action with log message.
+     */
+    public static void logOnSuccess(Task task, final String message) {
+        task.doLast(new Action<Task>() {
+            @Override
+            public void execute(Task task) {
+                LOG.lifecycle(message);
+            }
+        });
+    }
+}

--- a/src/test/groovy/org/shipkit/internal/gradle/release/tasks/ComparisonResultsTest.groovy
+++ b/src/test/groovy/org/shipkit/internal/gradle/release/tasks/ComparisonResultsTest.groovy
@@ -1,0 +1,37 @@
+package org.shipkit.internal.gradle.release.tasks
+
+import org.junit.Rule
+import org.junit.rules.TemporaryFolder
+import spock.lang.Specification
+
+class ComparisonResultsTest extends Specification {
+
+    @Rule TemporaryFolder tmp = new TemporaryFolder()
+    File diff
+    File empty
+
+    def setup() {
+        diff = tmp.newFile(); diff << "diff"
+        empty = tmp.newFile()
+    }
+
+    def "describes results"() {
+        expect:
+        new ComparisonResults([]).description ==
+            "\n  Publication comparison was skipped (no comparison result files found)."
+        new ComparisonResults([diff, empty]).description ==
+            "\n  Compared 2 publication(s). Changes since previous release:\ndiff"
+        new ComparisonResults([empty]).description ==
+            "\n  Compared 1 publication(s). No changes since previous release!"
+        new ComparisonResults([new File("does not exist")]).description ==
+            "\n  Publication comparison was skipped (no comparison result files found)."
+    }
+
+    def "knows if results are identical"() {
+        expect:
+        !new ComparisonResults([]).areResultsIdentical()
+        !new ComparisonResults([diff, empty]).areResultsIdentical()
+        new ComparisonResults([empty]).areResultsIdentical()
+        !new ComparisonResults([new File("does not exist")]).areResultsIdentical()
+    }
+}

--- a/src/test/groovy/org/shipkit/internal/gradle/release/tasks/ComparisonResultsTest.groovy
+++ b/src/test/groovy/org/shipkit/internal/gradle/release/tasks/ComparisonResultsTest.groovy
@@ -18,13 +18,13 @@ class ComparisonResultsTest extends Specification {
     def "describes results"() {
         expect:
         new ComparisonResults([]).description ==
-            "\n  Publication comparison was skipped (no comparison result files found)."
+            "\n  Publication comparison was skipped (no comparison result files found).\n"
         new ComparisonResults([diff, empty]).description ==
             "\n  Compared 2 publication(s). Changes since previous release:\ndiff"
         new ComparisonResults([empty]).description ==
-            "\n  Compared 1 publication(s). No changes since previous release!"
+            "\n  Compared 1 publication(s). No changes since previous release!\n"
         new ComparisonResults([new File("does not exist")]).description ==
-            "\n  Publication comparison was skipped (no comparison result files found)."
+            "\n  Publication comparison was skipped (no comparison result files found).\n"
     }
 
     def "knows if results are identical"() {


### PR DESCRIPTION
Tested by doing ```./gradlew testRelease``` and inspecting the build log:

```
[./gradlew] :gitStash
[./gradlew]   Running:
[./gradlew]     git stash
[./gradlew] Saved working directory and index state WIP on sf: 400b90d Bumped Shipkit
[./gradlew] HEAD is now at 400b90d Bumped Shipkit
[./gradlew] :performGitCommitCleanUp
[./gradlew] 
[./gradlew] BUILD SUCCESSFUL
[./gradlew] 
[./gradlew] Total time: 28.313 secs
  External process [[./gradlew] ] completed.
  The release test was successful. Ship it!

BUILD SUCCESSFUL
```