### PR TITLE
Small fixes in CreatePullRequest task #302

### DIFF
--- a/src/main/groovy/org/shipkit/internal/gradle/versionupgrade/CreatePullRequest.java
+++ b/src/main/groovy/org/shipkit/internal/gradle/versionupgrade/CreatePullRequest.java
@@ -19,18 +19,20 @@ class CreatePullRequest {
             LOG.lifecycle("  Skipping pull request creation due to dryRun = true");
             return;
         }
+        String headBranch = getHeadBranch(task.getForkRepositoryName(), task.getVersionBranch());
+
         LOG.lifecycle("  [INCUBATING] creating pull requests in incubating.");
         LOG.lifecycle("  Creating a pull request of title '{}' in repository '{}' between base = '{}' and head = '{}'.",
-            getTitle(task), task.getRepositoryName(), task.getVersionUpgrade().getBaseBranch(), task.getHeadBranch());
+            getTitle(task), task.getUpstreamRepositoryName(), task.getVersionUpgrade().getBaseBranch(), headBranch);
 
         String body = "{" +
             "  \"title\": \"" + getTitle(task) + "\"," +
             "  \"body\": \"" + getMessage(task) + "\"," +
-            "  \"head\": \"" + task.getHeadBranch() + "\"," +
+            "  \"head\": \"" + headBranch + "\"," +
             "  \"base\": \"" + task.getVersionUpgrade().getBaseBranch() + "\"" +
             "}";
 
