### PR TITLE
use gradle daemon on travis ci again ...

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,4 +22,4 @@ install:
  - true
 
 script:
-  - ./gradlew build -PcheckJava6Compatibility -s -i && ./gradlew ciPerformRelease
+  - ./gradlew build -PcheckJava6Compatibility --daemon -s -i && ./gradlew ciPerformRelease


### PR DESCRIPTION
... in order to get travis builds green again.

travis ci recently disabled the daemon by default, see https://docs.travis-ci.com/user/languages/java#Gradle-daemon-is-disabled-by-default