### PR TITLE
More clean up before 1.0

### DIFF
--- a/src/main/groovy/org/shipkit/internal/gradle/configuration/ShipkitConfigurationPlugin.java
+++ b/src/main/groovy/org/shipkit/internal/gradle/configuration/ShipkitConfigurationPlugin.java
@@ -3,14 +3,11 @@ package org.shipkit.internal.gradle.configuration;
 import org.gradle.api.Action;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
-import org.gradle.api.logging.Logger;
-import org.gradle.api.logging.Logging;
 import org.gradle.api.plugins.ObjectConfigurationAction;
-import org.shipkit.internal.gradle.git.GitRemoteOriginPlugin;
-import org.shipkit.internal.gradle.init.InitPlugin;
 import org.shipkit.gradle.configuration.ShipkitConfiguration;
+import org.shipkit.internal.gradle.init.InitPlugin;
 import org.shipkit.internal.gradle.version.VersioningPlugin;
-import org.shipkit.internal.version.VersionInfo;
+import org.shipkit.version.VersionInfo;
 
 import java.io.File;
 

--- a/src/main/groovy/org/shipkit/internal/gradle/notes/ReleaseNotesPlugin.java
+++ b/src/main/groovy/org/shipkit/internal/gradle/notes/ReleaseNotesPlugin.java
@@ -12,7 +12,7 @@ import org.shipkit.internal.gradle.contributors.github.GitHubContributorsPlugin;
 import org.shipkit.internal.gradle.git.GitPlugin;
 import org.shipkit.internal.gradle.util.TaskMaker;
 import org.shipkit.internal.gradle.version.VersioningPlugin;
-import org.shipkit.internal.version.VersionInfo;
+import org.shipkit.version.VersionInfo;
 
 import java.io.File;
 

--- a/src/main/groovy/org/shipkit/internal/gradle/version/VersioningPlugin.java
+++ b/src/main/groovy/org/shipkit/internal/gradle/version/VersioningPlugin.java
@@ -32,12 +32,15 @@ import static java.util.Collections.singletonList;
  *     of type {@link VersionInfo} that contains version information</li>
  * </ul>
  *
+ * Added behavior:
+ *
+ * <ul>
+ *     <li>plugin loads 'version.properties' file to identify the version to build</li>
+ *     <li>if 'version.properties' does not exist, the plugin uses project version as declared in build.gradle file</li>
+ *     <li>'bumpVersionFile' task participates in 'gitCommit' task if {@link GitPlugin} is also applied</li>
+ * </ul>
+ *
  * Also, the plugin configures all projects' version property to the value specified in "version.properties"
- *
- * BEWARE! If version.properties doesn't exists, this plugin will create it automatically and set
- * version value to project.version
- *
- * Plugin adds bumped version changes if {@link GitPlugin} applied
  */
 public class VersioningPlugin implements Plugin<Project> {
 

--- a/src/main/groovy/org/shipkit/internal/gradle/version/VersioningPlugin.java
+++ b/src/main/groovy/org/shipkit/internal/gradle/version/VersioningPlugin.java
@@ -10,7 +10,7 @@ import org.shipkit.internal.gradle.git.GitPlugin;
 import org.shipkit.internal.gradle.util.StringUtil;
 import org.shipkit.internal.gradle.util.TaskMaker;
 import org.shipkit.internal.version.Version;
-import org.shipkit.internal.version.VersionInfo;
+import org.shipkit.version.VersionInfo;
 
 import java.io.File;
 

--- a/src/main/groovy/org/shipkit/internal/gradle/version/tasks/BumpVersionFile.java
+++ b/src/main/groovy/org/shipkit/internal/gradle/version/tasks/BumpVersionFile.java
@@ -4,7 +4,7 @@ import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
 import org.shipkit.gradle.version.BumpVersionFileTask;
 import org.shipkit.internal.version.Version;
-import org.shipkit.internal.version.VersionInfo;
+import org.shipkit.version.VersionInfo;
 
 public class BumpVersionFile {
 

--- a/src/main/groovy/org/shipkit/internal/version/DefaultVersionInfo.java
+++ b/src/main/groovy/org/shipkit/internal/version/DefaultVersionInfo.java
@@ -2,6 +2,7 @@ package org.shipkit.internal.version;
 
 import org.shipkit.internal.gradle.util.StringUtil;
 import org.shipkit.internal.notes.util.IOUtil;
+import org.shipkit.version.VersionInfo;
 
 import java.io.File;
 import java.io.FileReader;

--- a/src/main/groovy/org/shipkit/internal/version/Version.java
+++ b/src/main/groovy/org/shipkit/internal/version/Version.java
@@ -1,5 +1,7 @@
 package org.shipkit.internal.version;
 
+import org.shipkit.version.VersionInfo;
+
 import java.io.File;
 import java.util.LinkedList;
 

--- a/src/main/groovy/org/shipkit/version/VersionInfo.java
+++ b/src/main/groovy/org/shipkit/version/VersionInfo.java
@@ -1,7 +1,7 @@
-package org.shipkit.internal.version;
+package org.shipkit.version;
 
 /**
- * The file that contains version number
+ * Version information, by default backed by 'version.properties' file.
  */
 public interface VersionInfo {
 

--- a/src/test/groovy/org/shipkit/internal/gradle/version/VersioningPluginTest.groovy
+++ b/src/test/groovy/org/shipkit/internal/gradle/version/VersioningPluginTest.groovy
@@ -4,7 +4,7 @@ import org.shipkit.gradle.git.GitCommitTask
 import org.shipkit.gradle.version.BumpVersionFileTask
 import org.shipkit.internal.gradle.configuration.ShipkitConfigurationPlugin
 import org.shipkit.internal.gradle.git.GitPlugin
-import org.shipkit.internal.version.VersionInfo
+import org.shipkit.version.VersionInfo
 import testutil.PluginSpecification
 
 class VersioningPluginTest extends PluginSpecification {


### PR DESCRIPTION
Exposed new public interface: "VersionInfo". Needed because our plugin adds this extension object and users can use it.