### PR TITLE
Public API clean up

### DIFF
--- a/src/main/groovy/org/shipkit/gradle/configuration/ShipkitConfiguration.java
+++ b/src/main/groovy/org/shipkit/gradle/configuration/ShipkitConfiguration.java
@@ -32,10 +32,6 @@ public class ShipkitConfiguration {
 
     public ShipkitConfiguration() {
         this(new ShipkitConfigurationStore());
-    }
-
-    ShipkitConfiguration(ShipkitConfigurationStore store) {
-        this.store = store;
 
         //Configure default values
         git.setTagPrefix("v"); //so that tags are "v1.0", "v2.3.4"
@@ -56,6 +52,10 @@ public class ShipkitConfiguration {
 
         team.setContributors(Collections.<String>emptyList());
         team.setDevelopers(Collections.<String>emptyList());
+    }
+
+    ShipkitConfiguration(ShipkitConfigurationStore store) {
+        this.store = store;
     }
 
     private boolean dryRun;

--- a/src/main/groovy/org/shipkit/gradle/configuration/ShipkitConfiguration.java
+++ b/src/main/groovy/org/shipkit/gradle/configuration/ShipkitConfiguration.java
@@ -1,14 +1,9 @@
 package org.shipkit.gradle.configuration;
 
-import org.gradle.api.GradleException;
-import org.gradle.api.logging.Logger;
-import org.gradle.api.logging.Logging;
-import org.shipkit.internal.util.EnvVariables;
-import org.shipkit.internal.util.ExposedForTesting;
+import org.shipkit.internal.gradle.configuration.ShipkitConfigurationStore;
 
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.Map;
 
 import static java.util.Collections.singletonList;
@@ -26,33 +21,21 @@ import static org.shipkit.internal.gradle.util.team.TeamParser.validateTeamMembe
  */
 public class ShipkitConfiguration {
 
-    private static final Logger LOG = Logging.getLogger(ShipkitConfiguration.class);
-
-    private final Map<String, Object> configuration;
+    private final ShipkitConfigurationStore store;
 
     private final GitHub gitHub = new GitHub();
     private final ReleaseNotes releaseNotes = new ReleaseNotes();
     private final Git git = new Git();
     private final Team team = new Team();
-    private final boolean lenient;
 
     private String previousReleaseVersion;
-    private EnvVariables envVariables = new EnvVariables();
-
-    ShipkitConfiguration(Map<String, Object> configuration, boolean lenient) {
-        this.configuration = configuration;
-        this.lenient = lenient;
-    }
-
-    @ExposedForTesting
-    ShipkitConfiguration(EnvVariables envVariables) {
-        this();
-        this.envVariables = envVariables;
-    }
 
     public ShipkitConfiguration() {
-        configuration = new HashMap<String, Object>();
-        lenient = false;
+        this(new ShipkitConfigurationStore());
+    }
+
+    ShipkitConfiguration(ShipkitConfigurationStore store) {
+        this.store = store;
 
         //Configure default values
         git.setTagPrefix("v"); //so that tags are "v1.0", "v2.3.4"
@@ -75,8 +58,6 @@ public class ShipkitConfiguration {
         team.setDevelopers(Collections.<String>emptyList());
     }
 
-    //TODO currently it's not clear when to use class fields and when to use the 'configuration' map
-    //Let's make it clear in the docs
     private boolean dryRun;
 
     /**
@@ -133,35 +114,35 @@ public class ShipkitConfiguration {
          * and your url is different than the default GitHub instance for Open Source
          */
         public String getUrl() {
-            return getStringUrl("gitHub.url");
+            return store.getStringUrl("gitHub.url");
         }
 
         /**
          * See {@link #getUrl()}
          */
         public void setUrl(String url) {
-            configuration.put("gitHub.url", url);
+            store.put("gitHub.url", url);
         }
 
         /**
          * GitHub API endpoint address, for example:  https://api.github.com
          */
         public String getApiUrl() {
-            return getStringUrl("gitHub.apiUrl");
+            return store.getStringUrl("gitHub.apiUrl");
         }
 
         /**
          * See {@link #getApiUrl()}
          */
         public void setApiUrl(String apiUrl) {
-            configuration.put("gitHub.apiUrl", apiUrl);
+            store.put("gitHub.apiUrl", apiUrl);
         }
 
         /**
          * GitHub repository name, for example: "mockito/shipkit"
          */
         public String getRepository() {
-            return getString("gitHub.repository");
+            return store.getString("gitHub.repository");
         }
 
         /**
@@ -170,7 +151,7 @@ public class ShipkitConfiguration {
          * @param repository name of the repo, including user or organization section, for example: "mockito/shipkit"
          */
         public void setRepository(String repository) {
-            configuration.put("gitHub.repository", repository);
+            store.put("gitHub.repository", repository);
         }
 
         /**
@@ -178,14 +159,14 @@ public class ShipkitConfiguration {
          * Needed for the release process to push changes.
          */
         public String getWriteAuthUser() {
-            return getString("gitHub.writeAuthUser");
+            return store.getString("gitHub.writeAuthUser");
         }
 
         /**
          * See {@link #getWriteAuthUser()}
          */
         public void setWriteAuthUser(String user) {
-            configuration.put("gitHub.writeAuthUser", user);
+            store.put("gitHub.writeAuthUser", user);
         }
 
         /**
@@ -193,14 +174,14 @@ public class ShipkitConfiguration {
          * Since the token is read-only it is ok to check that in to VCS.
          */
         public String getReadOnlyAuthToken() {
-            return getString("gitHub.readOnlyAuthToken");
+            return store.getString("gitHub.readOnlyAuthToken");
         }
 
         /**
          * See {@link #getReadOnlyAuthToken()}
          */
         public void setReadOnlyAuthToken(String token) {
-            configuration.put("gitHub.readOnlyAuthToken", token);
+            store.put("gitHub.readOnlyAuthToken", token);
         }
 
         /**
@@ -211,14 +192,14 @@ public class ShipkitConfiguration {
          * if this value is not specified.
          */
         public String getWriteAuthToken() {
-            return (String) getValue("gitHub.writeAuthToken", "GH_WRITE_TOKEN", "Please export 'GH_WRITE_TOKEN' variable first!\n" +
+            return (String) store.getValue("gitHub.writeAuthToken", "GH_WRITE_TOKEN", "Please export 'GH_WRITE_TOKEN' variable first!\n" +
                 "It is highly recommended to keep write token secure and store env variable 'GH_WRITE_TOKEN' with your CI configuration." +
                 "Alternatively, you can configure GitHub write auth token explicitly (don't check this in to Git!):\n" +
                 "  shipkit.gitHub.writeAuthToken = 'secret'");
         }
 
         public void setWriteAuthToken(String writeAuthToken) {
-            configuration.put("gitHub.writeAuthToken", writeAuthToken);
+            store.put("gitHub.writeAuthToken", writeAuthToken);
         }
     }
 
@@ -228,14 +209,14 @@ public class ShipkitConfiguration {
          * Release notes file relative path, for example: "docs/release-notes.md"
          */
         public String getFile() {
-            return getString("releaseNotes.file");
+            return store.getString("releaseNotes.file");
         }
 
         /**
          * See {@link #getFile()}
          */
         public void setFile(String file) {
-            configuration.put("releaseNotes.file", file);
+            store.put("releaseNotes.file", file);
         }
 
         /**
@@ -246,14 +227,14 @@ public class ShipkitConfiguration {
          * Examples: ['java-9': 'Java 9 support', 'BDD': 'Behavior-Driven Development support']
          */
         public Map<String, String> getLabelMapping() {
-            return getMap("releaseNotes.labelMapping");
+            return store.getMap("releaseNotes.labelMapping");
         }
 
         /**
          * See {@link #getLabelMapping()}
          */
         public void setLabelMapping(Map<String, String> labelMapping) {
-            configuration.put("releaseNotes.labelMapping", labelMapping);
+            store.put("releaseNotes.labelMapping", labelMapping);
         }
 
         /**
@@ -262,14 +243,14 @@ public class ShipkitConfiguration {
          * that commit will be ignored and not used for generating release notes.
          */
         public Collection<String> getIgnoreCommitsContaining() {
-            return getCollection("releaseNotes.ignoreCommitsContaining");
+            return store.getCollection("releaseNotes.ignoreCommitsContaining");
         }
 
         /**
          * See {@link #getIgnoreCommitsContaining()}
          */
         public void setIgnoreCommitsContaining(Collection<String> commitMessageParts) {
-            configuration.put("releaseNotes.ignoreCommitsContaining", commitMessageParts);
+            store.put("releaseNotes.ignoreCommitsContaining", commitMessageParts);
         }
     }
 
@@ -281,14 +262,14 @@ public class ShipkitConfiguration {
          * For example: "shipkit"
          */
         public String getUser() {
-            return getString("git.user");
+            return store.getString("git.user");
         }
 
         /**
          * See {@link #getUser()} ()}
          */
         public void setUser(String user) {
-            configuration.put("git.user", user);
+            store.put("git.user", user);
         }
 
         /**
@@ -297,28 +278,28 @@ public class ShipkitConfiguration {
          * For example "shipkit.org@gmail.com"
          */
         public String getEmail() {
-            return getString("git.email");
+            return store.getString("git.email");
         }
 
         /**
          * See {@link #getEmail()}
          */
         public void setEmail(String email) {
-            configuration.put("git.email", email);
+            store.put("git.email", email);
         }
 
         /**
          * Regex to be used to identify branches that are entitled to be released, for example "master|release/.+"
          */
         public String getReleasableBranchRegex() {
-            return getString("git.releasableBranchRegex");
+            return store.getString("git.releasableBranchRegex");
         }
 
         /**
          * See {@link #getReleasableBranchRegex()}
          */
         public void setReleasableBranchRegex(String releasableBranchRegex) {
-            configuration.put("git.releasableBranchRegex", releasableBranchRegex);
+            store.put("git.releasableBranchRegex", releasableBranchRegex);
         }
 
         /**
@@ -327,14 +308,14 @@ public class ShipkitConfiguration {
          * Empty string is ok and it means that there is not prefix.
          */
         public String getTagPrefix() {
-            return getString("git.tagPrefix");
+            return store.getString("git.tagPrefix");
         }
 
         /**
          * See {@link #getTagPrefix()}
          */
         public void setTagPrefix(String tagPrefix) {
-            configuration.put("git.tagPrefix", tagPrefix);
+            store.put("git.tagPrefix", tagPrefix);
         }
 
         /**
@@ -343,7 +324,7 @@ public class ShipkitConfiguration {
          * By default it is configured to append "[ci skip]" keyword which will prevent CI builds on Travis CI.
          */
         public String getCommitMessagePostfix() {
-            return getString("git.commitMessagePostfix");
+            return store.getString("git.commitMessagePostfix");
         }
 
         /**
@@ -351,7 +332,7 @@ public class ShipkitConfiguration {
          */
         public void setCommitMessagePostfix(String commitMessagePostfix) {
             //TODO protect this setter and other relevant from invalid input (null value)
-            configuration.put("git.commitMessagePostfix", commitMessagePostfix);
+            store.put("git.commitMessagePostfix", commitMessagePostfix);
         }
     }
 
@@ -368,7 +349,7 @@ public class ShipkitConfiguration {
          * See POM reference for <a href="https://maven.apache.org/pom.html#Developers">Developers</a>.
          */
         public Collection<String> getDevelopers() {
-            return getCollection("team.developers");
+            return store.getCollection("team.developers");
         }
 
         /**
@@ -376,7 +357,7 @@ public class ShipkitConfiguration {
          */
         public void setDevelopers(Collection<String> developers) {
             validateTeamMembers(developers);
-            configuration.put("team.developers", developers);
+            store.put("team.developers", developers);
         }
 
         /**
@@ -387,7 +368,7 @@ public class ShipkitConfiguration {
          * See POM reference for <a href="https://maven.apache.org/pom.html#Contributors">Contributors</a>.
          */
         public Collection<String> getContributors() {
-            return getCollection("team.contributors");
+            return store.getCollection("team.contributors");
         }
 
         /**
@@ -395,53 +376,8 @@ public class ShipkitConfiguration {
          */
         public void setContributors(Collection<String> contributors) {
             validateTeamMembers(contributors);
-            configuration.put("team.contributors", contributors);
+            store.put("team.contributors", contributors);
         }
-    }
-
-    private String getStringUrl(String key) {
-        String url = getString(key);
-        if(url.endsWith("/")) {
-            return url.replaceAll("/*$", "");
-        }
-        return url;
-    }
-
-    private String getString(String key) {
-        return (String) getValue(key, "Please configure 'shipkit." + key + "' value (String).");
-    }
-
-    private Map getMap(String key) {
-        return (Map) getValue(key, "Please configure 'shipkit." + key + "' value (Map).");
-    }
-
-    private Collection<String> getCollection(String key) {
-        return (Collection) getValue(key, "Please configure 'shipkit." + key + "' value (Collection).");
-    }
-
-    private Object getValue(String key, String message) {
-        return getValue(key, null, message);
-    }
-
-    private Object getValue(String key, String envVarName, String message) {
-        Object value = configuration.get(key);
-
-        if (value != null) {
-            return value;
-        }
-
-        if (envVarName != null) {
-            value = envVariables.getNonEmptyEnv(envVarName);
-            if (value != null) {
-                return value;
-            }
-        }
-
-        if (lenient) {
-            return null;
-        }
-
-        throw new GradleException(message);
     }
 
     /**
@@ -455,6 +391,6 @@ public class ShipkitConfiguration {
      * @return lenient copy of this configuration instance
      */
     public ShipkitConfiguration getLenient() {
-        return new ShipkitConfiguration(configuration, true);
+        return new ShipkitConfiguration(store.getLenient());
     }
 }

--- a/src/main/groovy/org/shipkit/gradle/git/GitCommitTask.java
+++ b/src/main/groovy/org/shipkit/gradle/git/GitCommitTask.java
@@ -5,6 +5,7 @@ import org.gradle.api.Task;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.SkipWhenEmpty;
 import org.gradle.api.tasks.TaskAction;
+import org.shipkit.gradle.configuration.ShipkitConfiguration;
 import org.shipkit.internal.gradle.git.tasks.GitCommitImpl;
 
 import java.io.File;
@@ -28,40 +29,73 @@ public class GitCommitTask extends DefaultTask {
         new GitCommitImpl().commit(this);
     }
 
+    /**
+     * Registers a change to be committed.
+     * Invoke this method only in Gradle's configuration phase because this method calls 'dependsOn' automatically.
+     *
+     * @param files to be committed
+     * @param changeDescription description to be included in commit message
+     * @param taskMakingChange task that makes the change, we will automatically set 'dependsOn' this task
+     */
     public void addChange(List<File> files, String changeDescription, Task taskMakingChange) {
         dependsOn(taskMakingChange);
         filesToCommit.addAll(files);
         descriptions.add(changeDescription);
     }
 
+    /**
+     * See {@link ShipkitConfiguration.Git#getUser()}
+     */
     public String getGitUserName() {
         return gitUserName;
     }
 
+    /**
+     * See {@link #getGitUserName()}
+     */
     public void setGitUserName(String gitUserName) {
         this.gitUserName = gitUserName;
     }
 
+    /**
+     * See {@link ShipkitConfiguration.Git#getEmail()}
+     */
     public String getGitUserEmail() {
         return gitUserEmail;
     }
 
+    /**
+     * See {@link #getGitUserEmail()}
+     */
     public void setGitUserEmail(String gitUserEmail) {
         this.gitUserEmail = gitUserEmail;
     }
 
+    /**
+     * See {@link ShipkitConfiguration.Git#getCommitMessagePostfix()}
+     */
     public String getCommitMessagePostfix() {
         return commitMessagePostfix;
     }
 
+    /**
+     * See {@link #getCommitMessagePostfix()}
+     */
     public void setCommitMessagePostfix(String commitMessagePostfix) {
         this.commitMessagePostfix = commitMessagePostfix;
     }
 
+    /**
+     * The files to be committed as registered using {@link #addChange(List, String, Task)} method.
+     */
     public List<File> getFilesToCommit() {
         return filesToCommit;
     }
 
+    /**
+     * Change descriptions to be included in the commit message.
+     * Descriptions are registered using {@link #addChange(List, String, Task)}
+     */
     public List<String> getDescriptions() {
         return descriptions;
     }

--- a/src/main/groovy/org/shipkit/gradle/git/GitCommitTask.java
+++ b/src/main/groovy/org/shipkit/gradle/git/GitCommitTask.java
@@ -1,4 +1,4 @@
-package org.shipkit.internal.gradle.git;
+package org.shipkit.gradle.git;
 
 import org.gradle.api.DefaultTask;
 import org.gradle.api.Task;

--- a/src/main/groovy/org/shipkit/internal/gradle/configuration/ShipkitConfigurationStore.java
+++ b/src/main/groovy/org/shipkit/internal/gradle/configuration/ShipkitConfigurationStore.java
@@ -1,0 +1,81 @@
+package org.shipkit.internal.gradle.configuration;
+
+import org.gradle.api.GradleException;
+import org.shipkit.internal.util.EnvVariables;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+
+public class ShipkitConfigurationStore {
+
+    private final boolean lenient;
+    private final EnvVariables envVariables;
+    private final Map<String, Object> configuration;
+
+    public ShipkitConfigurationStore() {
+        this(new HashMap<String, Object>(), new EnvVariables(), false);
+    }
+
+    ShipkitConfigurationStore(Map<String, Object> configuration, EnvVariables envVariables, boolean lenient) {
+        this.lenient = lenient;
+        this.configuration = configuration;
+        this.envVariables = envVariables;
+    }
+
+    /**
+     * Adds key-value pair to the story. If the key already exists, it is replaced.
+     */
+    public void put(String key, Object value) {
+        configuration.put(key, value);
+    }
+
+    public String getStringUrl(String key) {
+        String url = getString(key);
+        if(url.endsWith("/")) {
+            return url.replaceAll("/*$", "");
+        }
+        return url;
+    }
+
+    public String getString(String key) {
+        return (String) getValue(key, "Please configure 'shipkit." + key + "' value (String).");
+    }
+
+    public Map getMap(String key) {
+        return (Map) getValue(key, "Please configure 'shipkit." + key + "' value (Map).");
+    }
+
+    public Collection<String> getCollection(String key) {
+        return (Collection) getValue(key, "Please configure 'shipkit." + key + "' value (Collection).");
+    }
+
+    private Object getValue(String key, String message) {
+        return getValue(key, null, message);
+    }
+
+    public Object getValue(String key, String envVarName, String message) {
+        Object value = configuration.get(key);
+
+        if (value != null) {
+            return value;
+        }
+
+        if (envVarName != null) {
+            value = envVariables.getNonEmptyEnv(envVarName);
+            if (value != null) {
+                return value;
+            }
+        }
+
+        if (lenient) {
+            return null;
+        }
+
+        throw new GradleException(message);
+    }
+
+    public ShipkitConfigurationStore getLenient() {
+        return new ShipkitConfigurationStore(this.configuration, new EnvVariables(), true);
+    }
+}

--- a/src/main/groovy/org/shipkit/internal/gradle/git/GitCommitTask.java
+++ b/src/main/groovy/org/shipkit/internal/gradle/git/GitCommitTask.java
@@ -16,7 +16,7 @@ public class GitCommitTask extends ShipkitExecTask {
     private List<File> filesToCommit = new ArrayList<File>();
     private List<String> descriptions = new ArrayList<String>();
 
-    public void addChange(List<File> files, String changeDescription, Task taskMakingChange){
+    public void addChange(List<File> files, String changeDescription, Task taskMakingChange) {
         dependsOn(taskMakingChange);
         filesToCommit.addAll(files);
         descriptions.add(changeDescription);
@@ -24,18 +24,18 @@ public class GitCommitTask extends ShipkitExecTask {
 
     public List<String> getFiles() {
         List<String> result = new ArrayList<String>();
-        for(File file : filesToCommit){
+        for (File file : filesToCommit) {
             result.add(file.getAbsolutePath());
         }
         return result;
     }
 
-    public String getAggregatedCommitMessage(){
+    public String getAggregatedCommitMessage() {
         StringBuilder result = new StringBuilder();
-        for(String msg : descriptions){
+        for (String msg : descriptions) {
             result.append(msg).append(" + ");
         }
-        if(!descriptions.isEmpty()){
+        if (!descriptions.isEmpty()) {
             result.delete(result.length() - 3, result.length());
         }
         return result.toString();

--- a/src/main/groovy/org/shipkit/internal/gradle/git/GitCommitTask.java
+++ b/src/main/groovy/org/shipkit/internal/gradle/git/GitCommitTask.java
@@ -1,25 +1,70 @@
 package org.shipkit.internal.gradle.git;
 
+import org.gradle.api.DefaultTask;
 import org.gradle.api.Task;
-import org.shipkit.gradle.exec.ShipkitExecTask;
+import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.SkipWhenEmpty;
+import org.gradle.api.tasks.TaskAction;
+import org.shipkit.gradle.exec.ExecCommand;
+import org.shipkit.internal.gradle.exec.ShipkitExec;
+import org.shipkit.internal.gradle.util.GitUtil;
 
 import java.io.File;
 import java.util.ArrayList;
+import java.util.Collection;
+import java.util.LinkedList;
 import java.util.List;
+
+import static org.shipkit.internal.gradle.exec.ExecCommandFactory.execCommand;
 
 /**
  * Commits all changes registered with {@link GitCommitTask#addChange} method
  * Commit message is concatenated from all descriptions of registered changes
  */
-public class GitCommitTask extends ShipkitExecTask {
+public class GitCommitTask extends DefaultTask {
 
-    private List<File> filesToCommit = new ArrayList<File>();
+    @Input @SkipWhenEmpty private List<File> filesToCommit = new ArrayList<File>();
     private List<String> descriptions = new ArrayList<String>();
+
+    @Input String gitUserName;
+    @Input String gitUserEmail;
+    @Input String commitMessagePostfix;
 
     public void addChange(List<File> files, String changeDescription, Task taskMakingChange) {
         dependsOn(taskMakingChange);
         filesToCommit.addAll(files);
         descriptions.add(changeDescription);
+    }
+
+    public String getGitUserName() {
+        return gitUserName;
+    }
+
+    public void setGitUserName(String gitUserName) {
+        this.gitUserName = gitUserName;
+    }
+
+    public String getGitUserEmail() {
+        return gitUserEmail;
+    }
+
+    public void setGitUserEmail(String gitUserEmail) {
+        this.gitUserEmail = gitUserEmail;
+    }
+
+    public String getCommitMessagePostfix() {
+        return commitMessagePostfix;
+    }
+
+    public void setCommitMessagePostfix(String commitMessagePostfix) {
+        this.commitMessagePostfix = commitMessagePostfix;
+    }
+
+    @TaskAction public void commit() {
+        Collection<ExecCommand> commands = new LinkedList<ExecCommand>();
+        commands.add(execCommand("Adding files to git", getAddCommand(getFiles())));
+        commands.add(execCommand("Performing git commit", getCommitCommand(getAggregatedCommitMessage())));
+        new ShipkitExec().execCommands(commands, getProject());
     }
 
     public List<String> getFiles() {
@@ -39,5 +84,24 @@ public class GitCommitTask extends ShipkitExecTask {
             result.delete(result.length() - 3, result.length());
         }
         return result.toString();
+    }
+
+    private List<String> getAddCommand(List<String> files) {
+        List<String> args = new ArrayList<String>();
+        args.add("git");
+        args.add("add");
+        args.addAll(files);
+        return args;
+    }
+
+    private List<String> getCommitCommand(String aggregatedCommitMsg) {
+        List<String> args = new ArrayList<String>();
+        args.add("git");
+        args.add("commit");
+        args.add("--author");
+        args.add(GitUtil.getGitGenericUserNotation(this.gitUserName, this.gitUserEmail));
+        args.add("-m");
+        args.add(GitUtil.getCommitMessage(aggregatedCommitMsg, this.commitMessagePostfix));
+        return args;
     }
 }

--- a/src/main/groovy/org/shipkit/internal/gradle/git/GitPlugin.java
+++ b/src/main/groovy/org/shipkit/internal/gradle/git/GitPlugin.java
@@ -6,6 +6,7 @@ import org.gradle.api.Project;
 import org.gradle.api.Task;
 import org.gradle.api.tasks.Exec;
 import org.shipkit.gradle.configuration.ShipkitConfiguration;
+import org.shipkit.gradle.git.GitCommitTask;
 import org.shipkit.gradle.git.GitPushTask;
 import org.shipkit.gradle.git.IdentifyGitBranchTask;
 import org.shipkit.internal.gradle.configuration.ShipkitConfigurationPlugin;

--- a/src/main/groovy/org/shipkit/internal/gradle/git/GitPlugin.java
+++ b/src/main/groovy/org/shipkit/internal/gradle/git/GitPlugin.java
@@ -44,7 +44,6 @@ public class GitPlugin implements Plugin<Project> {
     static final String GIT_TAG_TASK = "gitTag";
     public static final String GIT_PUSH_TASK = "gitPush";
     public static final String PERFORM_GIT_PUSH_TASK = "performGitPush";
-    static final String WRITE_TOKEN_ENV = "GH_WRITE_TOKEN";
     public static final String GIT_COMMIT_TASK = "gitCommit";
 
     public void apply(final Project project) {

--- a/src/main/groovy/org/shipkit/internal/gradle/git/GitPush.java
+++ b/src/main/groovy/org/shipkit/internal/gradle/git/GitPush.java
@@ -39,7 +39,7 @@ public class GitPush {
     public static void setPushUrl(GitPushTask pushTask, ShipkitConfiguration conf) {
         String ghUser = conf.getGitHub().getWriteAuthUser();
         String ghRepo = conf.getGitHub().getRepository();
-        String writeToken = conf.getGitHub().getWriteAuthToken();
+        String writeToken = conf.getLenient().getGitHub().getWriteAuthToken();
         setPushUrl(pushTask, writeToken, ghUser, ghRepo);
     }
 
@@ -49,7 +49,7 @@ public class GitPush {
             pushTask.setUrl(url);
             pushTask.setSecretValue(writeToken);
         } else {
-            LOG.lifecycle("  'git push' does not use GitHub write token because it was not specified.");
+            LOG.lifecycle("  'git push' does not use GitHub auth token because it was not specified.");
             String url = MessageFormat.format("https://github.com/{0}.git", ghRepo);
             pushTask.setUrl(url);
         }

--- a/src/main/groovy/org/shipkit/internal/gradle/git/tasks/GitCommitImpl.java
+++ b/src/main/groovy/org/shipkit/internal/gradle/git/tasks/GitCommitImpl.java
@@ -17,8 +17,10 @@ public class GitCommitImpl {
 
     public void commit(GitCommitTask task) {
         Collection<ExecCommand> commands = new LinkedList<ExecCommand>();
-        commands.add(execCommand("Adding files to git", getAddCommand(task.getFilesToCommit())));
-        commands.add(execCommand("Performing git commit", getCommitCommand(task)));
+        commands.add(execCommand("Adding files to git",
+            getAddCommand(task.getFilesToCommit())));
+        commands.add(execCommand("Performing git commit",
+            getCommitCommand(task.getGitUserName(), task.getGitUserEmail(), task.getDescriptions(), task.getCommitMessagePostfix())));
         new ShipkitExec().execCommands(commands, task.getProject());
     }
 
@@ -43,14 +45,15 @@ public class GitCommitImpl {
         return args;
     }
 
-    private List<String> getCommitCommand(GitCommitTask task) {
+    static List<String> getCommitCommand(String gitUserName, String gitUserEmail,
+                                         List<String> descriptions, String commitMessagePostfix) {
         List<String> args = new ArrayList<String>();
         args.add("git");
         args.add("commit");
         args.add("--author");
-        args.add(GitUtil.getGitGenericUserNotation(task.getGitUserName(), task.getGitUserEmail()));
+        args.add(GitUtil.getGitGenericUserNotation(gitUserName, gitUserEmail));
         args.add("-m");
-        args.add(GitUtil.getCommitMessage(getAggregatedCommitMessage(task.getDescriptions()), task.getCommitMessagePostfix()));
+        args.add(GitUtil.getCommitMessage(getAggregatedCommitMessage(descriptions), commitMessagePostfix));
         return args;
     }
 }

--- a/src/main/groovy/org/shipkit/internal/gradle/git/tasks/GitCommitImpl.java
+++ b/src/main/groovy/org/shipkit/internal/gradle/git/tasks/GitCommitImpl.java
@@ -1,0 +1,56 @@
+package org.shipkit.internal.gradle.git.tasks;
+
+import org.shipkit.gradle.exec.ExecCommand;
+import org.shipkit.gradle.git.GitCommitTask;
+import org.shipkit.internal.gradle.exec.ShipkitExec;
+import org.shipkit.internal.gradle.util.GitUtil;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.LinkedList;
+import java.util.List;
+
+import static org.shipkit.internal.gradle.exec.ExecCommandFactory.execCommand;
+
+public class GitCommitImpl {
+
+    public void commit(GitCommitTask task) {
+        Collection<ExecCommand> commands = new LinkedList<ExecCommand>();
+        commands.add(execCommand("Adding files to git", getAddCommand(task.getFilesToCommit())));
+        commands.add(execCommand("Performing git commit", getCommitCommand(task)));
+        new ShipkitExec().execCommands(commands, task.getProject());
+    }
+
+    static String getAggregatedCommitMessage(List<String> descriptions) {
+        StringBuilder result = new StringBuilder();
+        for (String msg : descriptions) {
+            result.append(msg).append(" + ");
+        }
+        if (!descriptions.isEmpty()) {
+            result.delete(result.length() - 3, result.length());
+        }
+        return result.toString();
+    }
+
+    static List<String> getAddCommand(List<File> files) {
+        List<String> args = new ArrayList<String>();
+        args.add("git");
+        args.add("add");
+        for (File file : files) {
+            args.add(file.getAbsolutePath());
+        }
+        return args;
+    }
+
+    private List<String> getCommitCommand(GitCommitTask task) {
+        List<String> args = new ArrayList<String>();
+        args.add("git");
+        args.add("commit");
+        args.add("--author");
+        args.add(GitUtil.getGitGenericUserNotation(task.getGitUserName(), task.getGitUserEmail()));
+        args.add("-m");
+        args.add(GitUtil.getCommitMessage(getAggregatedCommitMessage(task.getDescriptions()), task.getCommitMessagePostfix()));
+        return args;
+    }
+}

--- a/src/main/groovy/org/shipkit/internal/gradle/release/tasks/ReleaseNeeded.java
+++ b/src/main/groovy/org/shipkit/internal/gradle/release/tasks/ReleaseNeeded.java
@@ -21,7 +21,7 @@ public class ReleaseNeeded {
     }
 
     public boolean releaseNeeded(ReleaseNeededTask task, EnvVariables envVariables) {
-        boolean skipEnvVariable = envVariables.getenv(SKIP_RELEASE_ENV) != null;
+        boolean skipEnvVariable = envVariables.getNonEmptyEnv(SKIP_RELEASE_ENV) != null;
         LOG.lifecycle("  Environment variable {} present: {}", SKIP_RELEASE_ENV, skipEnvVariable);
 
         boolean commitMessageEmpty = task.getCommitMessage() == null || task.getCommitMessage().trim().isEmpty();

--- a/src/main/groovy/org/shipkit/internal/gradle/util/GitUtil.java
+++ b/src/main/groovy/org/shipkit/internal/gradle/util/GitUtil.java
@@ -12,8 +12,8 @@ public class GitUtil {
      * Returns Git generic user notation based on settings, for example:
      * "Mockito Release Tools &lt;mockito.release.tools@gmail.com&gt;"
      */
-    public static String getGitGenericUserNotation(ShipkitConfiguration conf) {
-        return conf.getGit().getUser() + " <" + conf.getGit().getEmail() + ">";
+    public static String getGitGenericUserNotation(String gitUserName, String gitUserEmail) {
+        return gitUserName + " <" + gitUserEmail + ">";
     }
 
     /**
@@ -26,11 +26,10 @@ public class GitUtil {
     /**
      * Returns Git commit message based on release configuration and the given message
      */
-    public static String getCommitMessage(ShipkitConfiguration conf, String message) {
-        String postfix = conf.getGit().getCommitMessagePostfix();
-        if (postfix.isEmpty()) {
+    public static String getCommitMessage(String message, String commitMessagePostfix) {
+        if (commitMessagePostfix.isEmpty()) {
             return message;
         }
-        return message + " " + postfix;
+        return message + " " + commitMessagePostfix;
     }
 }

--- a/src/main/groovy/org/shipkit/internal/gradle/versionupgrade/CreatePullRequest.java
+++ b/src/main/groovy/org/shipkit/internal/gradle/versionupgrade/CreatePullRequest.java
@@ -19,7 +19,7 @@ class CreatePullRequest {
             LOG.lifecycle("  Skipping pull request creation due to dryRun = true");
             return;
         }
-
+        LOG.lifecycle("  [INCUBATING] creating pull requests in incubating.");
         LOG.lifecycle("  Creating a pull request of title '{}' in repository '{}' between base = '{}' and head = '{}'.",
             getTitle(task), task.getRepositoryUrl(), task.getVersionUpgrade().getBaseBranch(), task.getHeadBranch());
 

--- a/src/main/groovy/org/shipkit/internal/gradle/versionupgrade/CreatePullRequestTask.java
+++ b/src/main/groovy/org/shipkit/internal/gradle/versionupgrade/CreatePullRequestTask.java
@@ -1,6 +1,7 @@
 package org.shipkit.internal.gradle.versionupgrade;
 
 import org.gradle.api.DefaultTask;
+import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.TaskAction;
 import org.shipkit.gradle.configuration.ShipkitConfiguration;
 
@@ -12,10 +13,11 @@ import java.io.IOException;
  */
 public class CreatePullRequestTask extends DefaultTask{
 
-    private String repositoryUrl;
-    private String gitHubApiUrl;
-    private String authToken;
-    private String headBranch;
+    @Input private String repositoryUrl;
+    @Input private String gitHubApiUrl;
+    @Input private String authToken;
+    @Input private String headBranch;
+
     private boolean dryRun;
     private VersionUpgradeConsumerExtension versionUpgrade;
 

--- a/src/main/groovy/org/shipkit/internal/gradle/versionupgrade/VersionUpgradeConsumerPlugin.java
+++ b/src/main/groovy/org/shipkit/internal/gradle/versionupgrade/VersionUpgradeConsumerPlugin.java
@@ -66,7 +66,7 @@ public class VersionUpgradeConsumerPlugin implements Plugin<Project> {
 
     @Override
     public void apply(final Project project) {
-        LOG.lifecycle("Applying VersionUpgradeConsumerPlugin, beware that it's is INCUBATING state, so its API may change!");
+        LOG.lifecycle("  [INCUBATING] VersionUpgradeConsumerPlugin is incubating and its API may change");
         final ShipkitConfiguration conf = project.getPlugins().apply(ShipkitConfigurationPlugin.class).getConfiguration();
 
         versionUpgrade = project.getExtensions().create("versionUpgrade", VersionUpgradeConsumerExtension.class);

--- a/src/main/groovy/org/shipkit/internal/util/EnvVariables.java
+++ b/src/main/groovy/org/shipkit/internal/util/EnvVariables.java
@@ -8,10 +8,6 @@ import org.shipkit.internal.gradle.util.StringUtil;
  */
 public class EnvVariables {
 
-    public String getenv(String name) {
-        return System.getenv(name);
-    }
-
     /**
      * Returns env variable or null if the env variable is empty
      */

--- a/src/test/groovy/org/shipkit/gradle/release/ReleaseNeededTaskTest.groovy
+++ b/src/test/groovy/org/shipkit/gradle/release/ReleaseNeededTaskTest.groovy
@@ -19,7 +19,7 @@ class ReleaseNeededTaskTest extends Specification {
         task.setBranch(branch)
         task.setPullRequest(pullRequest)
         def envVariables = Mock(EnvVariables)
-        envVariables.getenv("SKIP_RELEASE") >> skipEnvVar
+        envVariables.getNonEmptyEnv("SKIP_RELEASE") >> skipEnvVar
         comparisonResults.each {
             def f = File.createTempFile("shipkit-testing", "")
             f << it

--- a/src/test/groovy/org/shipkit/internal/gradle/configuration/ShipkitConfigurationStoreTest.groovy
+++ b/src/test/groovy/org/shipkit/internal/gradle/configuration/ShipkitConfigurationStoreTest.groovy
@@ -1,0 +1,42 @@
+package org.shipkit.internal.gradle.configuration
+
+import org.gradle.api.GradleException
+import org.shipkit.internal.util.EnvVariables
+import spock.lang.Specification
+
+class ShipkitConfigurationStoreTest extends Specification {
+
+    def envVariables = Mock(EnvVariables)
+    def store = new ShipkitConfigurationStore([:], envVariables, false)
+
+    def "should use env variable if value not set explicitly"() {
+        given:
+        envVariables.getNonEmptyEnv("ENV") >> "some value"
+
+        expect:
+        store.getValue("foo", "ENV", "Error!") == "some value"
+    }
+
+    def "should override env variable value set explicitly"() {
+        given:
+        envVariables.getNonEmptyEnv("ENV") >> "some value"
+        store.put("foo", "other value");
+
+        expect:
+        store.getValue("foo", "ENV", "Error!") == "other value"
+    }
+
+    def "should throw exception if value is not present"() {
+        when:
+        store.getValue("foo", "ENV", "Error!")
+
+        then:
+        def ex = thrown(GradleException)
+        ex.message == "Error!"
+    }
+
+    def "should return null if lenient and value not present"() {
+        expect:
+        store.lenient.getValue("foo", "ENV", "Error!") == null
+    }
+}

--- a/src/test/groovy/org/shipkit/internal/gradle/configuration/ShipkitConfigurationTest.groovy
+++ b/src/test/groovy/org/shipkit/internal/gradle/configuration/ShipkitConfigurationTest.groovy
@@ -66,7 +66,10 @@ class ShipkitConfigurationTest extends Specification {
     }
 
     def "offers a way to find out if settings are configured"() {
+        conf.git.user = "foo"
+
         expect:
+        conf.lenient.git.user == "foo"
         conf.lenient.gitHub.repository == null
     }
 }

--- a/src/test/groovy/org/shipkit/internal/gradle/configuration/ShipkitConfigurationTest.groovy
+++ b/src/test/groovy/org/shipkit/internal/gradle/configuration/ShipkitConfigurationTest.groovy
@@ -3,7 +3,6 @@ package org.shipkit.internal.gradle.configuration
 import org.gradle.api.GradleException
 import org.shipkit.gradle.configuration.ShipkitConfiguration
 import org.shipkit.internal.gradle.util.team.TeamParser
-import org.shipkit.internal.util.EnvVariables
 import spock.lang.Specification
 import spock.lang.Unroll
 
@@ -38,27 +37,6 @@ class ShipkitConfigurationTest extends Specification {
 
         when: conf.team.contributors = ["ala:"]
         then: thrown(TeamParser.InvalidInput.class)
-    }
-
-    def "should use env variable for writeAuthToken when it's not set explicitly"() {
-        given:
-        def envVariables = Mock(EnvVariables)
-        envVariables.getNonEmptyEnv("GH_WRITE_TOKEN") >> "writeToken"
-        conf = new ShipkitConfiguration(envVariables)
-
-        expect:
-        conf.gitHub.writeAuthToken == "writeToken"
-    }
-
-    def "should override env variable for writeAuthToken"() {
-        given:
-        def envVariables = Mock(EnvVariables)
-        envVariables.getNonEmptyEnv("GH_WRITE_TOKEN") >> "writeToken"
-        conf = new ShipkitConfiguration(envVariables)
-        conf.gitHub.writeAuthToken = "overriddenWriteToken"
-
-        expect:
-        conf.gitHub.writeAuthToken == "overriddenWriteToken"
     }
 
     @Unroll

--- a/src/test/groovy/org/shipkit/internal/gradle/configuration/ShipkitConfigurationTest.groovy
+++ b/src/test/groovy/org/shipkit/internal/gradle/configuration/ShipkitConfigurationTest.groovy
@@ -43,7 +43,7 @@ class ShipkitConfigurationTest extends Specification {
     def "should use env variable for writeAuthToken when it's not set explicitly"() {
         given:
         def envVariables = Mock(EnvVariables)
-        envVariables.getenv("GH_WRITE_TOKEN") >> "writeToken"
+        envVariables.getNonEmptyEnv("GH_WRITE_TOKEN") >> "writeToken"
         conf = new ShipkitConfiguration(envVariables)
 
         expect:
@@ -53,7 +53,7 @@ class ShipkitConfigurationTest extends Specification {
     def "should override env variable for writeAuthToken"() {
         given:
         def envVariables = Mock(EnvVariables)
-        envVariables.getenv("GH_WRITE_TOKEN") >> "writeToken"
+        envVariables.getNonEmptyEnv("GH_WRITE_TOKEN") >> "writeToken"
         conf = new ShipkitConfiguration(envVariables)
         conf.gitHub.writeAuthToken = "overriddenWriteToken"
 

--- a/src/test/groovy/org/shipkit/internal/gradle/git/GitCommitTaskTest.groovy
+++ b/src/test/groovy/org/shipkit/internal/gradle/git/GitCommitTaskTest.groovy
@@ -1,52 +1,23 @@
 package org.shipkit.internal.gradle.git
 
-import org.apache.commons.lang.RandomStringUtils
-import org.gradle.api.DefaultTask
-import org.gradle.api.Task
 import org.gradle.testfixtures.ProjectBuilder
 import org.shipkit.gradle.git.GitCommitTask
 import spock.lang.Specification
 
-import static java.io.File.separator
-
 class GitCommitTaskTest extends Specification {
 
-    def tasksContainer = new ProjectBuilder().build().tasks
-    def gitCommitTask = tasksContainer.create("gitCommitTask", GitCommitTask)
+    def project = new ProjectBuilder().build()
 
-    def "aggregated commit message is empty when no changes registered"() {
-        expect:
-        gitCommitTask.aggregatedCommitMessage == ""
-    }
+    def "enables adding changes to commit"() {
+        def f = new File("foo")
+        def task = project.tasks.create("task")
+        def gitCommit = project.tasks.create("foo", GitCommitTask)
 
-    def "list of files is empty when no changes registered"() {
-        expect:
-        gitCommitTask.files.isEmpty()
-    }
-
-    def "aggregates message correctly"() {
         when:
-        gitCommitTask.addChange([], "release notes updated", anyTask())
-        gitCommitTask.addChange([], "version bumped", anyTask())
+        gitCommit.addChange([f], "description", task)
 
         then:
-        gitCommitTask.aggregatedCommitMessage == "release notes updated + version bumped"
-    }
-
-    def "aggregates files correctly"() {
-        given:
-        def basePath = new File("").absolutePath
-        when:
-        gitCommitTask.addChange([new File("test"), new File("test2")], "", anyTask())
-        gitCommitTask.addChange([new File("test3")], "", anyTask())
-
-        then:
-        gitCommitTask.files == [basePath + separator + "test",
-                                basePath + separator + "test2",
-                                basePath + separator + "test3"]
-    }
-
-    Task anyTask() {
-        return tasksContainer.create(RandomStringUtils.random(15), DefaultTask)
+        gitCommit.descriptions == ["description"]
+        gitCommit.filesToCommit == [f]
     }
 }

--- a/src/test/groovy/org/shipkit/internal/gradle/git/GitCommitTaskTest.groovy
+++ b/src/test/groovy/org/shipkit/internal/gradle/git/GitCommitTaskTest.groovy
@@ -4,6 +4,7 @@ import org.apache.commons.lang.RandomStringUtils
 import org.gradle.api.DefaultTask
 import org.gradle.api.Task
 import org.gradle.testfixtures.ProjectBuilder
+import org.shipkit.gradle.git.GitCommitTask
 import spock.lang.Specification
 
 import static java.io.File.separator

--- a/src/test/groovy/org/shipkit/internal/gradle/git/GitPushTest.groovy
+++ b/src/test/groovy/org/shipkit/internal/gradle/git/GitPushTest.groovy
@@ -9,20 +9,14 @@ import static org.shipkit.internal.gradle.git.GitPush.setPushUrl
 
 class GitPushTest extends Specification {
 
-    ShipkitConfiguration conf
-    ShipkitConfiguration.GitHub gitHubConf
-
-    void setup(){
-        conf = Mock(ShipkitConfiguration)
-        gitHubConf = Mock(ShipkitConfiguration.GitHub)
-        conf.getGitHub() >> gitHubConf
-    }
+    def conf = new ShipkitConfiguration()
 
     def "push url with write token"() {
-        GitPushTask task = Mock(GitPushTask)
-        gitHubConf.getWriteAuthUser() >> "dummy"
-        gitHubConf.getWriteAuthToken() >> "secret"
-        gitHubConf.getRepository() >> "repo"
+        def task = Mock(GitPushTask)
+
+        conf.gitHub.writeAuthUser = "dummy"
+        conf.gitHub.writeAuthToken = "secret"
+        conf.gitHub.repository = "repo"
 
         when:
         setPushUrl(task, conf)
@@ -34,8 +28,7 @@ class GitPushTest extends Specification {
 
     def "push url without write token"() {
         GitPushTask task = Mock(GitPushTask)
-        gitHubConf.getRepository() >> "repo"
-        gitHubConf.getWriteAuthToken() >> null
+        conf.gitHub.repository = "repo"
 
         when:
         setPushUrl(task, conf)

--- a/src/test/groovy/org/shipkit/internal/gradle/git/GitPushTest.groovy
+++ b/src/test/groovy/org/shipkit/internal/gradle/git/GitPushTest.groovy
@@ -28,10 +28,9 @@ class GitPushTest extends Specification {
 
     def "push url without write token"() {
         GitPushTask task = Mock(GitPushTask)
-        conf.gitHub.repository = "repo"
 
         when:
-        setPushUrl(task, conf)
+        setPushUrl(task, null, "joe", "repo")
 
         then:
         1 * task.setUrl("https://github.com/repo.git")

--- a/src/test/groovy/org/shipkit/internal/gradle/git/tasks/GitCommitImplTest.groovy
+++ b/src/test/groovy/org/shipkit/internal/gradle/git/tasks/GitCommitImplTest.groovy
@@ -4,6 +4,7 @@ import spock.lang.Specification
 
 import static org.shipkit.internal.gradle.git.tasks.GitCommitImpl.getAddCommand
 import static org.shipkit.internal.gradle.git.tasks.GitCommitImpl.getAggregatedCommitMessage
+import static org.shipkit.internal.gradle.git.tasks.GitCommitImpl.getCommitCommand
 
 class GitCommitImplTest extends Specification {
 
@@ -19,5 +20,11 @@ class GitCommitImplTest extends Specification {
 
         expect:
         getAddCommand([f1, f2]) == ["git", "add", f1.absolutePath, f2.absolutePath]
+    }
+
+    def "git commit command"() {
+        expect:
+        getCommitCommand("joe", "doe", ["desc"], "by shipkit") ==
+            ["git", "commit", "--author", "joe <doe>", "-m", "desc by shipkit"]
     }
 }

--- a/src/test/groovy/org/shipkit/internal/gradle/git/tasks/GitCommitImplTest.groovy
+++ b/src/test/groovy/org/shipkit/internal/gradle/git/tasks/GitCommitImplTest.groovy
@@ -1,0 +1,23 @@
+package org.shipkit.internal.gradle.git.tasks
+
+import spock.lang.Specification
+
+import static org.shipkit.internal.gradle.git.tasks.GitCommitImpl.getAddCommand
+import static org.shipkit.internal.gradle.git.tasks.GitCommitImpl.getAggregatedCommitMessage
+
+class GitCommitImplTest extends Specification {
+
+    def "aggregates message correctly"() {
+        expect:
+        getAggregatedCommitMessage([]) == ""
+        getAggregatedCommitMessage(["release notes updated", "version bumped"]) == "release notes updated + version bumped"
+    }
+
+    def "git add command"() {
+        def f1 = new File("f1")
+        def f2 = new File("f2")
+
+        expect:
+        getAddCommand([f1, f2]) == ["git", "add", f1.absolutePath, f2.absolutePath]
+    }
+}

--- a/src/test/groovy/org/shipkit/internal/gradle/notes/ReleaseNotesPluginTest.groovy
+++ b/src/test/groovy/org/shipkit/internal/gradle/notes/ReleaseNotesPluginTest.groovy
@@ -1,6 +1,6 @@
 package org.shipkit.internal.gradle.notes
 
-import org.shipkit.internal.gradle.git.GitCommitTask
+import org.shipkit.gradle.git.GitCommitTask
 import org.shipkit.internal.gradle.git.GitPlugin
 import testutil.PluginSpecification
 

--- a/src/test/groovy/org/shipkit/internal/gradle/notes/ReleaseNotesPluginTest.groovy
+++ b/src/test/groovy/org/shipkit/internal/gradle/notes/ReleaseNotesPluginTest.groovy
@@ -20,8 +20,8 @@ class ReleaseNotesPluginTest extends PluginSpecification {
 
         then:
         GitCommitTask gitCommitTask = project.tasks.getByName(GitPlugin.GIT_COMMIT_TASK)
-        gitCommitTask.files.contains(project.file("docs/release-notes.md").absolutePath)
-        gitCommitTask.aggregatedCommitMessage.contains("release notes updated")
+        gitCommitTask.filesToCommit.contains(project.file("docs/release-notes.md"))
+        gitCommitTask.descriptions.contains("release notes updated")
     }
 
 }

--- a/src/test/groovy/org/shipkit/internal/gradle/util/GitUtilTest.groovy
+++ b/src/test/groovy/org/shipkit/internal/gradle/util/GitUtilTest.groovy
@@ -18,22 +18,13 @@ class GitUtilTest extends Specification {
     }
 
     def "generic user notation" () {
-        def project = new ProjectBuilder().build()
-        project.version = "1.0.0"
-        conf.git.user = "shipkit-bot"
-        conf.git.email = "shipkit.org@gmail.com"
-
-        GitUtil.getGitGenericUserNotation(conf)
-
         expect:
-        GitUtil.getGitGenericUserNotation(conf) == "shipkit-bot <shipkit.org@gmail.com>"
+        GitUtil.getGitGenericUserNotation("shipkit-bot", "shipkit.org@gmail.com") == "shipkit-bot <shipkit.org@gmail.com>"
     }
 
     def "commit message" () {
-        conf.git.commitMessagePostfix = postfix
-
         expect:
-        GitUtil.getCommitMessage(conf, info) == message
+        GitUtil.getCommitMessage(info, postfix) == message
 
         where:
         info  | postfix     | message

--- a/src/test/groovy/org/shipkit/internal/gradle/version/VersioningPluginTest.groovy
+++ b/src/test/groovy/org/shipkit/internal/gradle/version/VersioningPluginTest.groovy
@@ -1,8 +1,8 @@
 package org.shipkit.internal.gradle.version
 
+import org.shipkit.gradle.git.GitCommitTask
 import org.shipkit.gradle.version.BumpVersionFileTask
 import org.shipkit.internal.gradle.configuration.ShipkitConfigurationPlugin
-import org.shipkit.internal.gradle.git.GitCommitTask
 import org.shipkit.internal.gradle.git.GitPlugin
 import org.shipkit.internal.version.VersionInfo
 import testutil.PluginSpecification

--- a/src/test/groovy/org/shipkit/internal/gradle/version/VersioningPluginTest.groovy
+++ b/src/test/groovy/org/shipkit/internal/gradle/version/VersioningPluginTest.groovy
@@ -58,9 +58,9 @@ class VersioningPluginTest extends PluginSpecification {
         project.plugins.apply(VersioningPlugin)
 
         then:
-        GitCommitTask gitCommitTask = project.tasks.getByName(GitPlugin.GIT_COMMIT_TASK)
-        gitCommitTask.files.contains(project.file(VersioningPlugin.VERSION_FILE_NAME).absolutePath)
-        gitCommitTask.aggregatedCommitMessage.contains("0.9.0 release (previous 0.8.114)")
+        GitCommitTask commit = project.tasks.getByName(GitPlugin.GIT_COMMIT_TASK)
+        commit.filesToCommit.contains(project.file(VersioningPlugin.VERSION_FILE_NAME))
+        commit.descriptions[0].contains("0.9.0 release (previous 0.8.114)")
     }
 
     def "should skip previous version in release commit message if not available"() {
@@ -75,10 +75,10 @@ class VersioningPluginTest extends PluginSpecification {
         project.plugins.apply(VersioningPlugin)
 
         then:
-        GitCommitTask gitCommitTask = project.tasks.getByName(GitPlugin.GIT_COMMIT_TASK)
-        gitCommitTask.files.contains(project.file(VersioningPlugin.VERSION_FILE_NAME).absolutePath)
-        gitCommitTask.aggregatedCommitMessage.contains("0.9.0 release")
-        !gitCommitTask.aggregatedCommitMessage.contains("previous")
+        GitCommitTask commit = project.tasks.getByName(GitPlugin.GIT_COMMIT_TASK)
+        commit.filesToCommit.contains(project.file(VersioningPlugin.VERSION_FILE_NAME))
+        commit.descriptions[0].contains("0.9.0 release")
+        !commit.descriptions[0].contains("previous")
     }
 
     @Override

--- a/src/test/groovy/org/shipkit/internal/gradle/versionupgrade/VersionUpgradeConsumerPluginTest.groovy
+++ b/src/test/groovy/org/shipkit/internal/gradle/versionupgrade/VersionUpgradeConsumerPluginTest.groovy
@@ -7,6 +7,10 @@ import testutil.PluginSpecification
 
 class VersionUpgradeConsumerPluginTest extends PluginSpecification {
 
+    def setup() {
+        conf.gitHub.writeAuthToken = "secret"
+    }
+
     def "should initialize VersionUpgradeConsumerPlugin correctly and with default values"() {
         when:
         def versionUpgrade = project.plugins.apply(VersionUpgradeConsumerPlugin).versionUpgrade


### PR DESCRIPTION
 - pushed complexity out of public type to an internal type (ShipkitConfiguration -> ShipkitConfigurationStore, GitCommitTask -> GitCommitImpl)
 - moved GitCommitTask to the public API and made it more robust, easier to use. Updated documentation and tests.