### PR TITLE
Automatically validate plugin property files

### DIFF
--- a/src/main/groovy/org/shipkit/internal/gradle/java/JavaLibraryPlugin.java
+++ b/src/main/groovy/org/shipkit/internal/gradle/java/JavaLibraryPlugin.java
@@ -5,8 +5,8 @@ import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.Task;
 import org.gradle.api.file.CopySpec;
-import org.gradle.api.plugins.JavaPluginConvention;
 import org.gradle.api.tasks.bundling.Jar;
+import org.shipkit.internal.gradle.util.JavaPluginUtil;
 
 /**
  * Makes a java library that has not only the main jar but also sources and javadoc jars.
@@ -48,11 +48,9 @@ public class JavaLibraryPlugin implements Plugin<Project> {
 
         ((Jar) project.getTasks().getByName("jar")).with(license);
 
-        final JavaPluginConvention java = project.getConvention().getPlugin(JavaPluginConvention.class);
-
         final Jar sourcesJar = project.getTasks().create(SOURCES_JAR_TASK, Jar.class, new Action<Jar>() {
             public void execute(Jar jar) {
-                jar.from(java.getSourceSets().getByName("main").getAllSource());
+                jar.from(JavaPluginUtil.getMainSourceSet(project).getAllSource());
                 jar.setClassifier("sources");
                 jar.with(license);
             }

--- a/src/main/groovy/org/shipkit/internal/gradle/plugin/PluginDiscoveryPlugin.java
+++ b/src/main/groovy/org/shipkit/internal/gradle/plugin/PluginDiscoveryPlugin.java
@@ -15,6 +15,8 @@ import java.io.InputStream;
 import java.util.Properties;
 import java.util.Set;
 
+import static org.shipkit.internal.gradle.plugin.PluginUtil.DOT_PROPERTIES;
+
 /**
  * This plugin discovers gradle plugins and adds them to the {@link PluginBundleExtension}.
  *
@@ -25,7 +27,6 @@ import java.util.Set;
 public class PluginDiscoveryPlugin implements Plugin<Project> {
 
     private static Logger LOG = Logging.getLogger(PluginDiscoveryPlugin.class);
-    static final String DOT_PROPERTIES = ".properties";
 
     @Override
     public void apply(final Project project) {

--- a/src/main/groovy/org/shipkit/internal/gradle/plugin/PluginDiscoveryPlugin.java
+++ b/src/main/groovy/org/shipkit/internal/gradle/plugin/PluginDiscoveryPlugin.java
@@ -5,11 +5,8 @@ import com.gradle.publish.PluginConfig;
 import org.gradle.api.Action;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
-import org.gradle.api.file.FileTree;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
-import org.gradle.api.plugins.JavaPluginConvention;
-import org.gradle.api.tasks.util.PatternSet;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -28,7 +25,7 @@ import java.util.Set;
 public class PluginDiscoveryPlugin implements Plugin<Project> {
 
     private static Logger LOG = Logging.getLogger(PluginDiscoveryPlugin.class);
-    private static final String DOT_PROPERTIES = ".properties";
+    static final String DOT_PROPERTIES = ".properties";
 
     @Override
     public void apply(final Project project) {
@@ -37,7 +34,7 @@ public class PluginDiscoveryPlugin implements Plugin<Project> {
             public void execute(Plugin plugin) {
                 PluginBundleExtension extension = project.getExtensions().findByType(PluginBundleExtension.class);
 
-                Set<File> pluginPropertyFiles = discoverGradlePluginPropertyFiles(project);
+                Set<File> pluginPropertyFiles = PluginUtil.discoverGradlePluginPropertyFiles(project);
                 LOG.lifecycle("  Adding {} discovered Gradle plugins to 'pluginBundle'", pluginPropertyFiles.size());
                 for (File pluginPropertyFile : pluginPropertyFiles) {
                     PluginConfig config = new PluginConfig(generatePluginName(pluginPropertyFile.getName()));
@@ -48,13 +45,6 @@ public class PluginDiscoveryPlugin implements Plugin<Project> {
                 }
             }
         });
-    }
-
-    private Set<File> discoverGradlePluginPropertyFiles(Project project) {
-        final JavaPluginConvention java = project.getConvention().getPlugin(JavaPluginConvention.class);
-        FileTree resources = java.getSourceSets().getByName("main").getResources();
-        FileTree plugins = resources.matching(new PatternSet().include("META-INF/gradle-plugins/*.properties"));
-        return plugins.getFiles();
     }
 
     static String generatePluginName(String fileName) {

--- a/src/main/groovy/org/shipkit/internal/gradle/plugin/PluginUtil.java
+++ b/src/main/groovy/org/shipkit/internal/gradle/plugin/PluginUtil.java
@@ -1,0 +1,25 @@
+package org.shipkit.internal.gradle.plugin;
+
+import org.gradle.api.Project;
+import org.gradle.api.file.FileTree;
+import org.gradle.api.plugins.JavaPluginConvention;
+import org.gradle.api.tasks.util.PatternSet;
+
+import java.io.File;
+import java.util.Set;
+
+public class PluginUtil {
+    static Set<File> discoverGradlePluginPropertyFiles(Project project) {
+        final JavaPluginConvention java = project.getConvention().getPlugin(JavaPluginConvention.class);
+        FileTree resources = java.getSourceSets().getByName("main").getResources();
+        FileTree plugins = resources.matching(new PatternSet().include("META-INF/gradle-plugins/*.properties"));
+        return plugins.getFiles();
+    }
+
+    static Set<File> discoverGradlePlugins(Project project) {
+        final JavaPluginConvention java = project.getConvention().getPlugin(JavaPluginConvention.class);
+        FileTree resources = java.getSourceSets().getByName("main").getAllJava();
+        FileTree plugins = resources.matching(new PatternSet().include("**/*Plugin.java").include("**/*Plugin.groovy"));
+        return plugins.getFiles();
+    }
+}

--- a/src/main/groovy/org/shipkit/internal/gradle/plugin/PluginUtil.java
+++ b/src/main/groovy/org/shipkit/internal/gradle/plugin/PluginUtil.java
@@ -2,6 +2,7 @@ package org.shipkit.internal.gradle.plugin;
 
 import org.gradle.api.Project;
 import org.gradle.api.file.FileTree;
+import org.gradle.api.tasks.SourceSet;
 import org.gradle.api.tasks.util.PatternSet;
 import org.shipkit.internal.gradle.util.JavaPluginUtil;
 
@@ -12,13 +13,19 @@ class PluginUtil {
     static final String DOT_PROPERTIES = ".properties";
 
     static Set<File> discoverGradlePluginPropertyFiles(Project project) {
-        FileTree resources = JavaPluginUtil.getMainSourceSet(project).getResources();
-        return getFilteredFileset(resources, "META-INF/gradle-plugins/*" + DOT_PROPERTIES);
+        return discoverGradlePluginPropertyFiles(JavaPluginUtil.getMainSourceSet(project));
+    }
+
+    static Set<File> discoverGradlePluginPropertyFiles(SourceSet sourceSet) {
+        return getFilteredFileset(sourceSet.getResources(), "META-INF/gradle-plugins/*" + DOT_PROPERTIES);
     }
 
     static Set<File> discoverGradlePlugins(Project project) {
-        FileTree allJava = JavaPluginUtil.getMainSourceSet(project).getAllJava();
-        return getFilteredFileset(allJava, "**/*Plugin.java", "**/*Plugin.groovy");
+        return discoverGradlePlugins(JavaPluginUtil.getMainSourceSet(project));
+    }
+
+    static Set<File> discoverGradlePlugins(SourceSet sourceSet) {
+        return getFilteredFileset(sourceSet.getAllJava(), "**/*Plugin.java", "**/*Plugin.groovy");
     }
 
     private static Set<File> getFilteredFileset(FileTree fileTree, String... includes) {

--- a/src/main/groovy/org/shipkit/internal/gradle/plugin/PluginUtil.java
+++ b/src/main/groovy/org/shipkit/internal/gradle/plugin/PluginUtil.java
@@ -2,9 +2,8 @@ package org.shipkit.internal.gradle.plugin;
 
 import org.gradle.api.Project;
 import org.gradle.api.file.FileTree;
-import org.gradle.api.plugins.JavaPluginConvention;
-import org.gradle.api.tasks.SourceSet;
 import org.gradle.api.tasks.util.PatternSet;
+import org.shipkit.internal.gradle.util.JavaPluginUtil;
 
 import java.io.File;
 import java.util.Set;
@@ -13,18 +12,13 @@ class PluginUtil {
     static final String DOT_PROPERTIES = ".properties";
 
     static Set<File> discoverGradlePluginPropertyFiles(Project project) {
-        FileTree resources = getMainSourceSet(project).getResources();
+        FileTree resources = JavaPluginUtil.getMainSourceSet(project).getResources();
         return getFilteredFileset(resources, "META-INF/gradle-plugins/*" + DOT_PROPERTIES);
     }
 
     static Set<File> discoverGradlePlugins(Project project) {
-        FileTree allJava = getMainSourceSet(project).getAllJava();
+        FileTree allJava = JavaPluginUtil.getMainSourceSet(project).getAllJava();
         return getFilteredFileset(allJava, "**/*Plugin.java", "**/*Plugin.groovy");
-    }
-
-    private static SourceSet getMainSourceSet(Project project) {
-        final JavaPluginConvention java = project.getConvention().getPlugin(JavaPluginConvention.class);
-        return java.getSourceSets().getByName(SourceSet.MAIN_SOURCE_SET_NAME);
     }
 
     private static Set<File> getFilteredFileset(FileTree fileTree, String... includes) {

--- a/src/main/groovy/org/shipkit/internal/gradle/plugin/PluginUtil.java
+++ b/src/main/groovy/org/shipkit/internal/gradle/plugin/PluginUtil.java
@@ -13,16 +13,19 @@ public class PluginUtil {
     static final String DOT_PROPERTIES = ".properties";
 
     static Set<File> discoverGradlePluginPropertyFiles(Project project) {
-        final JavaPluginConvention java = project.getConvention().getPlugin(JavaPluginConvention.class);
-        FileTree resources = java.getSourceSets().getByName(SourceSet.MAIN_SOURCE_SET_NAME).getResources();
+        FileTree resources = getMainSourceSet(project).getResources();
         FileTree plugins = resources.matching(new PatternSet().include("META-INF/gradle-plugins/*" + DOT_PROPERTIES));
         return plugins.getFiles();
     }
 
     static Set<File> discoverGradlePlugins(Project project) {
-        final JavaPluginConvention java = project.getConvention().getPlugin(JavaPluginConvention.class);
-        FileTree resources = java.getSourceSets().getByName(SourceSet.MAIN_SOURCE_SET_NAME).getAllJava();
-        FileTree plugins = resources.matching(new PatternSet().include("**/*Plugin.java").include("**/*Plugin.groovy"));
+        FileTree allJava = getMainSourceSet(project).getAllJava();
+        FileTree plugins = allJava.matching(new PatternSet().include("**/*Plugin.java").include("**/*Plugin.groovy"));
         return plugins.getFiles();
+    }
+
+    private static SourceSet getMainSourceSet(Project project) {
+        final JavaPluginConvention java = project.getConvention().getPlugin(JavaPluginConvention.class);
+        return java.getSourceSets().getByName(SourceSet.MAIN_SOURCE_SET_NAME);
     }
 }

--- a/src/main/groovy/org/shipkit/internal/gradle/plugin/PluginUtil.java
+++ b/src/main/groovy/org/shipkit/internal/gradle/plugin/PluginUtil.java
@@ -3,6 +3,7 @@ package org.shipkit.internal.gradle.plugin;
 import org.gradle.api.Project;
 import org.gradle.api.file.FileTree;
 import org.gradle.api.plugins.JavaPluginConvention;
+import org.gradle.api.tasks.SourceSet;
 import org.gradle.api.tasks.util.PatternSet;
 
 import java.io.File;
@@ -13,14 +14,14 @@ public class PluginUtil {
 
     static Set<File> discoverGradlePluginPropertyFiles(Project project) {
         final JavaPluginConvention java = project.getConvention().getPlugin(JavaPluginConvention.class);
-        FileTree resources = java.getSourceSets().getByName("main").getResources();
+        FileTree resources = java.getSourceSets().getByName(SourceSet.MAIN_SOURCE_SET_NAME).getResources();
         FileTree plugins = resources.matching(new PatternSet().include("META-INF/gradle-plugins/*" + DOT_PROPERTIES));
         return plugins.getFiles();
     }
 
     static Set<File> discoverGradlePlugins(Project project) {
         final JavaPluginConvention java = project.getConvention().getPlugin(JavaPluginConvention.class);
-        FileTree resources = java.getSourceSets().getByName("main").getAllJava();
+        FileTree resources = java.getSourceSets().getByName(SourceSet.MAIN_SOURCE_SET_NAME).getAllJava();
         FileTree plugins = resources.matching(new PatternSet().include("**/*Plugin.java").include("**/*Plugin.groovy"));
         return plugins.getFiles();
     }

--- a/src/main/groovy/org/shipkit/internal/gradle/plugin/PluginUtil.java
+++ b/src/main/groovy/org/shipkit/internal/gradle/plugin/PluginUtil.java
@@ -9,10 +9,12 @@ import java.io.File;
 import java.util.Set;
 
 public class PluginUtil {
+    static final String DOT_PROPERTIES = ".properties";
+
     static Set<File> discoverGradlePluginPropertyFiles(Project project) {
         final JavaPluginConvention java = project.getConvention().getPlugin(JavaPluginConvention.class);
         FileTree resources = java.getSourceSets().getByName("main").getResources();
-        FileTree plugins = resources.matching(new PatternSet().include("META-INF/gradle-plugins/*.properties"));
+        FileTree plugins = resources.matching(new PatternSet().include("META-INF/gradle-plugins/*" + DOT_PROPERTIES));
         return plugins.getFiles();
     }
 

--- a/src/main/groovy/org/shipkit/internal/gradle/plugin/PluginUtil.java
+++ b/src/main/groovy/org/shipkit/internal/gradle/plugin/PluginUtil.java
@@ -9,23 +9,25 @@ import org.gradle.api.tasks.util.PatternSet;
 import java.io.File;
 import java.util.Set;
 
-public class PluginUtil {
+class PluginUtil {
     static final String DOT_PROPERTIES = ".properties";
 
     static Set<File> discoverGradlePluginPropertyFiles(Project project) {
         FileTree resources = getMainSourceSet(project).getResources();
-        FileTree plugins = resources.matching(new PatternSet().include("META-INF/gradle-plugins/*" + DOT_PROPERTIES));
-        return plugins.getFiles();
+        return getFilteredFileset(resources, "META-INF/gradle-plugins/*" + DOT_PROPERTIES);
     }
 
     static Set<File> discoverGradlePlugins(Project project) {
         FileTree allJava = getMainSourceSet(project).getAllJava();
-        FileTree plugins = allJava.matching(new PatternSet().include("**/*Plugin.java").include("**/*Plugin.groovy"));
-        return plugins.getFiles();
+        return getFilteredFileset(allJava, "**/*Plugin.java", "**/*Plugin.groovy");
     }
 
     private static SourceSet getMainSourceSet(Project project) {
         final JavaPluginConvention java = project.getConvention().getPlugin(JavaPluginConvention.class);
         return java.getSourceSets().getByName(SourceSet.MAIN_SOURCE_SET_NAME);
+    }
+
+    private static Set<File> getFilteredFileset(FileTree fileTree, String... includes) {
+        return fileTree.matching(new PatternSet().include(includes)).getFiles();
     }
 }

--- a/src/main/groovy/org/shipkit/internal/gradle/plugin/PluginValidationPlugin.java
+++ b/src/main/groovy/org/shipkit/internal/gradle/plugin/PluginValidationPlugin.java
@@ -19,13 +19,17 @@ public class PluginValidationPlugin implements Plugin<Project> {
 
     @Override
     public void apply(final Project project) {
-        project.getPlugins().apply("java");
-        TaskMaker.task(project, "validatePlugins", PluginValidatorTask.class, new Action<PluginValidatorTask>() {
+        project.getPlugins().withId("java", new Action<Plugin>() {
             @Override
-            public void execute(PluginValidatorTask task) {
-                task.setDescription("Validates Gradle Plugins and their properties files");
-                task.setGradlePlugins(PluginUtil.discoverGradlePlugins(project));
-                task.setGradleProperties(PluginUtil.discoverGradlePluginPropertyFiles(project));
+            public void execute(Plugin plugin) {
+                TaskMaker.task(project, "validatePlugins", PluginValidatorTask.class, new Action<PluginValidatorTask>() {
+                    @Override
+                    public void execute(PluginValidatorTask task) {
+                        task.setDescription("Validates Gradle Plugins and their properties files");
+                        task.setGradlePlugins(PluginUtil.discoverGradlePlugins(project));
+                        task.setGradleProperties(PluginUtil.discoverGradlePluginPropertyFiles(project));
+                    }
+                });
             }
         });
     }

--- a/src/main/groovy/org/shipkit/internal/gradle/plugin/PluginValidationPlugin.java
+++ b/src/main/groovy/org/shipkit/internal/gradle/plugin/PluginValidationPlugin.java
@@ -1,0 +1,32 @@
+package org.shipkit.internal.gradle.plugin;
+
+
+import org.gradle.api.Action;
+import org.gradle.api.Plugin;
+import org.gradle.api.Project;
+import org.shipkit.internal.gradle.util.TaskMaker;
+
+/**
+ * This plugin validates that every plugin has a corresponding .properties file.
+ *
+ * Adds tasks:
+ * <ul>
+ *     <li>'validatePlugins' - of type {@link PluginValidatorTask}.
+ *          Validates that every plugin has a corresponding .properties file.</li>
+ * </ul>
+ */
+public class PluginValidationPlugin implements Plugin<Project> {
+
+    @Override
+    public void apply(final Project project) {
+        project.getPlugins().apply("java");
+        TaskMaker.task(project, "validatePlugins", PluginValidatorTask.class, new Action<PluginValidatorTask>() {
+            @Override
+            public void execute(PluginValidatorTask task) {
+                task.setDescription("Validates Gradle Plugins and their properties files");
+                task.setGradlePlugins(PluginUtil.discoverGradlePlugins(project));
+                task.setGradleProperties(PluginUtil.discoverGradlePluginPropertyFiles(project));
+            }
+        });
+    }
+}

