### PR TITLE
Completed public API cleanup for 'org.shipkit.java' before 1.0

### DIFF
--- a/src/main/groovy/org/shipkit/gradle/git/GitPushTask.java
+++ b/src/main/groovy/org/shipkit/gradle/git/GitPushTask.java
@@ -3,7 +3,7 @@ package org.shipkit.gradle.git;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.TaskAction;
-import org.shipkit.internal.gradle.git.GitPush;
+import org.shipkit.internal.gradle.git.tasks.GitPush;
 
 import java.util.LinkedList;
 import java.util.List;

--- a/src/main/groovy/org/shipkit/internal/gradle/bintray/ShipkitBintrayPlugin.java
+++ b/src/main/groovy/org/shipkit/internal/gradle/bintray/ShipkitBintrayPlugin.java
@@ -18,13 +18,13 @@ import static org.shipkit.internal.gradle.configuration.DeferredConfiguration.de
 /**
  * Applies and configures "com.jfrog.bintray" plugin based on sensible defaults
  * and user-defined values in "shipkit" extension ({@link ShipkitConfiguration}).
- *
+ * <p>
  * Applies plugins:
  * <ul>
- *     <li>{@link ShipkitConfigurationPlugin} to the root project</li>
- *     <li>"com.jfrog.bintray" to this project</li>
+ * <li>{@link ShipkitConfigurationPlugin} to the root project</li>
+ * <li>"com.jfrog.bintray" to this project</li>
  * </ul>
- *
+ * <p>
  * Configures "com.jfrog.bintray" plugin with sensible defaults
  * and with values specified in Shipkit file.
  */
@@ -58,7 +58,6 @@ public class ShipkitBintrayPlugin implements Plugin<Project> {
                 LOG.lifecycle(welcomeMessage);
             }
         });
-
 
         final BintrayExtension.PackageConfig pkg = bintray.getPkg();
         pkg.setPublicDownloadNumbers(true);
@@ -96,7 +95,7 @@ public class ShipkitBintrayPlugin implements Plugin<Project> {
         LazyConfiguration.lazyConfiguration(bintrayUpload, new Runnable() {
             public void run() {
                 String key = notNull(bintray.getKey(), "BINTRAY_API_KEY",
-                        "Missing 'bintray.key' value.\n" +
+                    "Missing 'bintray.key' value.\n" +
                         "  Please configure Bintray extension or export 'BINTRAY_API_KEY' env variable.");
                 bintray.setKey(key);
                 // api key is set by Bintray plugin, based on 'bintray.key' value, before lazy configuration.
@@ -105,17 +104,17 @@ public class ShipkitBintrayPlugin implements Plugin<Project> {
 
                 //workaround for https://github.com/bintray/gradle-bintray-plugin/issues/170
                 notNull(bintray.getUser(), "Missing 'bintray.user' value.\n" +
-                        "  Please configure Bintray extension.");
+                    "  Please configure Bintray extension.");
             }
         });
     }
 
     static String uploadWelcomeMessage(BintrayUploadTask t) {
         return t.getPath() + " - publishing to Bintray\n" +
-                            "  - dry run: " + t.getDryRun()
-                            + ", version: " + t.getVersionName()
-                            + ", Maven Central sync: " + t.getSyncToMavenCentral() + "\n" +
-                            "  - user/org: " + t.getUser() + "/" + t.getUserOrg()
-                            + ", repository/package: " + t.getRepoName() + "/" + t.getPackageName();
+            "  - dry run: " + t.getDryRun()
+            + ", version: " + t.getVersionName()
+            + ", Maven Central sync: " + t.getSyncToMavenCentral() + "\n" +
+            "  - user/org: " + t.getUser() + "/" + t.getUserOrg()
+            + ", repository/package: " + t.getRepoName() + "/" + t.getPackageName();
     }
 }

--- a/src/main/groovy/org/shipkit/internal/gradle/e2e/E2ETestTask.java
+++ b/src/main/groovy/org/shipkit/internal/gradle/e2e/E2ETestTask.java
@@ -3,7 +3,7 @@ package org.shipkit.internal.gradle.e2e;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
-import org.shipkit.internal.gradle.git.CloneGitRepositoryTask;
+import org.shipkit.internal.gradle.git.tasks.CloneGitRepositoryTask;
 
 import java.io.File;
 import java.util.ArrayList;

