### PR TITLE
Fixed bug with releaseNeeded, replaced Exec use with ShipkitExecTask

### DIFF
--- a/src/main/groovy/org/shipkit/internal/gradle/exec/ExecCommandFactory.java
+++ b/src/main/groovy/org/shipkit/internal/gradle/exec/ExecCommandFactory.java
@@ -2,7 +2,11 @@ package org.shipkit.internal.gradle.exec;
 
 import org.gradle.api.Action;
 import org.gradle.api.GradleException;
+import org.gradle.api.logging.Logger;
+import org.gradle.api.logging.Logging;
+import org.gradle.api.tasks.StopExecutionException;
 import org.gradle.process.ExecResult;
+import org.gradle.process.ExecSpec;
 import org.shipkit.gradle.exec.ExecCommand;
 
 import java.util.Collection;
@@ -11,21 +15,40 @@ import static java.util.Arrays.asList;
 
 public class ExecCommandFactory {
 
-    private final static Action NO_OP_ACTION = new Action() {
-        public void execute(Object o) {
-        }
-    };
+    private final static Logger LOG = Logging.getLogger(ExecCommandFactory.class);
 
-    private final static Action ENSURE_SUCCEEDED_ACTION = new Action<ExecResult>() {
-        public void execute(ExecResult result) {
-            ensureSucceeded(result);
-        }
-    };
+    public static Action<ExecSpec> ignoreResult() {
+        return new Action<ExecSpec>() {
+            public void execute(ExecSpec spec) {
+                spec.setIgnoreExitValue(true);
+            }
+        };
+    }
 
-    static void ensureSucceeded(ExecResult result) {
+    public static Action<ExecResult> stopExecution() {
+        return new Action<ExecResult>() {
+            public void execute(ExecResult exec) {
+                if (exec.getExitValue() != 0) {
+                    LOG.info("External process returned exit code: {}. Stopping the execution of the task.");
+                    //Cleanly stop executing the task, without making the task failed.
+                    throw new StopExecutionException();
+                }
+            }
+        };
+    }
+
+    private static Action<ExecResult> ensureSucceeded(final String prefix) {
+        return new Action<ExecResult>() {
+            public void execute(ExecResult result) {
+                ensureSucceeded(result, prefix);
+            }
+        };
+    }
+
+    static void ensureSucceeded(ExecResult result, String prefix) {
         if (result.getExitValue() != 0) {
-            throw new GradleException("Command execution failed. The exit code was: " + result.getExitValue() + "\n" +
-                    "Please inspect the process output prefixed in the build log.");
+            throw new GradleException("External command failed with exit code " + result.getExitValue() + "\n" +
+                    "Please inspect the command output prefixed with '" + prefix.trim() + "' the build log.");
         }
     }
 
@@ -34,7 +57,8 @@ public class ExecCommandFactory {
      * This is the most typical kind of exec command.
      */
     public static ExecCommand execCommand(String description, Collection<String> commandLine) {
-        return new ExecCommand(defaultPrefix(commandLine), description, commandLine, NO_OP_ACTION, ENSURE_SUCCEEDED_ACTION);
+        String prefix = defaultPrefix(commandLine);
+        return new ExecCommand(prefix, description, commandLine, ignoreResult(), ensureSucceeded(prefix));
     }
 
     /**
@@ -55,6 +79,6 @@ public class ExecCommandFactory {
      * For example, we can ignore the failure.
      */
     public static ExecCommand execCommand(String description, Collection<String> commandLine, Action<ExecResult> resultAction) {
-        return new ExecCommand(defaultPrefix(commandLine), description, commandLine, NO_OP_ACTION, resultAction);
+        return new ExecCommand(defaultPrefix(commandLine), description, commandLine, ignoreResult(), resultAction);
     }
 }

--- a/src/main/groovy/org/shipkit/internal/gradle/exec/ExecCommandFactory.java
+++ b/src/main/groovy/org/shipkit/internal/gradle/exec/ExecCommandFactory.java
@@ -9,6 +9,7 @@ import org.gradle.process.ExecResult;
 import org.gradle.process.ExecSpec;
 import org.shipkit.gradle.exec.ExecCommand;
 
+import java.io.File;
 import java.util.Collection;
 
 import static java.util.Arrays.asList;
@@ -21,6 +22,15 @@ public class ExecCommandFactory {
         return new Action<ExecSpec>() {
             public void execute(ExecSpec spec) {
                 spec.setIgnoreExitValue(true);
+            }
+        };
+    }
+
+    public static Action<ExecSpec> ignoreResult(final File workingDir) {
+        return new Action<ExecSpec>() {
+            public void execute(ExecSpec spec) {
+                spec.setIgnoreExitValue(true);
+                spec.setWorkingDir(workingDir);
             }
         };
     }
@@ -66,6 +76,15 @@ public class ExecCommandFactory {
      */
     public static ExecCommand execCommand(String description, String ... commandLine) {
         return execCommand(description, asList(commandLine));
+    }
+
+    /**
+     * See {@link #execCommand(String, Collection)}
+     */
+    public static ExecCommand execCommand(String description, File workingDir, String ... commandLine) {
+        Collection<String> cmd = asList(commandLine);
+        String prefix = defaultPrefix(cmd);
+        return new ExecCommand(prefix, description, cmd, ignoreResult(workingDir), ensureSucceeded(prefix));
     }
 
     private static String defaultPrefix(Collection<String> commandLine) {

--- a/src/main/groovy/org/shipkit/internal/gradle/git/GitSetupPlugin.java
+++ b/src/main/groovy/org/shipkit/internal/gradle/git/GitSetupPlugin.java
@@ -6,7 +6,6 @@ import org.gradle.api.Project;
 import org.gradle.api.Task;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
-import org.gradle.api.tasks.Exec;
 import org.gradle.process.ExecResult;
 import org.shipkit.gradle.configuration.ShipkitConfiguration;
 import org.shipkit.gradle.exec.ShipkitExecTask;
@@ -81,17 +80,19 @@ public class GitSetupPlugin implements Plugin<Project> {
             }
         });
 
-        TaskMaker.execTask(project, SET_USER_TASK, new Action<Exec>() {
-            public void execute(final Exec t) {
+        TaskMaker.task(project, SET_USER_TASK, ShipkitExecTask.class, new Action<ShipkitExecTask>() {
+            public void execute(final ShipkitExecTask t) {
                 t.setDescription("Overwrites local git 'user.name' with a generic name. Intended for CI.");
-                t.commandLine("git", "config", "--local", "user.name", conf.getGit().getUser());
+                t.execCommand(ExecCommandFactory.execCommand("Setting git user name",
+                    "git", "config", "--local", "user.name", conf.getGit().getUser()));
             }
         });
 
-        TaskMaker.execTask(project, SET_EMAIL_TASK, new Action<Exec>() {
-            public void execute(final Exec t) {
+        TaskMaker.task(project, SET_EMAIL_TASK, ShipkitExecTask.class, new Action<ShipkitExecTask>() {
+            public void execute(final ShipkitExecTask t) {
                 t.setDescription("Overwrites local git 'user.email' with a generic email. Intended for CI.");
-                t.commandLine("git", "config", "--local", "user.email", conf.getGit().getEmail());
+                t.execCommand(ExecCommandFactory.execCommand("Setting git user email",
+                    "git", "config", "--local", "user.email", conf.getGit().getEmail()));
             }
         });
 

--- a/src/main/groovy/org/shipkit/internal/gradle/release/CiReleasePlugin.java
+++ b/src/main/groovy/org/shipkit/internal/gradle/release/CiReleasePlugin.java
@@ -5,9 +5,8 @@ import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
-import org.gradle.api.tasks.StopExecutionException;
-import org.gradle.process.ExecResult;
 import org.shipkit.gradle.exec.ShipkitExecTask;
+import org.shipkit.internal.gradle.exec.ExecCommandFactory;
 import org.shipkit.internal.gradle.git.GitSetupPlugin;
 import org.shipkit.internal.gradle.util.TaskMaker;
 import org.shipkit.internal.gradle.util.TaskSuccessfulMessage;
@@ -54,7 +53,7 @@ public class CiReleasePlugin implements Plugin<Project> {
             public void execute(ShipkitExecTask task) {
                 task.setDescription("Checks if release is needed. If so it will prepare for ci release and perform release.");
                 task.getExecCommands().add(execCommand(
-                        "Checking if release is needed", asList("./gradlew", ReleaseNeededPlugin.ASSERT_RELEASE_NEEDED_TASK), stopExecution()));
+                        "Checking if release is needed", asList("./gradlew", ReleaseNeededPlugin.ASSERT_RELEASE_NEEDED_TASK), ExecCommandFactory.stopExecution()));
                 task.getExecCommands().add(execCommand(
                         "Preparing working copy for the release", asList("./gradlew", GitSetupPlugin.CI_RELEASE_PREPARE_TASK)));
                 task.getExecCommands().add(execCommand(
@@ -63,17 +62,5 @@ public class CiReleasePlugin implements Plugin<Project> {
                 TaskSuccessfulMessage.logOnSuccess(task, "  Release " + project.getVersion() + " was shipped! Thank you for using Shipkit!");
             }
         });
-    }
-
-    private Action<ExecResult> stopExecution() {
-        return new Action<ExecResult>() {
-            public void execute(ExecResult exec) {
-                if (exec.getExitValue() != 0) {
-                    LOG.info("External process returned exit code: {}. Stopping the execution of the task.");
-                    //Cleanly stop executing the task, without making the task failed.
-                    throw new StopExecutionException();
-                }
-            }
-        };
     }
 }

--- a/src/main/groovy/org/shipkit/internal/gradle/util/TaskMaker.java
+++ b/src/main/groovy/org/shipkit/internal/gradle/util/TaskMaker.java
@@ -3,11 +3,6 @@ package org.shipkit.internal.gradle.util;
 import org.gradle.api.Action;
 import org.gradle.api.Project;
 import org.gradle.api.Task;
-import org.gradle.api.logging.Logger;
-import org.gradle.api.logging.Logging;
-import org.gradle.api.tasks.Exec;
-
-import static org.shipkit.internal.gradle.util.StringUtil.join;
 
 /**
  * Handy class that should be used to create tasks.
@@ -15,22 +10,6 @@ import static org.shipkit.internal.gradle.util.StringUtil.join;
  * It also adds consistent logging for some kinds of tasks (like exec tasks).
  */
 public class TaskMaker {
-
-    private static final Logger LOG = Logging.getLogger(TaskMaker.class);
-
-    /**
-     * Creates exec task with preconfigured defaults
-     */
-    public static Exec execTask(Project project, String name, Action<Exec> configure) {
-        //TODO replace with ShipkitExec and remove this method
-        final Exec exec = project.getTasks().create(name, Exec.class);
-        exec.doFirst(new Action<Task>() {
-            public void execute(Task task) {
-                LOG.lifecycle("  Running:\n    {}", join(exec.getCommandLine(), " "));
-            }
-        });
-        return configure(configure, exec);
-    }
 
     /**
      * Creates task with preconfigured defaults

--- a/src/main/groovy/org/shipkit/internal/gradle/versionupgrade/UpgradeDownstreamPlugin.java
+++ b/src/main/groovy/org/shipkit/internal/gradle/versionupgrade/UpgradeDownstreamPlugin.java
@@ -1,10 +1,14 @@
 package org.shipkit.internal.gradle.versionupgrade;
 
-import org.gradle.api.*;
-import org.gradle.api.tasks.Exec;
+import org.gradle.api.Action;
+import org.gradle.api.Plugin;
+import org.gradle.api.Project;
+import org.gradle.api.Task;
 import org.shipkit.gradle.configuration.ShipkitConfiguration;
+import org.shipkit.gradle.exec.ShipkitExecTask;
 import org.shipkit.internal.gradle.configuration.DeferredConfiguration;
 import org.shipkit.internal.gradle.configuration.ShipkitConfigurationPlugin;
+import org.shipkit.internal.gradle.exec.ExecCommandFactory;
 import org.shipkit.internal.gradle.git.CloneGitRepositoryTask;
 import org.shipkit.internal.gradle.util.TaskMaker;
 import org.shipkit.internal.util.ExposedForTesting;
@@ -97,12 +101,13 @@ public class UpgradeDownstreamPlugin implements Plugin<Project> {
     }
 
     private Task createProduceUpgradeTask(final Project project, final String consumerRepository){
-        return TaskMaker.execTask(project, "upgrade" + capitalize(toCamelCase(consumerRepository)), new Action<Exec>() {
+        return TaskMaker.task(project, "upgrade" + capitalize(toCamelCase(consumerRepository)), ShipkitExecTask.class, new Action<ShipkitExecTask>() {
             @Override
-            public void execute(final Exec task) {
+            public void execute(final ShipkitExecTask task) {
                 task.setDescription("Performs dependency upgrade in " + consumerRepository);
-                task.setWorkingDir(getConsumerRepoTempDir(project, consumerRepository));
-                task.commandLine("./gradlew", "performVersionUpgrade", getDependencyProperty(project));
+                task.execCommand(ExecCommandFactory.execCommand("Upgrading dependency",
+                    getConsumerRepoTempDir(project, consumerRepository),
+                    "./gradlew", "performVersionUpgrade", getDependencyProperty(project)));
             }
         });
     }

--- a/src/test/groovy/org/shipkit/gradle/exec/ShipkitExecTaskTest.groovy
+++ b/src/test/groovy/org/shipkit/gradle/exec/ShipkitExecTaskTest.groovy
@@ -1,6 +1,8 @@
 package org.shipkit.gradle.exec
 
+import org.gradle.api.tasks.TaskExecutionException
 import org.gradle.testfixtures.ProjectBuilder
+import org.shipkit.internal.gradle.exec.ExecCommandFactory
 import spock.lang.Specification
 
 import static org.shipkit.internal.gradle.exec.ExecCommandFactory.execCommand
@@ -9,7 +11,7 @@ class ShipkitExecTaskTest extends Specification {
 
     def project = new ProjectBuilder().build()
 
-    def "executes with clean output"() {
+    def "successful command"() {
         def t = (ShipkitExecTask) project.tasks.create("t", ShipkitExecTask)
         t.execCommands.add(execCommand("Saying first", ["echo", "first"]))
         t.execCommands.add(execCommand("Saying second", ["echo", "second"]))
@@ -20,6 +22,32 @@ class ShipkitExecTaskTest extends Specification {
         then:
         //this is a smoke test. it's hard to write tests for this logic.
         //since the logic does not have complexity, let's have a smoke test for now and see how it goes
+        noExceptionThrown()
+    }
+
+    def "failing command"() {
+        def t = (ShipkitExecTask) project.tasks.create("t", ShipkitExecTask)
+        t.execCommands.add(execCommand("good", ["ls"]))
+        t.execCommands.add(execCommand("bad", ["ls", "missing file"]))
+
+        when:
+        t.execute()
+
+        then:
+        def ex = thrown(TaskExecutionException.class)
+        ex.cause.message == "External command failed with exit code 1\n" +
+            "Please inspect the command output prefixed with '[ls]' the build log."
+    }
+
+    def "when first command is configured to stop execution, second command will not fail the entire task"() {
+        def t = (ShipkitExecTask) project.tasks.create("t", ShipkitExecTask)
+        t.execCommands.add(execCommand("bad", ["ls", "missing file"], ExecCommandFactory.stopExecution()))
+        t.execCommands.add(execCommand("another bad", ["ls", "missing file"]))
+
+        when:
+        t.execute()
+
+        then:
         noExceptionThrown()
     }
 }

--- a/src/test/groovy/org/shipkit/gradle/exec/ShipkitExecTaskTest.groovy
+++ b/src/test/groovy/org/shipkit/gradle/exec/ShipkitExecTaskTest.groovy
@@ -35,8 +35,8 @@ class ShipkitExecTaskTest extends Specification {
 
         then:
         def ex = thrown(TaskExecutionException.class)
-        ex.cause.message == "External command failed with exit code 1\n" +
-            "Please inspect the command output prefixed with '[ls]' the build log."
+        ex.cause.message.startsWith "External command failed with exit code"
+        ex.cause.message.endsWith "\nPlease inspect the command output prefixed with '[ls]' the build log."
     }
 
     def "when first command is configured to stop execution, second command will not fail the entire task"() {

--- a/src/test/groovy/org/shipkit/internal/gradle/exec/ExecCommandFactoryTest.groovy
+++ b/src/test/groovy/org/shipkit/internal/gradle/exec/ExecCommandFactoryTest.groovy
@@ -2,6 +2,7 @@ package org.shipkit.internal.gradle.exec
 
 import org.gradle.api.GradleException
 import org.gradle.process.ExecResult
+import org.gradle.process.ExecSpec
 import spock.lang.Specification
 
 class ExecCommandFactoryTest extends Specification {
@@ -26,5 +27,29 @@ class ExecCommandFactoryTest extends Specification {
         def e = thrown(GradleException)
         e.message == """External command failed with exit code -100
 Please inspect the command output prefixed with '[git]' the build log."""
+    }
+
+    def "exec command with custom working dir"() {
+        def execSpec = Mock(ExecSpec)
+        def dir = new File("foo")
+        def command = ExecCommandFactory.execCommand("Doing stuff", dir, "git", "status")
+
+        when:
+        command.setupAction.execute(execSpec)
+
+        then:
+        1 * execSpec.setWorkingDir(dir)
+        1 * execSpec.setIgnoreExitValue(true)
+    }
+
+    def "commands ignore result by default"() {
+        def execSpec = Mock(ExecSpec)
+        def command = ExecCommandFactory.execCommand("Doing stuff", "git", "status")
+
+        when:
+        command.setupAction.execute(execSpec)
+
+        then:
+        1 * execSpec.setIgnoreExitValue(true)
     }
 }

--- a/src/test/groovy/org/shipkit/internal/gradle/exec/ExecCommandFactoryTest.groovy
+++ b/src/test/groovy/org/shipkit/internal/gradle/exec/ExecCommandFactoryTest.groovy
@@ -12,7 +12,7 @@ class ExecCommandFactoryTest extends Specification {
         result.exitValue >> 0
 
         expect:
-        ExecCommandFactory.ensureSucceeded(result)
+        ExecCommandFactory.ensureSucceeded(result, "[git] ")
     }
 
     def "throws exception if command fails"() {
@@ -20,10 +20,11 @@ class ExecCommandFactoryTest extends Specification {
         result.exitValue >> -100
 
         when:
-        ExecCommandFactory.ensureSucceeded(result)
+        ExecCommandFactory.ensureSucceeded(result, "[git] ")
 
         then:
         def e = thrown(GradleException)
-        e.message.contains("-100")
+        e.message == """External command failed with exit code -100
+Please inspect the command output prefixed with '[git]' the build log."""
     }
 }

--- a/src/test/groovy/org/shipkit/internal/gradle/versionupgrade/UpgradeDownstreamPluginTest.groovy
+++ b/src/test/groovy/org/shipkit/internal/gradle/versionupgrade/UpgradeDownstreamPluginTest.groovy
@@ -1,8 +1,8 @@
 package org.shipkit.internal.gradle.versionupgrade
 
 import org.gradle.api.ProjectConfigurationException
-import org.gradle.api.tasks.Exec
 import org.gradle.testfixtures.ProjectBuilder
+import org.shipkit.gradle.exec.ShipkitExecTask
 import org.shipkit.internal.gradle.git.CloneGitRepositoryTask
 import testutil.PluginSpecification
 
@@ -55,9 +55,8 @@ class UpgradeDownstreamPluginTest extends PluginSpecification {
         project.evaluate()
 
         then:
-        Exec task = project.tasks['upgradeWwilkMockito']
-        task.workingDir == project.file(project.buildDir.absolutePath + '/downstream-upgrade/wwilkMockito')
-        task.commandLine == ["./gradlew", "performVersionUpgrade", "-Pdependency=depGroup:depName:0.1.2"]
+        ShipkitExecTask task = project.tasks['upgradeWwilkMockito']
+        task.execCommands[0].commandLine == ["./gradlew", "performVersionUpgrade", "-Pdependency=depGroup:depName:0.1.2"]
     }
 
     @Override


### PR DESCRIPTION
 - fixed issue with releaseNeeded. Previously we were incorrectly failing the entire build when assertReleaseNeeded failed. Instead of failing the entire build, we should stop executing the task.
 - refactored remaining usages of Exec task to ShipkitExecTask (this improves logging when we fork of external processes). After 1.0, it would be hard to change the task types due to the compatibility contract.