--- a/src/main/groovy/org/shipkit/internal/gradle/plugin/PluginValidationPlugin.java
+++ b/src/main/groovy/org/shipkit/internal/gradle/plugin/PluginValidationPlugin.java
@@ -26,8 +26,6 @@ public class PluginValidationPlugin implements Plugin<Project> {
                     @Override
                     public void execute(PluginValidatorTask task) {
                         task.setDescription("Validates Gradle Plugins and their properties files");
-                        task.setGradlePlugins(PluginUtil.discoverGradlePlugins(project));
-                        task.setGradleProperties(PluginUtil.discoverGradlePluginPropertyFiles(project));
                     }
                 });
             }

--- a/src/main/groovy/org/shipkit/internal/gradle/plugin/PluginValidator.java
+++ b/src/main/groovy/org/shipkit/internal/gradle/plugin/PluginValidator.java
@@ -1,0 +1,66 @@
+package org.shipkit.internal.gradle.plugin;
+
+import org.gradle.api.logging.Logger;
+import org.gradle.api.logging.Logging;
+
+import java.io.File;
+import java.util.Set;
+
+import static org.shipkit.internal.gradle.plugin.PluginDiscoveryPlugin.DOT_PROPERTIES;
+
+
+public class PluginValidator {
+
+    private static final Logger LOG = Logging.getLogger(PluginValidator.class);
+
+    public void validate(Set<File> gradlePlugins, Set<File> gradleProperties) {
+        ensurePluginsHavePropertiesFile(gradlePlugins, gradleProperties);
+    }
+
+    void ensurePluginsHavePropertiesFile(Set<File> gradlePlugins, Set<File> gradleProperties) {
+        for (File plugin : gradlePlugins) {
+            String pluginFilename = plugin.getName();
+            String pluginName = extractPluginName(pluginFilename);
+            if (pluginName != null) {
+                String className = extractClassName(pluginName);
+                boolean matchingPropertiesFound = false;
+                for (File properties : gradleProperties) {
+                    int lastIndexOfProperties = properties.getName().lastIndexOf(DOT_PROPERTIES);
+                    if (lastIndexOfProperties != -1) {
+                        String pluginExtractedFromProperties = properties.getName().substring(0, lastIndexOfProperties);
+                        if (pluginExtractedFromProperties.toLowerCase().endsWith(className.toLowerCase())) {
+                            matchingPropertiesFound = true;
+                            LOG.info("plugin " + plugin + " has properties file " + gradleProperties);
+                            break;
+                        }
+                    }
+                }
+                if (!matchingPropertiesFound) {
+                    throw new RuntimeException("no properties file found for plugin '" + pluginName + "' (" + plugin + ")");
+                }
+            }
+        }
+    }
+
+    private String extractClassName(String pluginName) {
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < pluginName.length(); i++) {
+            char c = pluginName.charAt(i);
+            if (Character.isUpperCase(c)) {
+                if (sb.length() != 0) {
+                    sb.append("-");
+                }
+            }
+            sb.append(c);
+        }
+        return sb.toString();
+    }
+
+    private String extractPluginName(String pluginFilename) {
+        String pluginName = null;
+        if (pluginFilename.endsWith("Plugin.java") || pluginFilename.endsWith("Plugin.groovy")) {
+            pluginName = pluginFilename.substring(0, pluginFilename.lastIndexOf("Plugin."));
+        }
+        return pluginName;
+    }
+}