--- a/src/main/groovy/org/shipkit/internal/gradle/git/GitAuthPlugin.java
+++ b/src/main/groovy/org/shipkit/internal/gradle/git/GitAuthPlugin.java
@@ -30,15 +30,7 @@ public class GitAuthPlugin implements Plugin<Project> {
         String writeToken = conf.getLenient().getGitHub().getWriteAuthToken();
 
         String configUrl = getGitHubUrl(ghUser, conf.getGitHub().getRepository(), writeToken);
-        String secretValue = null;
-        //TODO we can push the lifecycle messages to the task execution (doFirst) and replace this plugin with simple convenience function
-        if (writeToken != null) {
-            LOG.lifecycle("  'git push/pull' use GitHub write token.");
-            secretValue = writeToken;
-        } else {
-            LOG.lifecycle("  'git push/pull' do not use GitHub write token because it was not specified.");
-        }
-        gitAuth = new GitAuth(configUrl, secretValue);
+        gitAuth = new GitAuth(configUrl, writeToken);
     }
 
     static String getGitHubUrl(String ghUser, String ghRepo, String writeToken) {

--- a/src/main/groovy/org/shipkit/internal/gradle/git/GitPush.java
+++ b/src/main/groovy/org/shipkit/internal/gradle/git/GitPush.java
@@ -2,6 +2,7 @@ package org.shipkit.internal.gradle.git;
 
 import org.shipkit.gradle.git.GitPushTask;
 import org.shipkit.internal.exec.DefaultProcessRunner;
+import org.shipkit.internal.gradle.git.tasks.TokenAvailabilityMessage;
 
 import java.util.LinkedList;
 import java.util.List;
@@ -27,6 +28,8 @@ public class GitPush {
     }
 
     public void gitPush(GitPushTask task) {
+        TokenAvailabilityMessage.logMessage("git push", task.getSecretValue());
+
         new DefaultProcessRunner(task.getProject().getProjectDir())
                 .setSecretValue(task.getSecretValue())
                 .run(GitPush.gitPushArgs(task.getUrl(), task.getTargets(), task.isDryRun()));

--- a/src/main/groovy/org/shipkit/internal/gradle/git/GitSetupPlugin.java
+++ b/src/main/groovy/org/shipkit/internal/gradle/git/GitSetupPlugin.java
@@ -11,6 +11,7 @@ import org.shipkit.gradle.configuration.ShipkitConfiguration;
 import org.shipkit.gradle.exec.ShipkitExecTask;
 import org.shipkit.internal.gradle.configuration.ShipkitConfigurationPlugin;
 import org.shipkit.internal.gradle.exec.ExecCommandFactory;
+import org.shipkit.internal.gradle.git.tasks.GitCheckOutTask;
 import org.shipkit.internal.gradle.util.TaskMaker;
 
 import static java.util.Arrays.asList;

--- a/src/main/groovy/org/shipkit/internal/gradle/git/tasks/CloneGitRepositoryTask.java
+++ b/src/main/groovy/org/shipkit/internal/gradle/git/tasks/CloneGitRepositoryTask.java
@@ -1,4 +1,4 @@
-package org.shipkit.internal.gradle.git;
+package org.shipkit.internal.gradle.git.tasks;
 
 import org.gradle.api.DefaultTask;
 import org.gradle.api.logging.Logger;
@@ -8,8 +8,8 @@ import org.gradle.api.tasks.Optional;
 import org.gradle.api.tasks.OutputDirectory;
 import org.gradle.api.tasks.TaskAction;
 import org.shipkit.internal.exec.Exec;
-import org.shipkit.internal.util.ExposedForTesting;
 import org.shipkit.internal.exec.ProcessRunner;
+import org.shipkit.internal.util.ExposedForTesting;
 
 import java.io.File;
 import java.util.ArrayList;

--- a/src/main/groovy/org/shipkit/internal/gradle/git/tasks/GitCheckOutTask.java
+++ b/src/main/groovy/org/shipkit/internal/gradle/git/tasks/GitCheckOutTask.java
@@ -1,4 +1,4 @@
-package org.shipkit.internal.gradle.git;
+package org.shipkit.internal.gradle.git.tasks;
 
 import org.gradle.api.DefaultTask;
 import org.gradle.api.tasks.Input;

--- a/src/main/groovy/org/shipkit/internal/gradle/git/tasks/GitPull.java
+++ b/src/main/groovy/org/shipkit/internal/gradle/git/tasks/GitPull.java
@@ -1,4 +1,4 @@
-package org.shipkit.internal.gradle.git;
+package org.shipkit.internal.gradle.git.tasks;
 
 import org.shipkit.internal.exec.DefaultProcessRunner;
 
@@ -11,6 +11,7 @@ import java.util.List;
 public class GitPull {
 
     public void gitPull(GitPullTask task){
+
         new DefaultProcessRunner(task.getProject().getProjectDir())
             .setSecretValue(task.getSecretValue())
             .run(gitPullArgs(task.getUrl(), task.getRev(), task.isDryRun()));

--- a/src/main/groovy/org/shipkit/internal/gradle/git/tasks/GitPull.java
+++ b/src/main/groovy/org/shipkit/internal/gradle/git/tasks/GitPull.java
@@ -10,8 +10,8 @@ import java.util.List;
  */
 public class GitPull {
 
-    public void gitPull(GitPullTask task){
-
+    public void gitPull(GitPullTask task) {
+        TokenAvailabilityMessage.logMessage("git pull", task.getSecretValue());
         new DefaultProcessRunner(task.getProject().getProjectDir())
             .setSecretValue(task.getSecretValue())
             .run(gitPullArgs(task.getUrl(), task.getRev(), task.isDryRun()));

--- a/src/main/groovy/org/shipkit/internal/gradle/git/tasks/GitPullTask.java
+++ b/src/main/groovy/org/shipkit/internal/gradle/git/tasks/GitPullTask.java
@@ -1,4 +1,4 @@
-package org.shipkit.internal.gradle.git;
+package org.shipkit.internal.gradle.git.tasks;
 
 import org.gradle.api.DefaultTask;
 import org.gradle.api.tasks.Input;

--- a/src/main/groovy/org/shipkit/internal/gradle/git/tasks/GitPush.java
+++ b/src/main/groovy/org/shipkit/internal/gradle/git/tasks/GitPush.java
@@ -1,8 +1,7 @@
-package org.shipkit.internal.gradle.git;
+package org.shipkit.internal.gradle.git.tasks;
 
 import org.shipkit.gradle.git.GitPushTask;
 import org.shipkit.internal.exec.DefaultProcessRunner;
-import org.shipkit.internal.gradle.git.tasks.TokenAvailabilityMessage;
 
 import java.util.LinkedList;
 import java.util.List;

--- a/src/main/groovy/org/shipkit/internal/gradle/git/tasks/TokenAvailabilityMessage.java
+++ b/src/main/groovy/org/shipkit/internal/gradle/git/tasks/TokenAvailabilityMessage.java
@@ -3,11 +3,11 @@ package org.shipkit.internal.gradle.git.tasks;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
 
-public class TokenAvailabilityMessage {
+class TokenAvailabilityMessage {
 
     private final static Logger LOG = Logging.getLogger(TokenAvailabilityMessage.class);
 
-    public static void logMessage(String context, String authToken) {
+    static void logMessage(String context, String authToken) {
         String message = createMessage(context, authToken);
         LOG.lifecycle(message);
     }

--- a/src/main/groovy/org/shipkit/internal/gradle/git/tasks/TokenAvailabilityMessage.java
+++ b/src/main/groovy/org/shipkit/internal/gradle/git/tasks/TokenAvailabilityMessage.java
@@ -1,0 +1,24 @@
+package org.shipkit.internal.gradle.git.tasks;
+
+import org.gradle.api.logging.Logger;
+import org.gradle.api.logging.Logging;
+
+public class TokenAvailabilityMessage {
+
+    private final static Logger LOG = Logging.getLogger(TokenAvailabilityMessage.class);
+
+    public static void logMessage(String context, String authToken) {
+        String message = createMessage(context, authToken);
+        LOG.lifecycle(message);
+    }
+
+    static String createMessage(String context, String authToken) {
+        String message;
+        if (authToken == null) {
+            message = "  '" + context + "' uses GitHub write token";
+        } else {
+            message = "  '" + context + "' does not use GitHub write token because it was not specified";
+        }
+        return message;
+    }
+}

--- a/src/main/groovy/org/shipkit/internal/gradle/release/ReleaseNeededPlugin.java
+++ b/src/main/groovy/org/shipkit/internal/gradle/release/ReleaseNeededPlugin.java
@@ -24,8 +24,10 @@ import org.shipkit.internal.gradle.util.TaskMaker;
  * Adds following tasks:
  *
  * <ul>
- *     <li>assertReleaseNeeded - {@link ReleaseNeededTask}</li>
- *     <li>releaseNeeded - {@link ReleaseNeededTask}</li>
+ *     <li>assertReleaseNeeded - {@link ReleaseNeededTask}
+ *      - checks if release is needed and fails the build if not needed. Used in release process.</li>
+ *     <li>releaseNeeded - {@link ReleaseNeededTask}
+ *     - prints information if the release is needed. Useful for testing.</li>
  * </ul>
  */
 public class ReleaseNeededPlugin implements Plugin<Project> {

--- a/src/main/groovy/org/shipkit/internal/gradle/release/TravisPlugin.java
+++ b/src/main/groovy/org/shipkit/internal/gradle/release/TravisPlugin.java
@@ -10,8 +10,8 @@ import org.shipkit.gradle.release.ReleaseNeededTask;
 import org.shipkit.internal.gradle.configuration.BasicValidator;
 import org.shipkit.internal.gradle.configuration.LazyConfiguration;
 import org.shipkit.internal.gradle.git.GitBranchPlugin;
-import org.shipkit.internal.gradle.git.GitCheckOutTask;
 import org.shipkit.internal.gradle.git.GitSetupPlugin;
+import org.shipkit.internal.gradle.git.tasks.GitCheckOutTask;
 import org.shipkit.internal.gradle.util.StringUtil;
 
 /**

--- a/src/main/groovy/org/shipkit/internal/gradle/versionupgrade/UpgradeDependencyPlugin.java
+++ b/src/main/groovy/org/shipkit/internal/gradle/versionupgrade/UpgradeDependencyPlugin.java
@@ -13,9 +13,9 @@ import org.shipkit.gradle.git.GitPushTask;
 import org.shipkit.internal.gradle.configuration.DeferredConfiguration;
 import org.shipkit.internal.gradle.configuration.ShipkitConfigurationPlugin;
 import org.shipkit.internal.gradle.git.GitAuthPlugin;
-import org.shipkit.internal.gradle.git.GitCheckOutTask;
-import org.shipkit.internal.gradle.git.GitPullTask;
 import org.shipkit.internal.gradle.git.GitRemoteOriginPlugin;
+import org.shipkit.internal.gradle.git.tasks.GitCheckOutTask;
+import org.shipkit.internal.gradle.git.tasks.GitPullTask;
 import org.shipkit.internal.gradle.util.TaskMaker;
 import org.shipkit.internal.util.RethrowingResultHandler;
 

--- a/src/main/groovy/org/shipkit/internal/gradle/versionupgrade/UpgradeDownstreamPlugin.java
+++ b/src/main/groovy/org/shipkit/internal/gradle/versionupgrade/UpgradeDownstreamPlugin.java
@@ -9,7 +9,7 @@ import org.shipkit.gradle.exec.ShipkitExecTask;
 import org.shipkit.internal.gradle.configuration.DeferredConfiguration;
 import org.shipkit.internal.gradle.configuration.ShipkitConfigurationPlugin;
 import org.shipkit.internal.gradle.exec.ExecCommandFactory;
-import org.shipkit.internal.gradle.git.CloneGitRepositoryTask;
+import org.shipkit.internal.gradle.git.tasks.CloneGitRepositoryTask;
 import org.shipkit.internal.gradle.util.TaskMaker;
 import org.shipkit.internal.util.ExposedForTesting;
 import org.shipkit.version.VersionInfo;

--- a/src/test/groovy/org/shipkit/internal/gradle/git/tasks/CloneGitRepositoryTaskTest.groovy
+++ b/src/test/groovy/org/shipkit/internal/gradle/git/tasks/CloneGitRepositoryTaskTest.groovy
@@ -1,9 +1,8 @@
-package org.shipkit.internal.gradle
+package org.shipkit.internal.gradle.git.tasks
 
 import org.gradle.testfixtures.ProjectBuilder
 import org.junit.Rule
 import org.junit.rules.TemporaryFolder
-import org.shipkit.internal.gradle.git.CloneGitRepositoryTask
 import spock.lang.Specification
 import spock.lang.Subject
 

--- a/src/test/groovy/org/shipkit/internal/gradle/git/tasks/GitCheckOutTaskTest.groovy
+++ b/src/test/groovy/org/shipkit/internal/gradle/git/tasks/GitCheckOutTaskTest.groovy
@@ -1,4 +1,4 @@
-package org.shipkit.internal.gradle.git
+package org.shipkit.internal.gradle.git.tasks
 
 import org.gradle.testfixtures.ProjectBuilder
 import org.shipkit.internal.exec.ProcessRunner

--- a/src/test/groovy/org/shipkit/internal/gradle/git/tasks/GitCommitTaskTest.groovy
+++ b/src/test/groovy/org/shipkit/internal/gradle/git/tasks/GitCommitTaskTest.groovy
@@ -1,4 +1,4 @@
-package org.shipkit.internal.gradle.git
+package org.shipkit.internal.gradle.git.tasks
 
 import org.gradle.testfixtures.ProjectBuilder
 import org.shipkit.gradle.git.GitCommitTask

--- a/src/test/groovy/org/shipkit/internal/gradle/git/tasks/GitPushTest.groovy
+++ b/src/test/groovy/org/shipkit/internal/gradle/git/tasks/GitPushTest.groovy
@@ -1,8 +1,8 @@
-package org.shipkit.internal.gradle.git
+package org.shipkit.internal.gradle.git.tasks
 
 import spock.lang.Specification
 
-import static org.shipkit.internal.gradle.git.GitPush.gitPushArgs
+import static org.shipkit.internal.gradle.git.tasks.GitPush.gitPushArgs
 
 class GitPushTest extends Specification {
 

--- a/src/test/groovy/org/shipkit/internal/gradle/git/tasks/TokenAvailabilityMessageTest.groovy
+++ b/src/test/groovy/org/shipkit/internal/gradle/git/tasks/TokenAvailabilityMessageTest.groovy
@@ -1,0 +1,12 @@
+package org.shipkit.internal.gradle.git.tasks
+
+import spock.lang.Specification
+
+class TokenAvailabilityMessageTest extends Specification {
+
+    def "creates message"() {
+        expect:
+        TokenAvailabilityMessage.createMessage("git push", null) == "  'git push' uses GitHub write token"
+        TokenAvailabilityMessage.createMessage("git push", "secret") == "  'git push' does not use GitHub write token because it was not specified"
+    }
+}

--- a/src/test/groovy/org/shipkit/internal/gradle/versionupgrade/UpgradeDependencyPluginTest.groovy
+++ b/src/test/groovy/org/shipkit/internal/gradle/versionupgrade/UpgradeDependencyPluginTest.groovy
@@ -2,8 +2,8 @@ package org.shipkit.internal.gradle.versionupgrade
 
 import org.shipkit.gradle.exec.ShipkitExecTask
 import org.shipkit.gradle.git.GitPushTask
-import org.shipkit.internal.gradle.git.GitCheckOutTask
-import org.shipkit.internal.gradle.git.GitPullTask
+import org.shipkit.internal.gradle.git.tasks.GitCheckOutTask
+import org.shipkit.internal.gradle.git.tasks.GitPullTask
 import testutil.PluginSpecification
 
 class UpgradeDependencyPluginTest extends PluginSpecification {

--- a/src/test/groovy/org/shipkit/internal/gradle/versionupgrade/UpgradeDownstreamPluginTest.groovy
+++ b/src/test/groovy/org/shipkit/internal/gradle/versionupgrade/UpgradeDownstreamPluginTest.groovy
@@ -3,7 +3,7 @@ package org.shipkit.internal.gradle.versionupgrade
 import org.gradle.api.ProjectConfigurationException
 import org.gradle.testfixtures.ProjectBuilder
 import org.shipkit.gradle.exec.ShipkitExecTask
-import org.shipkit.internal.gradle.git.CloneGitRepositoryTask
+import org.shipkit.internal.gradle.git.tasks.CloneGitRepositoryTask
 import testutil.PluginSpecification
 
 class UpgradeDownstreamPluginTest extends PluginSpecification {


### PR DESCRIPTION
 - moved classes to packages
 - documentation
 - logging

I think that 'org.shipkit.java' and all plugins beneath it are cleaned up now. My next steps is to do the same for few remaining plugins beneath 'org.shipkit.gradle' plugin.

1.0 soon :)