### PR TITLE
Test improvement - reflection rather than implement individual unit test for each property

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .gradle
 build/
 classes/
+out/
 
 # Ignore Gradle GUI config
 gradle-app.setting

--- a/src/test/groovy/org/shipkit/internal/gradle/ReleaseConfigurationGettersAndSettersTest.groovy
+++ b/src/test/groovy/org/shipkit/internal/gradle/ReleaseConfigurationGettersAndSettersTest.groovy
@@ -1,0 +1,62 @@
+package org.shipkit.internal.gradle
+
+import org.shipkit.gradle.ReleaseConfiguration
+import spock.lang.Shared
+import spock.lang.Specification
+import spock.lang.Unroll
+import testutil.ReflectionUtil
+
+import java.lang.reflect.Method
+
+class ReleaseConfigurationGettersAndSettersTest extends Specification {
+
+    @Shared
+    def conf = new ReleaseConfiguration()
+
+    def "default values"() {
+        conf.team.developers.empty
+        conf.team.contributors.empty
+        conf.git.commitMessagePostfix == "[ci skip]"
+        conf.releaseNotes.ignoreCommitsContaining == ["[ci skip]"]
+    }
+
+    @Unroll
+    def "setter #setter.name value should be the same like #getter.name"(row, Method setter, Method getter, Object obj) {
+        def valueForSetter = getValueForSetter(setter)
+        setter.invoke(obj, valueForSetter)
+
+        expect:
+        getter.invoke(obj) == valueForSetter
+
+        where:
+        row << ReflectionUtil.findGettersAndSetters(conf)
+        setter = row.setter
+        getter = row.getter
+        obj = row.object
+
+    }
+
+    def getValueForSetter(Method setter) {
+        if (setter.parameters[0].type == String.class) {
+            return "some string"
+        }
+
+        if (setter.parameters[0].type.name == "boolean") {
+            return true;
+        }
+
+        if (setter.parameters[0].type == Map.class) {
+            def emptyMap = [:]
+            emptyMap.put("key", "value")
+            return emptyMap
+        }
+
+        if (setter.parameters[0].type == Collection.class) {
+            def collection = []
+            collection << "anicos:Adrian Nicos"
+            return collection
+        }
+
+        throw new RuntimeException("Not supported field")
+    }
+}

