### PR TITLE
set working dir for ShipkitExec

### DIFF
--- a/src/main/groovy/org/shipkit/internal/gradle/exec/ShipkitExec.java
+++ b/src/main/groovy/org/shipkit/internal/gradle/exec/ShipkitExec.java
@@ -16,7 +16,7 @@ public class ShipkitExec {
 
     private final static Logger LOG = Logging.getLogger(ShipkitExec.class);
 
-    public void execCommands(Collection<ExecCommand> execCommands, Project project) {
+    public void execCommands(Collection<ExecCommand> execCommands, final Project project) {
         for (final ExecCommand execCommand : execCommands) {
             ExecResult result = project.exec(new Action<ExecSpec>() {
                 @Override
@@ -25,6 +25,7 @@ public class ShipkitExec {
                     spec.commandLine(execCommand.getCommandLine());
                     spec.setStandardOutput(new ExternalProcessStream(execCommand.getLoggingPrefix(), System.out));
                     spec.setErrorOutput(new ExternalProcessStream(execCommand.getLoggingPrefix(), System.err));
+                    spec.setWorkingDir(project.getRootDir());
 
                     execCommand.getSetupAction().execute(spec);
 


### PR DESCRIPTION
e.g. if shipkit is applied to a subproject we currently can't find the gradlew.

> Caused by: java.io.IOException: Cannot run program "./gradlew" (in directory "~/shipkit/subprojects/shipkit"): error=2, No such file or directory

I thought it might be a good idea to use `rootDir` as a `workingDir` default.
I headed into it while working on #360 and applying shipkit just on a subproject.