-        gitHubApi.post("/repos/" + task.getRepositoryName() + "/pulls", body);
+        gitHubApi.post("/repos/" + task.getUpstreamRepositoryName() + "/pulls", body);
     }
 
     private String getMessage(CreatePullRequestTask task){
@@ -43,5 +45,13 @@ class CreatePullRequest {
     private String getTitle(CreatePullRequestTask task){
         VersionUpgradeConsumerExtension versionUpgrade = task.getVersionUpgrade();
         return String.format("Version of %s upgraded to %s", versionUpgrade.getDependencyName(), versionUpgrade.getNewVersion());
+    }
+
+    private String getHeadBranch(String forkRepositoryName, String headBranch) {
+        return getUserOfForkRepo(forkRepositoryName) + ":" + headBranch;
+    }
+
+    private String getUserOfForkRepo(String forkRepositoryName){
+        return forkRepositoryName.split("/")[0];
     }
 }

--- a/src/main/groovy/org/shipkit/internal/gradle/versionupgrade/CreatePullRequestTask.java
+++ b/src/main/groovy/org/shipkit/internal/gradle/versionupgrade/CreatePullRequestTask.java
@@ -8,15 +8,21 @@ import org.shipkit.gradle.configuration.ShipkitConfiguration;
 import java.io.IOException;
 
 /**
- * Creates a pull request in {@link CreatePullRequestTask#repositoryName} between
- * {@link VersionUpgradeConsumerExtension#baseBranch} and {@link CreatePullRequestTask#headBranch}
+ * Creates a pull request in {@link CreatePullRequestTask#upstreamRepositoryName} between
+ * {@link VersionUpgradeConsumerExtension#baseBranch} and {@link CreatePullRequestTask#versionBranch} from
+ * {@link CreatePullRequestTask#forkRepositoryName}
+ *
+ * It is assumed that task is performed on fork repository, so {@link CreatePullRequestTask#forkRepositoryName}
+ * is based on origin repo, see {@link org.shipkit.internal.gradle.git.tasks.GitOriginRepoProvider}
+ * and {@link CreatePullRequestTask#upstreamRepositoryName} is based on {@link ShipkitConfiguration.GitHub#getRepository()}
  */
 public class CreatePullRequestTask extends DefaultTask{
 
-    @Input private String repositoryName;
+    @Input private String upstreamRepositoryName;
     @Input private String gitHubApiUrl;
     @Input private String authToken;
-    @Input private String headBranch;
+    @Input private String versionBranch;
+    @Input private String forkRepositoryName;
 
     private boolean dryRun;
     private VersionUpgradeConsumerExtension versionUpgrade;
@@ -29,15 +35,30 @@ public class CreatePullRequestTask extends DefaultTask{
     /**
      * See {@link ShipkitConfiguration.GitHub#getRepository()}
      */
-    public String getRepositoryName() {
-        return repositoryName;
+    public String getUpstreamRepositoryName() {
+        return upstreamRepositoryName;
     }
 
     /**
      * See {@link ShipkitConfiguration.GitHub#getRepository()}
      */
-    public void setRepositoryName(String repositoryName) {
-        this.repositoryName = repositoryName;
+    public void setUpstreamRepositoryName(String upstreamRepositoryName) {
+        this.upstreamRepositoryName = upstreamRepositoryName;
+    }
+
+    /**
+     * It is assumed that this task is performed on fork of the upstream repo, so this value is taken from
+     * git remote origin. See {@link org.shipkit.internal.gradle.git.tasks.GitOriginRepoProvider}
+     */
+    public String getForkRepositoryName() {
+        return forkRepositoryName;
+    }
+
+    /**
+     * See {@link #getForkRepositoryName()}
+     */
+    public void setForkRepositoryName(String forkRepositoryName) {
+        this.forkRepositoryName = forkRepositoryName;
     }
 
     /**
@@ -71,15 +92,15 @@ public class CreatePullRequestTask extends DefaultTask{
     /**
      * Head branch of pull request
      */
-    public String getHeadBranch() {
-        return headBranch;
+    public String getVersionBranch() {
+        return versionBranch;
     }
 
     /**
-     * See {@link #getHeadBranch()}
+     * See {@link #getVersionBranch()}
      */
-    public void setHeadBranch(String headBranch) {
-        this.headBranch = headBranch;
+    public void setVersionBranch(String versionBranch) {
+        this.versionBranch = versionBranch;
     }
 
     public VersionUpgradeConsumerExtension getVersionUpgrade() {

--- a/src/main/groovy/org/shipkit/internal/gradle/versionupgrade/VersionUpgradeConsumerPlugin.java
+++ b/src/main/groovy/org/shipkit/internal/gradle/versionupgrade/VersionUpgradeConsumerPlugin.java
@@ -191,14 +191,15 @@ public class VersionUpgradeConsumerPlugin implements Plugin<Project> {
                 task.mustRunAfter(PUSH_VERSION_UPGRADE);
                 task.setGitHubApiUrl(conf.getGitHub().getApiUrl());
                 task.setDryRun(conf.isDryRun());
-                task.setAuthToken(conf.getGitHub().getWriteAuthToken());
-                task.setHeadBranch(getVersionBranchName(versionUpgrade));
+                task.setAuthToken(conf.getLenient().getGitHub().getWriteAuthToken());
+                task.setVersionBranch(getVersionBranchName(versionUpgrade));
                 task.setVersionUpgrade(versionUpgrade);
+                task.setUpstreamRepositoryName(conf.getGitHub().getRepository());
 
                 gitOriginPlugin.provideOriginTo(task, new RethrowingResultHandler<GitRemoteOriginPlugin.GitOriginAuth>() {
                     @Override
                     public void onSuccess(GitRemoteOriginPlugin.GitOriginAuth result) {
-                        task.setRepositoryName(result.getOriginRepositoryName());
+                        task.setForkRepositoryName(result.getOriginRepositoryName());
                     }
                 });
             }

--- a/src/test/groovy/org/shipkit/internal/gradle/versionupgrade/CreatePullRequestTest.groovy
+++ b/src/test/groovy/org/shipkit/internal/gradle/versionupgrade/CreatePullRequestTest.groovy
@@ -12,8 +12,9 @@ class CreatePullRequestTest extends Specification {
         def createPullRequestTask = tasksContainer.create("createPullRequest", CreatePullRequestTask)
         def versionUpgrade = new VersionUpgradeConsumerExtension(
             baseBranch: "master", dependencyName: "shipkit", newVersion: "0.1.5")
-        createPullRequestTask.setHeadBranch("shipkit-version-upgraded-0.1.5")
-        createPullRequestTask.setRepositoryName("mockito/shipkit-example")
+        createPullRequestTask.setVersionBranch("shipkit-version-upgraded-0.1.5")
+        createPullRequestTask.setUpstreamRepositoryName("mockito/shipkit-example")
+        createPullRequestTask.setForkRepositoryName("wwilk/shipkit-example")
         createPullRequestTask.setVersionUpgrade(versionUpgrade)
         def gitHubApi = Mock(GitHubApi)
 
@@ -26,7 +27,7 @@ class CreatePullRequestTest extends Specification {
                 '  "body": "This pull request was automatically created by Shipkit\'s' +
                             ' \'version-upgrade-customer\' Gradle plugin (http://shipkit.org).' +
                             ' Please merge it so that you are using fresh version of \'shipkit\' dependency.",' +
-                '  "head": "shipkit-version-upgraded-0.1.5",' +
+                '  "head": "wwilk:shipkit-version-upgraded-0.1.5",' +
                 '  "base": "master"}')
     }
 

--- a/src/test/groovy/org/shipkit/internal/gradle/versionupgrade/VersionUpgradeConsumerPluginTest.groovy
+++ b/src/test/groovy/org/shipkit/internal/gradle/versionupgrade/VersionUpgradeConsumerPluginTest.groovy
@@ -135,7 +135,7 @@ class VersionUpgradeConsumerPluginTest extends PluginSpecification {
         given:
         project.extensions.dependency = "org.shipkit:shipkit:1.2.30"
         conf.gitHub.apiUrl = "http://api.com"
-        conf.gitHub.repository = "http://repository.com"
+        conf.gitHub.repository = "mockito/mockito"
         conf.gitHub.writeAuthToken = "writeToken"
 
         when:
@@ -146,6 +146,7 @@ class VersionUpgradeConsumerPluginTest extends PluginSpecification {
         task.gitHubApiUrl == "http://api.com"
         task.authToken == "writeToken"
         task.versionUpgrade == versionUpgrade
-        task.headBranch == "upgrade-shipkit-to-1.2.30"
+        task.versionBranch == "upgrade-shipkit-to-1.2.30"
+        task.upstreamRepositoryName == "mockito/mockito"
     }
 }


### PR DESCRIPTION
I've managed to finally test e2e VersionUpgradeConsumerPlugin. It wasn't possible before due to problems with gradle-plugins upload. 

It turns out that pull request has to be created in upstream repo, but we perform the performVersionUpgrade task on fork repo, so I included it in configuration of the task and fixed execution.