### PR TITLE
expose release notes url

### DIFF
--- a/src/main/groovy/org/shipkit/gradle/notes/UpdateReleaseNotesTask.java
+++ b/src/main/groovy/org/shipkit/gradle/notes/UpdateReleaseNotesTask.java
@@ -46,7 +46,7 @@ public class UpdateReleaseNotesTask extends DefaultTask {
      */
     @TaskAction
     public void updateReleaseNotes() {
-        new UpdateReleaseNotes(new HeaderProvider()).updateReleaseNotes(this);
+        new UpdateReleaseNotes().updateReleaseNotes(this, new HeaderProvider());
     }
 
     /**
@@ -132,7 +132,7 @@ public class UpdateReleaseNotesTask extends DefaultTask {
      * @return a link to the generated release notes file hosted on Github.
      */
     public String getReleaseNotesUrl(String branch) {
-        return  getGitHubUrl() + "/" + getGitHubRepository() + "/blob/" + branch + "/" + getProject().relativePath(getReleaseNotesFile());
+        return new UpdateReleaseNotes().getReleaseNotesUrl(this, branch);
     }
 
     /**

--- a/src/main/groovy/org/shipkit/gradle/notes/UpdateReleaseNotesTask.java
+++ b/src/main/groovy/org/shipkit/gradle/notes/UpdateReleaseNotesTask.java
@@ -129,6 +129,13 @@ public class UpdateReleaseNotesTask extends DefaultTask {
     }
 
     /**
+     * @return a link to the generated release notes file hosted on Github.
+     */
+    public String getReleaseNotesUrl(String branch) {
+        return  getGitHubUrl() + "/" + getGitHubRepository() + "/blob/" + branch + "/" + getProject().relativePath(getReleaseNotesFile());
+    }
+
+    /**
      * See {@link #getGitHubRepository()}
      */
     public void setGitHubRepository(String gitHubRepository) {

--- a/src/main/groovy/org/shipkit/internal/gradle/notes/tasks/UpdateReleaseNotes.java
+++ b/src/main/groovy/org/shipkit/internal/gradle/notes/tasks/UpdateReleaseNotes.java
@@ -26,14 +26,9 @@ import java.util.Map;
 public class UpdateReleaseNotes {
 
     private static final Logger LOG = Logging.getLogger(UpdateReleaseNotesTask.class);
-    private final HeaderProvider headerProvider;
 
-    public UpdateReleaseNotes(HeaderProvider headerProvider) {
-        this.headerProvider = headerProvider;
-    }
-
-    public void updateReleaseNotes(UpdateReleaseNotesTask task) {
-        String newContent = generateNewContent(task);
+    public void updateReleaseNotes(UpdateReleaseNotesTask task, HeaderProvider headerProvider) {
+        String newContent = generateNewContent(task, headerProvider);
         updateReleaseNotes(task.isPreviewMode(), task.getReleaseNotesFile(), newContent);
     }
 
@@ -68,7 +63,7 @@ public class UpdateReleaseNotes {
         return out;
     }
 
-    public String generateNewContent(UpdateReleaseNotesTask task) {
+    public String generateNewContent(UpdateReleaseNotesTask task, HeaderProvider headerProvider) {
         LOG.lifecycle("  Building new release notes based on {}", task.getReleaseNotesFile());
 
         String headerMessage = headerProvider.getHeader(task.getHeader());
@@ -101,5 +96,9 @@ public class UpdateReleaseNotes {
         } else {
             return "";
         }
+    }
+
+    public String getReleaseNotesUrl(UpdateReleaseNotesTask task, String branch) {
+        return  task.getGitHubUrl() + "/" + task.getGitHubRepository() + "/blob/" + branch + "/" + task.getProject().relativePath(task.getReleaseNotesFile());
     }
 }

--- a/src/test/groovy/org/shipkit/internal/gradle/notes/tasks/UpdateReleaseNotesTaskTest.groovy
+++ b/src/test/groovy/org/shipkit/internal/gradle/notes/tasks/UpdateReleaseNotesTaskTest.groovy
@@ -2,7 +2,6 @@ package org.shipkit.internal.gradle.notes.tasks
 
 import org.junit.Rule
 import org.junit.rules.TemporaryFolder
-import org.shipkit.internal.notes.header.HeaderProvider
 import spock.lang.Specification
 
 class UpdateReleaseNotesTaskTest extends Specification {
@@ -10,7 +9,7 @@ class UpdateReleaseNotesTaskTest extends Specification {
     @Rule
     TemporaryFolder tmp = new TemporaryFolder()
 
-    UpdateReleaseNotes update = new UpdateReleaseNotes(new HeaderProvider())
+    UpdateReleaseNotes update = new UpdateReleaseNotes()
 
     def "should update release notes if not in preview mode"() {
         def f = tmp.newFile("release-notes.md")

--- a/src/test/groovy/org/shipkit/internal/gradle/notes/tasks/UpdateReleaseNotesTaskTest.groovy
+++ b/src/test/groovy/org/shipkit/internal/gradle/notes/tasks/UpdateReleaseNotesTaskTest.groovy
@@ -1,7 +1,9 @@
 package org.shipkit.internal.gradle.notes.tasks
 
+import org.gradle.testfixtures.ProjectBuilder
 import org.junit.Rule
 import org.junit.rules.TemporaryFolder
+import org.shipkit.gradle.notes.UpdateReleaseNotesTask
 import spock.lang.Specification
 
 class UpdateReleaseNotesTaskTest extends Specification {
@@ -29,5 +31,25 @@ class UpdateReleaseNotesTaskTest extends Specification {
 
         then:
         f.text.isEmpty()
+    }
+
+    def "check release notes url"(branch, expectedUrl) {
+        given:
+        def task = Mock(UpdateReleaseNotesTask)
+        def project = new ProjectBuilder().withName("myProject").withProjectDir(tmp.root).build()
+
+        when:
+        task.gitHubUrl >> "https://github.com"
+        task.gitHubRepository >> 'mockito/mockito'
+        task.project >> project
+        task.releaseNotesFile >> project.file("doc/release-notes/official.md")
+
+        then:
+        expectedUrl == update.getReleaseNotesUrl(task, branch)
+
+        where:
+        branch          | expectedUrl
+        'master'        | 'https://github.com/mockito/mockito/blob/master/doc/release-notes/official.md'
+        'release/2.x'   | 'https://github.com/mockito/mockito/blob/release/2.x/doc/release-notes/official.md'
     }
 }

--- a/src/test/groovy/org/shipkit/internal/gradle/notes/tasks/UpdateReleaseNotesTest.groovy
+++ b/src/test/groovy/org/shipkit/internal/gradle/notes/tasks/UpdateReleaseNotesTest.groovy
@@ -6,7 +6,7 @@ import org.junit.rules.TemporaryFolder
 import org.shipkit.gradle.notes.UpdateReleaseNotesTask
 import spock.lang.Specification
 
-class UpdateReleaseNotesTaskTest extends Specification {
+class UpdateReleaseNotesTest extends Specification {
 
     @Rule
     TemporaryFolder tmp = new TemporaryFolder()


### PR DESCRIPTION
in order to be able to log the release notes url (see ##364).

I already did some local testing:

>   Release shipped!
>     - Files in Bintray:   https://dl.bintray.com/shipkit-bootstrap/bootstrap/org/shipkit/bootstrap/ep/shipkit-bootstrap/0.0.3
>     - Bintray repository: https://bintray.com/shipkit-bootstrap/bootstrap/maven/0.0.3
>     - Release notes:      https://github.com/mockito/shipkit-bootstrap/blob/master/docs/release-notes.md