--- a/src/test/groovy/org/shipkit/internal/gradle/ReleaseConfigurationGettersAndSettersTest.groovy
+++ b/src/test/groovy/org/shipkit/internal/gradle/ReleaseConfigurationGettersAndSettersTest.groovy
@@ -33,7 +33,6 @@ class ReleaseConfigurationGettersAndSettersTest extends Specification {
         setter = row.setter
         getter = row.getter
         obj = row.object
-
     }
 
     def getValueForSetter(Method setter) {

--- a/src/test/groovy/org/shipkit/internal/gradle/ReleaseConfigurationGettersAndSettersTest.groovy
+++ b/src/test/groovy/org/shipkit/internal/gradle/ReleaseConfigurationGettersAndSettersTest.groovy
@@ -23,7 +23,7 @@ class ReleaseConfigurationGettersAndSettersTest extends Specification {
     }
 
     @Unroll
-    def "setter #setter.name value should be the same like #getter.name"(row, Method setter, Method getter, Object obj) {
+    def "value assigned to #setter.name should be returned by #getter.name"(row, Method setter, Method getter, Object obj) {
         def valueForSetter = getValueForSetter(setter)
         setter.invoke(obj, valueForSetter)
 

--- a/src/test/groovy/org/shipkit/internal/gradle/ReleaseConfigurationGettersAndSettersTest.groovy
+++ b/src/test/groovy/org/shipkit/internal/gradle/ReleaseConfigurationGettersAndSettersTest.groovy
@@ -12,6 +12,8 @@ class ReleaseConfigurationGettersAndSettersTest extends Specification {
 
     @Shared
     def conf = new ReleaseConfiguration()
+    @Shared
+    int counter = 0
 
     def "default values"() {
         conf.team.developers.empty
@@ -36,23 +38,24 @@ class ReleaseConfigurationGettersAndSettersTest extends Specification {
     }
 
     def getValueForSetter(Method setter) {
+        counter++;
         if (setter.parameters[0].type == String.class) {
-            return "some string"
+            return 'some string' + counter
         }
 
         if (setter.parameters[0].type.name == "boolean") {
-            return true;
+            return (counter % 2 == 0);
         }
 
         if (setter.parameters[0].type == Map.class) {
             def emptyMap = [:]
-            emptyMap.put("key", "value")
+            emptyMap.put('key' + counter, 'value' + +counter)
             return emptyMap
         }
 
         if (setter.parameters[0].type == Collection.class) {
             def collection = []
-            collection << "anicos:Adrian Nicos"
+            collection << 'anicos:Adrian Nicos' + counter
             return collection
         }
 

--- a/src/test/groovy/org/shipkit/internal/gradle/ReleaseConfigurationTest.groovy
+++ b/src/test/groovy/org/shipkit/internal/gradle/ReleaseConfigurationTest.groovy
@@ -17,15 +17,6 @@ class ReleaseConfigurationTest extends Specification {
         conf.releaseNotes.ignoreCommitsContaining == ["[ci skip]"]
     }
 
-    def "custom commitMessagePostfix"() {
-        //TODO figure out a test that would validate all properties with reflection
-        //rather than implement individual unit test for each property (getter and setter)
-        conf.git.commitMessagePostfix = " by CI build 1234 [ci skip-release]"
-
-        expect:
-        conf.git.commitMessagePostfix ==  " by CI build 1234 [ci skip-release]"
-    }
-
     def "validates team members"() {
         when:
         conf.team.developers = []

--- a/src/test/groovy/testutil/ReflectionUtil.groovy
+++ b/src/test/groovy/testutil/ReflectionUtil.groovy
@@ -1,0 +1,107 @@
+package testutil
+
+import java.lang.reflect.Method
+
+class ReflectionUtil {
+
+    static List<ObjectWithProperties> findGettersAndSetters(obj) {
+        def gettersAndSettersList = []
+        def parentList = []
+        parentList << obj.class
+        doReflectionRec(obj, gettersAndSettersList, parentList)
+        return gettersAndSettersList;
+    }
+
+    static def doReflectionRec(obj, myList, parents) {
+        def methods = obj.class.declaredMethods
+
+        for (method in methods) {
+            if (isGetter(method)) {
+                def setter = findSetterForGetter(obj, method)
+                if (setter != null) {
+                    myList << new ObjectWithProperties(method, setter, obj)
+                } else {
+                    def getterResult = method.invoke(obj)
+                    //Protection against cyclic dependencies
+                    if (getterResult != null && !parents.contains(getterResult.class)) {
+                        parents << getterResult.class
+                        doReflectionRec(getterResult, myList, parents)
+                    }
+                }
+            }
+        }
+    }
+
+    static Method findSetterForGetter(Object object, Method getter) {
+        def methods = object.class.declaredMethods
+        for (it in methods) {
+            def fieldName = it.name.substring(3)
+            if (isSetter(it) && getter.name.endsWith(fieldName) && getter.name.length() <= it.name.length()) {
+                return it;
+            }
+        }
+        return null;
+    }
+
+    static boolean isSetter(Method method) {
+        if (method.name.startsWith("set") && method.parameterCount == 1) {
+            return true;
+        }
+        return false;
+    }
+
+    static boolean isGetter(Method method) {
+        if (!(method.name.startsWith("is") || method.name.startsWith("get"))) {
+            return false;
+        }
+        if (method.parameterCount != 0) {
+            return false;
+        }
+        return true;
+    }
+
+    static class ObjectWithProperties {
+        Method getter;
+        Method setter;
+        Object object;
+
+        ObjectWithProperties(Method getter, Method setter, Object object) {
+            this.getter = getter
+            this.setter = setter
+            this.object = object
+        }
+
+        Object getObject() {
+            return object
+        }
+
+        Method getGetter() {
+            return getter
+        }
+
+        Method getSetter() {
+            return setter
+        }
+
+        boolean equals(o) {
+            if (this.is(o)) return true
+            if (getClass() != o.class) return false
+
+            ObjectWithProperties value = (ObjectWithProperties) o
+
+            if (getter != value.getter) return false
+            if (object != value.object) return false
+            if (setter != value.setter) return false
+
+            return true
+        }
+
+        int hashCode() {
+            int result
+            result = (getter != null ? getter.hashCode() : 0)
+            result = 31 * result + (setter != null ? setter.hashCode() : 0)
+            result = 31 * result + (object != null ? object.hashCode() : 0)
+            return result
+        }
+    }
+}

--- a/src/test/groovy/testutil/ReflectionUtil.groovy
+++ b/src/test/groovy/testutil/ReflectionUtil.groovy
@@ -4,6 +4,12 @@ import java.lang.reflect.Method
 
 class ReflectionUtil {
 
+
+    public static final int SET_LENGTH = 3
+    public static final String GET = "get"
+    public static final String IS = "is"
+    public static final String SET = "set"
+
     static List<ObjectWithProperties> findGettersAndSetters(obj) {
         def gettersAndSettersList = []
         def parentList = []
@@ -35,8 +41,8 @@ class ReflectionUtil {
     static Method findSetterForGetter(Object object, Method getter) {
         def methods = object.class.declaredMethods
         for (it in methods) {
-            def fieldName = it.name.substring(3)
-            if (isSetter(it) && getter.name.endsWith(fieldName) && getter.name.length() <= it.name.length()) {
+            def fieldName = it.name.substring(SET_LENGTH)
+            if (isSetter(it) && (getter.name.equals(GET + fieldName) || getter.name.equals(IS + fieldName))) {
                 return it;
             }
         }
@@ -44,14 +50,14 @@ class ReflectionUtil {
     }
 
     static boolean isSetter(Method method) {
-        if (method.name.startsWith("set") && method.parameterCount == 1) {
+        if (method.name.startsWith(SET) && method.parameterCount == 1) {
             return true;
         }
         return false;
     }
 
     static boolean isGetter(Method method) {
-        if (!(method.name.startsWith("is") || method.name.startsWith("get"))) {
+        if (!(method.name.startsWith(IS) || method.name.startsWith(GET))) {
             return false;
         }
         if (method.parameterCount != 0) {
@@ -83,25 +89,35 @@ class ReflectionUtil {
             return setter
         }
 
-        boolean equals(o) {
-            if (this.is(o)) return true
-            if (getClass() != o.class) return false
-
-            ObjectWithProperties value = (ObjectWithProperties) o
-
-            if (getter != value.getter) return false
-            if (object != value.object) return false
-            if (setter != value.setter) return false
-
-            return true
-        }
-
         int hashCode() {
             int result
             result = (getter != null ? getter.hashCode() : 0)
             result = 31 * result + (setter != null ? setter.hashCode() : 0)
             result = 31 * result + (object != null ? object.hashCode() : 0)
             return result
+        }
+
+        boolean equals(o) {
+            if (this.is(o)) {
+                return true
+            }
+            if (getClass() != o.class) {
+                return false
+            }
+
+            ObjectWithProperties value = (ObjectWithProperties) o
+
+            if (getter != value.getter) {
+                return false
+            }
+            if (object != value.object) {
+                return false
+            }
+            if (setter != value.setter) {
+                return false
+            }
+
+            return true
         }
     }
 }


### PR DESCRIPTION
Adding a test to class `ReleaseConfiguration`. The test check whether assigning a value to a sitter returns the same value by the getter.
The test fails when key(in map) for setter is different than for getter.
The test works for setters and getters of the `ReleaseConfiguration` object and for objects inside this class such as `Git,` `Team,` etc.

Flow of test:
1. The test using reflection take all getters and setters from `ReleaseConfiguration` object.
2. Then assigning a value to each setter
3. Check if getter has expected value