### PR TITLE
README.md: Add link to CONTRIBUTING.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Core features offered by 1.0:
 
 ## Development guide
 
-See CONTRIBUTING.md
+See [CONTRIBUTING.md](https://github.com/mockito/shipkit/blob/master/CONTRIBUTING.md)
 
 ## Project Execution
 


### PR DESCRIPTION
The `README.md` file references `CONTRIBUTING.md`. In order to make the file easier to navigate, this patch changes this reference to a clickable link.