### PR TITLE
VersionUpgradeConsumerPlugin renamed to UpgradeDependencyPlugin

### DIFF
--- a/src/main/groovy/org/shipkit/internal/gradle/git/GitPull.java
+++ b/src/main/groovy/org/shipkit/internal/gradle/git/GitPull.java
@@ -5,6 +5,9 @@ import org.shipkit.internal.exec.DefaultProcessRunner;
 import java.util.LinkedList;
 import java.util.List;
 
+/**
+ * Utility class for configuring git pull task with the correct git pull arguments.
+ */
 public class GitPull {
 
     public void gitPull(GitPullTask task){
@@ -14,7 +17,7 @@ public class GitPull {
     }
 
     /**
-     * Constructs git pull arguments based of the url, rev and dry run
+     * Constructs git pull arguments basing on the url, rev and dry run
      */
     static List<String> gitPullArgs(String url, String rev, boolean dryRun) {
         List<String> args = new LinkedList<String>();

--- a/src/main/groovy/org/shipkit/internal/gradle/git/GitPullTask.java
+++ b/src/main/groovy/org/shipkit/internal/gradle/git/GitPullTask.java
@@ -4,6 +4,13 @@ import org.gradle.api.DefaultTask;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.TaskAction;
 
+/**
+ * Performs git pull operation.
+ * It does not expose the command line parameters when build is executed with '-i' (--info) level.
+ * It masks secret value configured via {@link #setSecretValue(String)} from logging, task output and exception messages.
+ * Replaces secret value with "[SECRET]".
+ * It really helps debugging if we can see the output and logging without exposing secret values like GitHub write auth token.
+ */
 public class GitPullTask extends DefaultTask{
 
     @Input private String url;

--- a/src/main/groovy/org/shipkit/internal/gradle/versionupgrade/CreatePullRequest.java
+++ b/src/main/groovy/org/shipkit/internal/gradle/versionupgrade/CreatePullRequest.java
@@ -43,7 +43,7 @@ class CreatePullRequest {
     }
 
     private String getTitle(CreatePullRequestTask task){
-        VersionUpgradeConsumerExtension versionUpgrade = task.getVersionUpgrade();
+        UpgradeDependencyExtension versionUpgrade = task.getVersionUpgrade();
         return String.format("Version of %s upgraded to %s", versionUpgrade.getDependencyName(), versionUpgrade.getNewVersion());
     }
 

--- a/src/main/groovy/org/shipkit/internal/gradle/versionupgrade/CreatePullRequestTask.java
+++ b/src/main/groovy/org/shipkit/internal/gradle/versionupgrade/CreatePullRequestTask.java
@@ -9,7 +9,7 @@ import java.io.IOException;
 
 /**
  * Creates a pull request in {@link CreatePullRequestTask#upstreamRepositoryName} between
- * {@link VersionUpgradeConsumerExtension#baseBranch} and {@link CreatePullRequestTask#versionBranch} from
+ * {@link UpgradeDependencyExtension#baseBranch} and {@link CreatePullRequestTask#versionBranch} from
  * {@link CreatePullRequestTask#forkRepositoryName}
  *
  * It is assumed that task is performed on fork repository, so {@link CreatePullRequestTask#forkRepositoryName}
@@ -25,7 +25,7 @@ public class CreatePullRequestTask extends DefaultTask{
     @Input private String forkRepositoryName;
 
     private boolean dryRun;
-    private VersionUpgradeConsumerExtension versionUpgrade;
+    private UpgradeDependencyExtension versionUpgrade;
 
     @TaskAction
     public void createPullRequest() throws IOException {
@@ -103,11 +103,11 @@ public class CreatePullRequestTask extends DefaultTask{
         this.versionBranch = versionBranch;
     }
 
-    public VersionUpgradeConsumerExtension getVersionUpgrade() {
+    public UpgradeDependencyExtension getVersionUpgrade() {
         return versionUpgrade;
     }
 
-    public void setVersionUpgrade(VersionUpgradeConsumerExtension versionUpgrade) {
+    public void setVersionUpgrade(UpgradeDependencyExtension versionUpgrade) {
         this.versionUpgrade = versionUpgrade;
     }
 

--- a/src/main/groovy/org/shipkit/internal/gradle/versionupgrade/DependencyNewVersionParser.java
+++ b/src/main/groovy/org/shipkit/internal/gradle/versionupgrade/DependencyNewVersionParser.java
@@ -31,7 +31,7 @@ public class DependencyNewVersionParser {
         return dependencyNewVersion.split(":");
     }
 
-    public void fillVersionUpgradeExtension(VersionUpgradeConsumerExtension versionUpgrade){
+    public void fillVersionUpgradeExtension(UpgradeDependencyExtension versionUpgrade){
         if(dependencyNewVersion != null) {
             if(!isValid()){
                 throw new IllegalArgumentException(

--- a/src/main/groovy/org/shipkit/internal/gradle/versionupgrade/ReplaceVersionTask.java
+++ b/src/main/groovy/org/shipkit/internal/gradle/versionupgrade/ReplaceVersionTask.java
@@ -19,6 +19,7 @@ public class ReplaceVersionTask extends DefaultTask{
     public static final String VERSION_REGEX = "[0-9.]+";
 
     private UpgradeDependencyExtension versionUpgrade;
+    private Boolean buildFileUpdated;
 
     @TaskAction
     public void replaceVersion(){
@@ -30,7 +31,12 @@ public class ReplaceVersionTask extends DefaultTask{
 
         String content = IOUtil.readFully(versionUpgrade.getBuildFile());
         String updatedContent = content.replaceAll(versionPattern, replacement);
-        IOUtil.writeFile(versionUpgrade.getBuildFile().getAbsoluteFile(), updatedContent);
+
+        buildFileUpdated = !content.equals(updatedContent);
+
+        if(buildFileUpdated) {
+            IOUtil.writeFile(versionUpgrade.getBuildFile().getAbsoluteFile(), updatedContent);
+        }
     }
 
     public UpgradeDependencyExtension getVersionUpgrade() {
@@ -39,5 +45,16 @@ public class ReplaceVersionTask extends DefaultTask{
 
     public void setVersionUpgrade(UpgradeDependencyExtension versionUpgrade) {
         this.versionUpgrade = versionUpgrade;
+    }
+
+    /**
+     * Was buildFile updated during the version replacement?
+     * It wasn't when newVersion == previousVersion
+     */
+    public boolean isBuildFileUpdated(){
+        if(buildFileUpdated == null){
+            throw new IllegalStateException("Property 'buildFileUpdated' should not be accessed before 'replaceVersion' task is executed.");
+        }
+        return buildFileUpdated;
     }
 }

--- a/src/main/groovy/org/shipkit/internal/gradle/versionupgrade/ReplaceVersionTask.java
+++ b/src/main/groovy/org/shipkit/internal/gradle/versionupgrade/ReplaceVersionTask.java
@@ -7,10 +7,10 @@ import org.gradle.api.tasks.TaskAction;
 import org.shipkit.internal.notes.util.IOUtil;
 
 /**
- * Replaces version of given dependency with {@link VersionUpgradeConsumerExtension#newVersion}
- * in the given {@link VersionUpgradeConsumerExtension#buildFile}
+ * Replaces version of given dependency with {@link UpgradeDependencyExtension#newVersion}
+ * in the given {@link UpgradeDependencyExtension#buildFile}
  * To replace the dependency this task uses following regex pattern:
- * "{@link VersionUpgradeConsumerExtension#dependencyGroup}:{@link VersionUpgradeConsumerExtension#dependencyName}:{@value VERSION_REGEX}
+ * "{@link UpgradeDependencyExtension#dependencyGroup}:{@link UpgradeDependencyExtension#dependencyName}:{@value VERSION_REGEX}
  */
 public class ReplaceVersionTask extends DefaultTask{
 
@@ -18,7 +18,7 @@ public class ReplaceVersionTask extends DefaultTask{
 
     public static final String VERSION_REGEX = "[0-9.]+";
 
-    private VersionUpgradeConsumerExtension versionUpgrade;
+    private UpgradeDependencyExtension versionUpgrade;
 
     @TaskAction
     public void replaceVersion(){
@@ -33,11 +33,11 @@ public class ReplaceVersionTask extends DefaultTask{
         IOUtil.writeFile(versionUpgrade.getBuildFile().getAbsoluteFile(), updatedContent);
     }
 
-    public VersionUpgradeConsumerExtension getVersionUpgrade() {
+    public UpgradeDependencyExtension getVersionUpgrade() {
         return versionUpgrade;
     }
 
-    public void setVersionUpgrade(VersionUpgradeConsumerExtension versionUpgrade) {
+    public void setVersionUpgrade(UpgradeDependencyExtension versionUpgrade) {
         this.versionUpgrade = versionUpgrade;
     }
 }

--- a/src/main/groovy/org/shipkit/internal/gradle/versionupgrade/UpgradeDependencyExtension.java
+++ b/src/main/groovy/org/shipkit/internal/gradle/versionupgrade/UpgradeDependencyExtension.java
@@ -3,9 +3,9 @@ package org.shipkit.internal.gradle.versionupgrade;
 import java.io.File;
 
 /**
- * Configuration of {@link VersionUpgradeConsumerPlugin}
+ * Configuration of {@link UpgradeDependencyPlugin}
  */
-public class VersionUpgradeConsumerExtension {
+public class UpgradeDependencyExtension {
     private String baseBranch;
     private File buildFile;
     private String newVersion;

--- a/src/main/groovy/org/shipkit/internal/gradle/versionupgrade/UpgradeDependencyPlugin.java
+++ b/src/main/groovy/org/shipkit/internal/gradle/versionupgrade/UpgradeDependencyPlugin.java
@@ -52,7 +52,7 @@ import org.shipkit.internal.util.RethrowingResultHandler;
  *
  *      upgradeDependency{
  *          baseBranch = 'release/2.x'
- *          buildFile = file('gradle.properties')
+ *          buildFile = file('build.gradle')
  *      }
  *
  * and then call it:

--- a/src/main/groovy/org/shipkit/internal/gradle/versionupgrade/UpgradeDependencyPlugin.java
+++ b/src/main/groovy/org/shipkit/internal/gradle/versionupgrade/UpgradeDependencyPlugin.java
@@ -47,21 +47,21 @@ import org.shipkit.internal.util.RethrowingResultHandler;
  *
  * Configure your 'shipkit.gradle' file like here:
  *
- *      apply plugin: 'org.shipkit.version-upgrade-consumer'
+ *      apply plugin: 'org.shipkit.upgrade-dependency'
  *
- *      versionUpgrade{
+ *      upgradeDependency{
  *          baseBranch = 'release/2.x'
  *          buildFile = file('gradle.properties')
  *      }
  *
  * and then call it:
  *
- * ./gradlew performVersionUpgrade -PdependencyNewVersion=org.shipkit:shipkit:1.2.3
+ * ./gradlew performVersionUpgrade -Pdependency=org.shipkit:shipkit:1.2.3
  *
  */
-public class VersionUpgradeConsumerPlugin implements Plugin<Project> {
+public class UpgradeDependencyPlugin implements Plugin<Project> {
 
-    private static final Logger LOG = Logging.getLogger(VersionUpgradeConsumerPlugin.class);
+    private static final Logger LOG = Logging.getLogger(UpgradeDependencyPlugin.class);
 
     public static final String CHECKOUT_BASE_BRANCH = "checkoutBaseBranch";
     public static final String PULL_UPSTREAM = "pullUpstream";
@@ -74,24 +74,24 @@ public class VersionUpgradeConsumerPlugin implements Plugin<Project> {
 
     public static final String DEPENDENCY_PROJECT_PROPERTY = "dependency";
 
-    private VersionUpgradeConsumerExtension versionUpgrade;
+    private UpgradeDependencyExtension upgradeDependencyExtension;
 
     @Override
     public void apply(final Project project) {
-        LOG.lifecycle("  [INCUBATING] VersionUpgradeConsumerPlugin is incubating and its API may change");
+        LOG.lifecycle("  [INCUBATING] UpgradeDependencyPlugin is incubating and its API may change");
         final GitRemoteOriginPlugin gitOriginPlugin = project.getPlugins().apply(GitRemoteOriginPlugin.class);
         final GitAuthPlugin.GitAuth gitAuth = project.getPlugins().apply(GitAuthPlugin.class).getGitAuth();
         final ShipkitConfiguration conf = project.getPlugins().apply(ShipkitConfigurationPlugin.class).getConfiguration();
 
-        versionUpgrade = project.getExtensions().create("versionUpgrade", VersionUpgradeConsumerExtension.class);
+        upgradeDependencyExtension = project.getExtensions().create("upgradeDependency", UpgradeDependencyExtension.class);
 
         // set defaults
-        versionUpgrade.setBuildFile(project.file("build.gradle"));
-        versionUpgrade.setBaseBranch("master");
+        upgradeDependencyExtension.setBuildFile(project.file("build.gradle"));
+        upgradeDependencyExtension.setBaseBranch("master");
 
         String dependency = (String) project.findProperty(DEPENDENCY_PROJECT_PROPERTY);
 
-        new DependencyNewVersionParser(dependency).fillVersionUpgradeExtension(versionUpgrade);
+        new DependencyNewVersionParser(dependency).fillVersionUpgradeExtension(upgradeDependencyExtension);
 
         TaskMaker.task(project, CHECKOUT_BASE_BRANCH, GitCheckOutTask.class, new Action<GitCheckOutTask>() {
             @Override
@@ -101,7 +101,7 @@ public class VersionUpgradeConsumerPlugin implements Plugin<Project> {
                 DeferredConfiguration.deferredConfiguration(project, new Runnable() {
                     @Override
                     public void run() {
-                        task.setRev(versionUpgrade.getBaseBranch());
+                        task.setRev(upgradeDependencyExtension.getBaseBranch());
                     }
                 });
             }
@@ -118,7 +118,7 @@ public class VersionUpgradeConsumerPlugin implements Plugin<Project> {
                 DeferredConfiguration.deferredConfiguration(project, new Runnable() {
                     @Override
                     public void run() {
-                        task.setRev(versionUpgrade.getBaseBranch());
+                        task.setRev(upgradeDependencyExtension.getBaseBranch());
                     }
                 });
 
@@ -135,7 +135,7 @@ public class VersionUpgradeConsumerPlugin implements Plugin<Project> {
             public void execute(final GitCheckOutTask task) {
                 task.setDescription("Creates a new version branch and checks it out.");
                 task.mustRunAfter(PULL_UPSTREAM);
-                task.setRev(getVersionBranchName(versionUpgrade));
+                task.setRev(getVersionBranchName(upgradeDependencyExtension));
                 task.setNewBranch(true);
             }
         });
@@ -145,7 +145,7 @@ public class VersionUpgradeConsumerPlugin implements Plugin<Project> {
             public void execute(final ReplaceVersionTask task) {
                 task.setDescription("Replaces dependency version in config file.");
                 task.mustRunAfter(CHECKOUT_VERSION_BRANCH);
-                task.setVersionUpgrade(versionUpgrade);
+                task.setVersionUpgrade(upgradeDependencyExtension);
             }
         });
 
@@ -158,8 +158,8 @@ public class VersionUpgradeConsumerPlugin implements Plugin<Project> {
                 DeferredConfiguration.deferredConfiguration(project, new Runnable() {
                     @Override
                     public void run() {
-                        String message = String.format("%s version upgraded to %s", versionUpgrade.getDependencyName(), versionUpgrade.getNewVersion());
-                        exec.commandLine("git", "commit", "-m", message, versionUpgrade.getBuildFile());
+                        String message = String.format("%s version upgraded to %s", upgradeDependencyExtension.getDependencyName(), upgradeDependencyExtension.getNewVersion());
+                        exec.commandLine("git", "commit", "-m", message, upgradeDependencyExtension.getBuildFile());
                     }
                 });
             }
@@ -173,7 +173,7 @@ public class VersionUpgradeConsumerPlugin implements Plugin<Project> {
                 task.setSecretValue(gitAuth.getSecretValue());
 
                 task.setDryRun(conf.isDryRun());
-                task.getTargets().add(getVersionBranchName(versionUpgrade));
+                task.getTargets().add(getVersionBranchName(upgradeDependencyExtension));
 
                 gitOriginPlugin.provideOriginTo(task, new RethrowingResultHandler<GitRemoteOriginPlugin.GitOriginAuth>() {
                     @Override
@@ -192,8 +192,8 @@ public class VersionUpgradeConsumerPlugin implements Plugin<Project> {
                 task.setGitHubApiUrl(conf.getGitHub().getApiUrl());
                 task.setDryRun(conf.isDryRun());
                 task.setAuthToken(conf.getLenient().getGitHub().getWriteAuthToken());
-                task.setVersionBranch(getVersionBranchName(versionUpgrade));
-                task.setVersionUpgrade(versionUpgrade);
+                task.setVersionBranch(getVersionBranchName(upgradeDependencyExtension));
+                task.setVersionUpgrade(upgradeDependencyExtension);
                 task.setUpstreamRepositoryName(conf.getGitHub().getRepository());
 
                 gitOriginPlugin.provideOriginTo(task, new RethrowingResultHandler<GitRemoteOriginPlugin.GitOriginAuth>() {
@@ -220,12 +220,12 @@ public class VersionUpgradeConsumerPlugin implements Plugin<Project> {
         });
     }
 
-    private String getVersionBranchName(VersionUpgradeConsumerExtension versionUpgrade){
+    private String getVersionBranchName(UpgradeDependencyExtension versionUpgrade){
         return "upgrade-" + versionUpgrade.getDependencyName() + "-to-" + versionUpgrade.getNewVersion();
     }
 
-    public VersionUpgradeConsumerExtension getVersionUpgrade(){
-        return versionUpgrade;
+    public UpgradeDependencyExtension getUpgradeDependencyExtension(){
+        return upgradeDependencyExtension;
     }
 
 }

--- a/src/main/resources/META-INF/gradle-plugins/org.shipkit.upgrade-dependency.properties
+++ b/src/main/resources/META-INF/gradle-plugins/org.shipkit.upgrade-dependency.properties
@@ -1,0 +1,1 @@
+implementation-class=org.shipkit.internal.gradle.versionupgrade.UpgradeDependencyPlugin

--- a/src/main/resources/META-INF/gradle-plugins/org.shipkit.version-upgrade-consumer.properties
+++ b/src/main/resources/META-INF/gradle-plugins/org.shipkit.version-upgrade-consumer.properties
@@ -1,1 +1,0 @@
-implementation-class=org.shipkit.internal.gradle.versionupgrade.VersionUpgradeConsumerPlugin

--- a/src/test/groovy/org/shipkit/internal/gradle/versionupgrade/CreatePullRequestTest.groovy
+++ b/src/test/groovy/org/shipkit/internal/gradle/versionupgrade/CreatePullRequestTest.groovy
@@ -10,7 +10,7 @@ class CreatePullRequestTest extends Specification {
         given:
         def tasksContainer = new ProjectBuilder().build().tasks
         def createPullRequestTask = tasksContainer.create("createPullRequest", CreatePullRequestTask)
-        def versionUpgrade = new VersionUpgradeConsumerExtension(
+        def versionUpgrade = new UpgradeDependencyExtension(
             baseBranch: "master", dependencyName: "shipkit", newVersion: "0.1.5")
         createPullRequestTask.setVersionBranch("shipkit-version-upgraded-0.1.5")
         createPullRequestTask.setUpstreamRepositoryName("mockito/shipkit-example")

--- a/src/test/groovy/org/shipkit/internal/gradle/versionupgrade/DependencyNewVersionParserTest.groovy
+++ b/src/test/groovy/org/shipkit/internal/gradle/versionupgrade/DependencyNewVersionParserTest.groovy
@@ -11,7 +11,7 @@ class DependencyNewVersionParserTest extends Specification {
         parser = new DependencyNewVersionParser("SHIP-kit_group1:SHIP-kit_parser1:0.1.2")
 
         expect:
-        def versionUpgrade = new VersionUpgradeConsumerExtension()
+        def versionUpgrade = new UpgradeDependencyExtension()
         parser.fillVersionUpgradeExtension(versionUpgrade)
         versionUpgrade.dependencyGroup == "SHIP-kit_group1"
         versionUpgrade.dependencyName == "SHIP-kit_parser1"
@@ -23,7 +23,7 @@ class DependencyNewVersionParserTest extends Specification {
         parser = new DependencyNewVersionParser("1.2.3")
 
         when:
-        parser.fillVersionUpgradeExtension(new VersionUpgradeConsumerExtension())
+        parser.fillVersionUpgradeExtension(new UpgradeDependencyExtension())
 
         then:
         def ex = thrown(IllegalArgumentException)
@@ -36,7 +36,7 @@ class DependencyNewVersionParserTest extends Specification {
         parser = new DependencyNewVersionParser(null)
 
         when:
-        def versionUpgrade = new VersionUpgradeConsumerExtension()
+        def versionUpgrade = new UpgradeDependencyExtension()
         parser.fillVersionUpgradeExtension(versionUpgrade)
 
         then:

--- a/src/test/groovy/org/shipkit/internal/gradle/versionupgrade/ReplaceVersionTaskTest.groovy
+++ b/src/test/groovy/org/shipkit/internal/gradle/versionupgrade/ReplaceVersionTaskTest.groovy
@@ -32,6 +32,44 @@ class ReplaceVersionTaskTest extends Specification {
 
         then:
         configFile.text == "dependencies{ compile org.shipkit:shipkit:0.2.3 }"
+        replaceVersionTask.buildFileUpdated
     }
 
+    def "sets buildFlagUpdated to false correctly"() {
+        given:
+        def configFile = tmp.newFile("build.gradle")
+
+        configFile << "dependencies{ compile org.shipkit:shipkit:0.1.2 }"
+
+        def versionUpgrade = new UpgradeDependencyExtension(
+            dependencyGroup: "org.shipkit",
+            dependencyName: "shipkit",
+            newVersion: "0.1.2",
+            buildFile: configFile
+        )
+        def tasksContainer = new ProjectBuilder().build().tasks
+        def replaceVersionTask = tasksContainer.create("replaceVersion", ReplaceVersionTask)
+
+        replaceVersionTask.versionUpgrade = versionUpgrade
+
+        when:
+        replaceVersionTask.replaceVersion()
+
+        then:
+        configFile.text == "dependencies{ compile org.shipkit:shipkit:0.1.2 }"
+        !replaceVersionTask.buildFileUpdated
+    }
+
+    def "throws IllegalStateException when buildFileUpdated accessed before task is executed"() {
+        given:
+        def tasksContainer = new ProjectBuilder().build().tasks
+        def replaceVersionTask = tasksContainer.create("replaceVersion", ReplaceVersionTask)
+
+        when:
+        replaceVersionTask.buildFileUpdated
+
+        then:
+        def ex = thrown(IllegalStateException)
+        ex.message == "Property 'buildFileUpdated' should not be accessed before 'replaceVersion' task is executed."
+    }
 }

--- a/src/test/groovy/org/shipkit/internal/gradle/versionupgrade/ReplaceVersionTaskTest.groovy
+++ b/src/test/groovy/org/shipkit/internal/gradle/versionupgrade/ReplaceVersionTaskTest.groovy
@@ -16,7 +16,7 @@ class ReplaceVersionTaskTest extends Specification {
 
         configFile << "dependencies{ compile org.shipkit:shipkit:0.1.2 }"
 
-        def versionUpgrade = new VersionUpgradeConsumerExtension(
+        def versionUpgrade = new UpgradeDependencyExtension(
             dependencyGroup: "org.shipkit",
             dependencyName: "shipkit",
             newVersion: "0.2.3",

--- a/src/test/groovy/org/shipkit/internal/gradle/versionupgrade/UpgradeDependencyPluginIntegTest.groovy
+++ b/src/test/groovy/org/shipkit/internal/gradle/versionupgrade/UpgradeDependencyPluginIntegTest.groovy
@@ -2,7 +2,7 @@ package org.shipkit.internal.gradle.versionupgrade
 
 import testutil.GradleSpecification
 
-class VersionUpgradeConsumerPluginIntegTest extends GradleSpecification {
+class UpgradeDependencyPluginIntegTest extends GradleSpecification {
 
     def "all tasks in dry run"() {
         projectDir.newFolder("gradle")
@@ -14,7 +14,7 @@ class VersionUpgradeConsumerPluginIntegTest extends GradleSpecification {
         """
 
         buildFile << """
-            apply plugin: "org.shipkit.version-upgrade-consumer"
+            apply plugin: "org.shipkit.upgrade-dependency"
         """
 
         projectDir.newFile("version.properties") << "version=1.0.0"

--- a/src/test/groovy/org/shipkit/internal/gradle/versionupgrade/UpgradeDependencyPluginTest.groovy
+++ b/src/test/groovy/org/shipkit/internal/gradle/versionupgrade/UpgradeDependencyPluginTest.groovy
@@ -6,15 +6,15 @@ import org.shipkit.internal.gradle.git.GitCheckOutTask
 import org.shipkit.internal.gradle.git.GitPullTask
 import testutil.PluginSpecification
 
-class VersionUpgradeConsumerPluginTest extends PluginSpecification {
+class UpgradeDependencyPluginTest extends PluginSpecification {
 
     def setup() {
         conf.gitHub.writeAuthToken = "secret"
     }
 
-    def "should initialize VersionUpgradeConsumerPlugin correctly and with default values"() {
+    def "should initialize plugin correctly and with default values"() {
         when:
-        def versionUpgrade = project.plugins.apply(VersionUpgradeConsumerPlugin).versionUpgrade
+        def versionUpgrade = project.plugins.apply(UpgradeDependencyPlugin).upgradeDependencyExtension
 
         then:
         versionUpgrade.buildFile == project.file("build.gradle")
@@ -34,7 +34,7 @@ class VersionUpgradeConsumerPluginTest extends PluginSpecification {
         project.extensions.dependency = "org.shipkit:shipkit:0.1.2"
 
         when:
-        def versionUpgrade = project.plugins.apply(VersionUpgradeConsumerPlugin).versionUpgrade
+        def versionUpgrade = project.plugins.apply(UpgradeDependencyPlugin).upgradeDependencyExtension
 
         then:
         versionUpgrade.dependencyGroup == "org.shipkit"
@@ -44,7 +44,7 @@ class VersionUpgradeConsumerPluginTest extends PluginSpecification {
 
     def "should configure checkoutBaseBranch"() {
         when:
-        def versionUpgrade = project.plugins.apply(VersionUpgradeConsumerPlugin).versionUpgrade
+        def versionUpgrade = project.plugins.apply(UpgradeDependencyPlugin).upgradeDependencyExtension
         versionUpgrade.baseBranch = "release/2.x"
 
         project.evaluate()
@@ -64,7 +64,7 @@ class VersionUpgradeConsumerPluginTest extends PluginSpecification {
         conf.gitHub.writeAuthUser = "writeUser"
 
         when:
-        def versionUpgrade = project.plugins.apply(VersionUpgradeConsumerPlugin).versionUpgrade
+        def versionUpgrade = project.plugins.apply(UpgradeDependencyPlugin).upgradeDependencyExtension
         versionUpgrade.baseBranch = "release/2.x"
 
         project.evaluate()
@@ -80,7 +80,7 @@ class VersionUpgradeConsumerPluginTest extends PluginSpecification {
     def "should configure checkoutVersionBranch"() {
         when:
         project.extensions.dependency = "org.shipkit:shipkit:0.1.2"
-        project.plugins.apply(VersionUpgradeConsumerPlugin)
+        project.plugins.apply(UpgradeDependencyPlugin)
 
         GitCheckOutTask task = project.tasks.checkoutVersionBranch
 
@@ -94,7 +94,7 @@ class VersionUpgradeConsumerPluginTest extends PluginSpecification {
         project.extensions.dependency = "org.shipkit:shipkit:0.1.2"
 
         when:
-        VersionUpgradeConsumerExtension versionUpgrade = project.plugins.apply(VersionUpgradeConsumerPlugin).versionUpgrade
+        UpgradeDependencyExtension versionUpgrade = project.plugins.apply(UpgradeDependencyPlugin).upgradeDependencyExtension
         ReplaceVersionTask task = project.tasks.replaceVersion
 
         then:
@@ -107,7 +107,7 @@ class VersionUpgradeConsumerPluginTest extends PluginSpecification {
         project.extensions.dependency = "org.shipkit:shipkit:1.2.30"
 
         when:
-        def versionUpgrade = project.plugins.apply(VersionUpgradeConsumerPlugin).versionUpgrade
+        def versionUpgrade = project.plugins.apply(UpgradeDependencyPlugin).upgradeDependencyExtension
         versionUpgrade.buildFile = dependencyFile
         project.evaluate()
 
@@ -123,7 +123,7 @@ class VersionUpgradeConsumerPluginTest extends PluginSpecification {
         project.extensions.dependency = "org.shipkit:shipkit:1.2.30"
 
         when:
-        project.plugins.apply(VersionUpgradeConsumerPlugin)
+        project.plugins.apply(UpgradeDependencyPlugin)
 
         GitPushTask task = project.tasks.pushVersionUpgrade
 
@@ -139,7 +139,7 @@ class VersionUpgradeConsumerPluginTest extends PluginSpecification {
         conf.gitHub.writeAuthToken = "writeToken"
 
         when:
-        def versionUpgrade = project.plugins.apply(VersionUpgradeConsumerPlugin).versionUpgrade
+        def versionUpgrade = project.plugins.apply(UpgradeDependencyPlugin).upgradeDependencyExtension
         CreatePullRequestTask task = project.tasks.createPullRequest
 
         then:


### PR DESCRIPTION
Additionally added documentation for GitPull and GitPullTask. Also I added ReplaceVersionTask.buildFileUpdated so that I can skip GitCommit, GitPush and CreatePullRequest tasks if version wasn't actually changed (newVersion == previousVersion). I tested it e2e on shipkit-example.