--- a/src/main/groovy/org/shipkit/internal/gradle/plugin/PluginValidator.java
+++ b/src/main/groovy/org/shipkit/internal/gradle/plugin/PluginValidator.java
@@ -6,7 +6,7 @@ import org.gradle.api.logging.Logging;
 import java.io.File;
 import java.util.Set;
 
-import static org.shipkit.internal.gradle.plugin.PluginDiscoveryPlugin.DOT_PROPERTIES;
+import static org.shipkit.internal.gradle.plugin.PluginUtil.DOT_PROPERTIES;
 
 
 public class PluginValidator {

--- a/src/main/groovy/org/shipkit/internal/gradle/plugin/PluginValidator.java
+++ b/src/main/groovy/org/shipkit/internal/gradle/plugin/PluginValidator.java
@@ -1,13 +1,13 @@
 package org.shipkit.internal.gradle.plugin;
 
 import org.gradle.api.GradleException;
-import org.gradle.api.Project;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
-import org.gradle.api.tasks.SourceSet;
 
 import java.io.File;
-import java.util.*;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
 
 import static org.shipkit.internal.gradle.plugin.PluginUtil.DOT_PROPERTIES;
 
@@ -16,24 +16,7 @@ public class PluginValidator {
 
     private static final Logger LOG = Logging.getLogger(PluginValidator.class);
 
-    private Project project;
-
-    public PluginValidator(Project project) {
-        this.project = project;
-    }
-
-    public void validate(SourceSet sourceSet) {
-        Set<File> gradlePlugins;
-        Set<File> gradleProperties;
-
-        if (sourceSet == null) {
-           gradlePlugins = PluginUtil.discoverGradlePlugins(project);
-           gradleProperties = PluginUtil.discoverGradlePluginPropertyFiles(project);
-        } else {
-            gradlePlugins = PluginUtil.discoverGradlePlugins(sourceSet);
-            gradleProperties = PluginUtil.discoverGradlePluginPropertyFiles(sourceSet);
-        }
-
+    public void validate(Set<File> gradlePlugins, Set<File> gradleProperties) {
         ensurePluginsHavePropertiesFile(gradlePlugins, gradleProperties);
     }
 

--- a/src/main/groovy/org/shipkit/internal/gradle/plugin/PluginValidator.java
+++ b/src/main/groovy/org/shipkit/internal/gradle/plugin/PluginValidator.java
@@ -1,5 +1,6 @@
 package org.shipkit.internal.gradle.plugin;
 
+import org.gradle.api.GradleException;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
 
@@ -57,7 +58,7 @@ public class PluginValidator {
                 sb.append(missingPropertiesFiles.get(pluginName));
                 sb.append(")");
             }
-            throw new RuntimeException(sb.toString());
+            throw new GradleException(sb.toString());
         }
     }
 
@@ -84,10 +85,9 @@ public class PluginValidator {
     }
 
     private String extractPluginName(String pluginFilename) {
-        String pluginName = null;
         if (pluginFilename.endsWith("Plugin.java") || pluginFilename.endsWith("Plugin.groovy")) {
-            pluginName = pluginFilename.substring(0, pluginFilename.lastIndexOf("Plugin."));
+            return pluginFilename.substring(0, pluginFilename.lastIndexOf("Plugin."));
         }
-        return pluginName;
+        return null;
     }
 }

