### PR TITLE
Plugin-publish-plugin version upgraded

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,7 +36,7 @@ dependencies {
 
     compile "com.github.cliftonlabs:json-simple:2.1.2"
     compile 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.7.3'
-    compile "com.gradle.publish:plugin-publish-plugin:0.9.6"
+    compile "com.gradle.publish:plugin-publish-plugin:0.9.7"
     compile 'com.googlecode.java-diff-utils:diffutils:1.3.0'
 
     testCompile("org.spockframework:spock-core:1.1-groovy-2.4") {


### PR DESCRIPTION
Since 0.9.14 (inclusive) shipkit upload to gradle plugins doesn't work. It seems that there may be an issue with plugin-publish-plugin version, according to https://discuss.gradle.org/t/published-plugin-not-found-404/23565. 