--- a/src/main/groovy/org/shipkit/internal/gradle/plugin/PluginValidator.java
+++ b/src/main/groovy/org/shipkit/internal/gradle/plugin/PluginValidator.java
@@ -1,8 +1,10 @@
 package org.shipkit.internal.gradle.plugin;
 
 import org.gradle.api.GradleException;
+import org.gradle.api.Project;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
+import org.gradle.api.tasks.SourceSet;
 
 import java.io.File;
 import java.util.*;
@@ -14,7 +16,24 @@ public class PluginValidator {
 
     private static final Logger LOG = Logging.getLogger(PluginValidator.class);
 
-    public void validate(Set<File> gradlePlugins, Set<File> gradleProperties) {
+    private Project project;
+
+    public PluginValidator(Project project) {
+        this.project = project;
+    }
+
+    public void validate(SourceSet sourceSet) {
+        Set<File> gradlePlugins;
+        Set<File> gradleProperties;
+
+        if (sourceSet == null) {
+           gradlePlugins = PluginUtil.discoverGradlePlugins(project);
+           gradleProperties = PluginUtil.discoverGradlePluginPropertyFiles(project);
+        } else {
+            gradlePlugins = PluginUtil.discoverGradlePlugins(sourceSet);
+            gradleProperties = PluginUtil.discoverGradlePluginPropertyFiles(sourceSet);
+        }
+
         ensurePluginsHavePropertiesFile(gradlePlugins, gradleProperties);
     }
 

--- a/src/main/groovy/org/shipkit/internal/gradle/plugin/PluginValidatorTask.java
+++ b/src/main/groovy/org/shipkit/internal/gradle/plugin/PluginValidatorTask.java
@@ -15,7 +15,16 @@ public class PluginValidatorTask extends DefaultTask {
 
     @TaskAction
     public void validate() {
-        new PluginValidator(getProject()).validate(sourceSet);
+        Set<File> gradlePlugins;
+        Set<File> gradleProperties;
+        if (sourceSet == null) {
+            gradlePlugins = PluginUtil.discoverGradlePlugins(getProject());
+            gradleProperties = PluginUtil.discoverGradlePluginPropertyFiles(getProject());
+        } else {
+            gradlePlugins = PluginUtil.discoverGradlePlugins(sourceSet);
+            gradleProperties = PluginUtil.discoverGradlePluginPropertyFiles(sourceSet);
+        }
+        new PluginValidator().validate(gradlePlugins, gradleProperties);
     }
 
     public void setSourceSet(SourceSet sourceSet) {

--- a/src/main/groovy/org/shipkit/internal/gradle/plugin/PluginValidatorTask.java
+++ b/src/main/groovy/org/shipkit/internal/gradle/plugin/PluginValidatorTask.java
@@ -1,0 +1,39 @@
+package org.shipkit.internal.gradle.plugin;
+
+import org.gradle.api.DefaultTask;
+import org.gradle.api.tasks.InputFiles;
+import org.gradle.api.tasks.TaskAction;
+
+import java.io.File;
+import java.util.Set;
+
+
+public class PluginValidatorTask extends DefaultTask {
+
+    @InputFiles
+    private Set<File> gradlePlugins;
+    @InputFiles
+    private Set<File> gradleProperties;
+
+
+    @TaskAction
+    public void validate() {
+        new PluginValidator().validate(gradlePlugins, gradleProperties);
+    }
+
+    public void setGradlePlugins(Set<File> gradlePlugins) {
+        this.gradlePlugins = gradlePlugins;
+    }
+
+    public Set<File> getGradlePlugins() {
+        return gradlePlugins;
+    }
+
+    public void setGradleProperties(Set<File> gradleProperties) {
+        this.gradleProperties = gradleProperties;
+    }
+
+    public Set<File> getGradleProperties() {
+        return gradleProperties;
+    }
+}

--- a/src/main/groovy/org/shipkit/internal/gradle/plugin/PluginValidatorTask.java
+++ b/src/main/groovy/org/shipkit/internal/gradle/plugin/PluginValidatorTask.java
@@ -1,8 +1,7 @@
 package org.shipkit.internal.gradle.plugin;
 
 import org.gradle.api.DefaultTask;
-import org.gradle.api.tasks.InputFiles;
-import org.gradle.api.tasks.TaskAction;
+import org.gradle.api.tasks.*;
 
 import java.io.File;
 import java.util.Set;
@@ -10,30 +9,20 @@ import java.util.Set;
 
 public class PluginValidatorTask extends DefaultTask {
 
-    @InputFiles
-    private Set<File> gradlePlugins;
-    @InputFiles
-    private Set<File> gradleProperties;
-
+    @Optional
+    @Input
+    private SourceSet sourceSet;
 
     @TaskAction
     public void validate() {
-        new PluginValidator().validate(gradlePlugins, gradleProperties);
+        new PluginValidator(getProject()).validate(sourceSet);
     }
 
-    public void setGradlePlugins(Set<File> gradlePlugins) {
-        this.gradlePlugins = gradlePlugins;
+    public void setSourceSet(SourceSet sourceSet) {
+        this.sourceSet = sourceSet;
     }
 
-    public Set<File> getGradlePlugins() {
-        return gradlePlugins;
-    }
-
-    public void setGradleProperties(Set<File> gradleProperties) {
-        this.gradleProperties = gradleProperties;
-    }
-
-    public Set<File> getGradleProperties() {
-        return gradleProperties;
+    public SourceSet getSourceSet() {
+        return sourceSet;
     }
 }

--- a/src/main/groovy/org/shipkit/internal/gradle/plugin/ShipkitGradlePlugin.java
+++ b/src/main/groovy/org/shipkit/internal/gradle/plugin/ShipkitGradlePlugin.java
@@ -14,6 +14,7 @@ import org.shipkit.internal.gradle.release.GradlePortalReleasePlugin;
  * <ul>
  *     <li>{@link TravisPlugin}</li>
  *     <li>{@link PluginDiscoveryPlugin}</li>
+ *     <li>{@link PluginValidationPlugin}</li>
  *     <li>{@link CiReleasePlugin}</li>
  *     <li>{@link GradlePortalReleasePlugin}</li>
  * </ul>
@@ -24,6 +25,7 @@ public class ShipkitGradlePlugin implements Plugin<Project> {
     public void apply(Project project) {
         project.getPlugins().apply(TravisPlugin.class);
         project.getPlugins().apply(PluginDiscoveryPlugin.class);
+        project.getPlugins().apply(PluginValidationPlugin.class);
         project.getPlugins().apply(CiReleasePlugin.class);
         project.getPlugins().apply(GradlePortalReleasePlugin.class);
     }

--- a/src/main/groovy/org/shipkit/internal/gradle/util/JavaPluginUtil.java
+++ b/src/main/groovy/org/shipkit/internal/gradle/util/JavaPluginUtil.java
@@ -1,0 +1,14 @@
+package org.shipkit.internal.gradle.util;
+
+
+import org.gradle.api.Project;
+import org.gradle.api.plugins.JavaPluginConvention;
+import org.gradle.api.tasks.SourceSet;
+
+public class JavaPluginUtil {
+
+    public static SourceSet getMainSourceSet(Project project) {
+        final JavaPluginConvention java = project.getConvention().getPlugin(JavaPluginConvention.class);
+        return java.getSourceSets().getByName(SourceSet.MAIN_SOURCE_SET_NAME);
+    }
+}

--- a/src/test/groovy/org/shipkit/internal/gradle/plugin/PluginValidationPluginTest.groovy
+++ b/src/test/groovy/org/shipkit/internal/gradle/plugin/PluginValidationPluginTest.groovy
@@ -1,0 +1,12 @@
+package org.shipkit.internal.gradle.plugin
+
+import testutil.PluginSpecification
+
+
+class PluginValidationPluginTest extends PluginSpecification {
+
+    def "apply"() {
+        expect:
+        project.plugins.apply(PluginValidationPlugin)
+    }
+}

--- a/src/test/groovy/org/shipkit/internal/gradle/plugin/PluginValidatorTest.groovy
+++ b/src/test/groovy/org/shipkit/internal/gradle/plugin/PluginValidatorTest.groovy
@@ -1,0 +1,65 @@
+package org.shipkit.internal.gradle.plugin
+
+import testutil.PluginSpecification
+
+
+class PluginValidatorTest extends PluginSpecification {
+
+    private static final String META_INF_GRADLE_PLUGINS = 'src/main/resources/META-INF/gradle-plugins'
+    private static final String PLUGIN_PACKAGE = 'src/main/groovy/org/sipkit/gradle/'
+
+    def "validate plugin properties files"() {
+        given:
+        project.file(META_INF_GRADLE_PLUGINS).mkdirs()
+        project.file(PLUGIN_PACKAGE).mkdirs()
+        def propertiesFile = project.file("$META_INF_GRADLE_PLUGINS/org.sipkit.test.properties") << "implementation-class=org.shipkit.gradle.TestPlugin"
+        def pluginFile = project.file("$PLUGIN_PACKAGE/TestPlugin.java") << "TODO content"
+
+        when:
+        new PluginValidator().validate([pluginFile] as Set<File>, [propertiesFile] as Set<File>)
+        then:
+        true
+    }
+
+    def "validate plugin properties files (groovy plugin)"() {
+        given:
+        project.file(META_INF_GRADLE_PLUGINS).mkdirs()
+        project.file(PLUGIN_PACKAGE).mkdirs()
+        def propertiesFile = project.file("$META_INF_GRADLE_PLUGINS/org.sipkit.test.properties") << "implementation-class=org.shipkit.gradle.TestPlugin"
+        def pluginFile = project.file("$PLUGIN_PACKAGE/TestPlugin.groovy") << "TODO content"
+
+        when:
+        new PluginValidator().validate([pluginFile] as Set<File>, [propertiesFile] as Set<File>)
+        then:
+        true
+    }
+
+
+    def "validate missing properties file"() {
+        given:
+        project.file(META_INF_GRADLE_PLUGINS).mkdirs()
+        project.file(PLUGIN_PACKAGE).mkdirs()
+        def pluginFile = project.file("$PLUGIN_PACKAGE/TestPlugin.java") << "TODO content"
+
+        when:
+        new PluginValidator().validate([pluginFile] as Set<File>, [] as Set<File>)
+        then:
+        RuntimeException ex = thrown()
+        ex.message.contains 'no properties file found for plugin \'Test\''
+    }
+
+    def "validate missing properties file not matching"() {
+        given:
+        project.file(META_INF_GRADLE_PLUGINS).mkdirs()
+        project.file(PLUGIN_PACKAGE).mkdirs()
+        def propertiesFile = project.file("$META_INF_GRADLE_PLUGINS/org.sipkit.test2.properties") << "implementation-class=org.shipkit.gradle.TestPlugin"
+        def pluginFile = project.file("$PLUGIN_PACKAGE/TestPlugin.java") << "TODO content"
+
+        when:
+        new PluginValidator().validate([pluginFile] as Set<File>, [propertiesFile] as Set<File>)
+        then:
+        RuntimeException ex = thrown()
+        ex.message.contains 'no properties file found for plugin \'Test\''
+    }
+
+}

--- a/src/test/groovy/org/shipkit/internal/gradle/plugin/PluginValidatorTest.groovy
+++ b/src/test/groovy/org/shipkit/internal/gradle/plugin/PluginValidatorTest.groovy
@@ -12,11 +12,11 @@ class PluginValidatorTest extends PluginSpecification {
         given:
         project.file(META_INF_GRADLE_PLUGINS).mkdirs()
         project.file(PLUGIN_PACKAGE).mkdirs()
-        def propertiesFile = project.file("$META_INF_GRADLE_PLUGINS/${propertiesFileName}.properties") << "implementation-class=org.shipkit.gradle.$className"
-        def pluginFile = project.file("$PLUGIN_PACKAGE/${className}.${extension}") << "TODO content"
+        Set propertiesFiles = [project.file("$META_INF_GRADLE_PLUGINS/${propertiesFileName}.properties") << "implementation-class=org.shipkit.gradle.$className"]
+        Set pluginFiles = [project.file("$PLUGIN_PACKAGE/${className}.${extension}") << "some content"]
 
         when:
-        new PluginValidator().validate([pluginFile] as Set<File>, [propertiesFile] as Set<File>)
+        new PluginValidator().validate(pluginFiles, propertiesFiles)
         then:
         noExceptionThrown()
 
@@ -33,11 +33,13 @@ class PluginValidatorTest extends PluginSpecification {
         given:
         project.file(META_INF_GRADLE_PLUGINS).mkdirs()
         project.file(PLUGIN_PACKAGE).mkdirs()
-        def pluginFile = project.file("$PLUGIN_PACKAGE/TestPlugin.java") << "TODO content"
-        def pluginFile2 = project.file("$PLUGIN_PACKAGE/AnotherTestPlugin.java") << "TODO content"
+        def pluginFile = project.file("$PLUGIN_PACKAGE/TestPlugin.java") << "some content"
+        def pluginFile2 = project.file("$PLUGIN_PACKAGE/AnotherTestPlugin.java") << "some content"
+        Set pluginFiles = [pluginFile, pluginFile2]
+        Set propertiesFiles = []
 
         when:
-        new PluginValidator().validate([pluginFile, pluginFile2] as Set<File>, [] as Set<File>)
+        new PluginValidator().validate(pluginFiles, propertiesFiles)
         then:
         RuntimeException ex = thrown()
         ex.message.contains 'no properties file found for plugin(s):'
@@ -49,11 +51,12 @@ class PluginValidatorTest extends PluginSpecification {
         given:
         project.file(META_INF_GRADLE_PLUGINS).mkdirs()
         project.file(PLUGIN_PACKAGE).mkdirs()
-        def propertiesFile = project.file("$META_INF_GRADLE_PLUGINS/org.sipkit.test2.properties") << "implementation-class=org.shipkit.gradle.TestPlugin"
-        def pluginFile = project.file("$PLUGIN_PACKAGE/TestPlugin.java") << "TODO content"
+        Set propertiesFiles = [project.file("$META_INF_GRADLE_PLUGINS/org.sipkit.test2.properties") << "implementation-class=org.shipkit.gradle.TestPlugin"]
+        def pluginFile = project.file("$PLUGIN_PACKAGE/TestPlugin.java") << "some content"
+        Set pluginFiles = [pluginFile]
 
         when:
-        new PluginValidator().validate([pluginFile] as Set<File>, [propertiesFile] as Set<File>)
+        new PluginValidator().validate(pluginFiles, propertiesFiles)
         then:
         RuntimeException ex = thrown()
         ex.message.contains 'no properties file found for plugin(s):'

--- a/src/test/groovy/org/shipkit/internal/gradle/plugin/PluginValidatorTest.groovy
+++ b/src/test/groovy/org/shipkit/internal/gradle/plugin/PluginValidatorTest.groovy
@@ -34,12 +34,15 @@ class PluginValidatorTest extends PluginSpecification {
         project.file(META_INF_GRADLE_PLUGINS).mkdirs()
         project.file(PLUGIN_PACKAGE).mkdirs()
         def pluginFile = project.file("$PLUGIN_PACKAGE/TestPlugin.java") << "TODO content"
+        def pluginFile2 = project.file("$PLUGIN_PACKAGE/AnotherTestPlugin.java") << "TODO content"
 
         when:
-        new PluginValidator().validate([pluginFile] as Set<File>, [] as Set<File>)
+        new PluginValidator().validate([pluginFile, pluginFile2] as Set<File>, [] as Set<File>)
         then:
         RuntimeException ex = thrown()
-        ex.message.contains 'no properties file found for plugin \'Test\''
+        ex.message.contains 'no properties file found for plugin(s):'
+        ex.message.contains "\'Test\' ($pluginFile)"
+        ex.message.contains "\'AnotherTest\' ($pluginFile2)"
     }
 
     def "validate missing properties file not matching"() {
@@ -53,7 +56,8 @@ class PluginValidatorTest extends PluginSpecification {
         new PluginValidator().validate([pluginFile] as Set<File>, [propertiesFile] as Set<File>)
         then:
         RuntimeException ex = thrown()
-        ex.message.contains 'no properties file found for plugin \'Test\''
+        ex.message.contains 'no properties file found for plugin(s):'
+        ex.message.contains "\'Test\' ($pluginFile)"
     }
 
 }

--- a/src/test/groovy/org/shipkit/internal/gradle/plugin/PluginValidatorTest.groovy
+++ b/src/test/groovy/org/shipkit/internal/gradle/plugin/PluginValidatorTest.groovy
@@ -8,30 +8,24 @@ class PluginValidatorTest extends PluginSpecification {
     private static final String META_INF_GRADLE_PLUGINS = 'src/main/resources/META-INF/gradle-plugins'
     private static final String PLUGIN_PACKAGE = 'src/main/groovy/org/sipkit/gradle/'
 
-    def "validate plugin properties files"() {
+    def "validate plugin properties files"(propertiesFileName, className, extension) {
         given:
         project.file(META_INF_GRADLE_PLUGINS).mkdirs()
         project.file(PLUGIN_PACKAGE).mkdirs()
-        def propertiesFile = project.file("$META_INF_GRADLE_PLUGINS/org.sipkit.test.properties") << "implementation-class=org.shipkit.gradle.TestPlugin"
-        def pluginFile = project.file("$PLUGIN_PACKAGE/TestPlugin.java") << "TODO content"
+        def propertiesFile = project.file("$META_INF_GRADLE_PLUGINS/${propertiesFileName}.properties") << "implementation-class=org.shipkit.gradle.$className"
+        def pluginFile = project.file("$PLUGIN_PACKAGE/${className}.${extension}") << "TODO content"
 
         when:
         new PluginValidator().validate([pluginFile] as Set<File>, [propertiesFile] as Set<File>)
         then:
-        true
-    }
+        noExceptionThrown()
 
-    def "validate plugin properties files (groovy plugin)"() {
-        given:
-        project.file(META_INF_GRADLE_PLUGINS).mkdirs()
-        project.file(PLUGIN_PACKAGE).mkdirs()
-        def propertiesFile = project.file("$META_INF_GRADLE_PLUGINS/org.sipkit.test.properties") << "implementation-class=org.shipkit.gradle.TestPlugin"
-        def pluginFile = project.file("$PLUGIN_PACKAGE/TestPlugin.groovy") << "TODO content"
-
-        when:
-        new PluginValidator().validate([pluginFile] as Set<File>, [propertiesFile] as Set<File>)
-        then:
-        true
+        where:
+        propertiesFileName      | className          | extension
+        'org.shipkit.test'      | 'TestPlugin'       | 'java'
+        'org.shipkit.test'      | 'TestPlugin'       | 'groovy'
+        'org.shipkit.my-sample' | 'MySamplePlugin'   | 'java'
+        'org.shipkit.my-sample' | 'MySamplePlugin'   | 'groovy'
     }
 
 


### PR DESCRIPTION
very first version for #284

tested locally:

> ./gradlew validatePlugins
>  Building version '0.9.9' (value loaded from 'version.properties' file).
>  Adding 18 discovered Gradle plugins to 'pluginBundle'
> :validatePlugins FAILED
>
> FAILURE: Build failed with an exception.
> 
> * What went wrong:
> Execution failed for task ':validatePlugins'.
> no properties file found for plugin 'ShipkitBintray' (/home/ep/projects/github/mockito-project/mockito-release-tools/src/main/groovy/org/shipkit/internal/gradle/ShipkitBintrayPlugin.java)
>
> * Try:
> Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output.
> 
> BUILD FAILED
