### PR TITLE
Improved Gradle releasing plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,6 +20,7 @@ apply from: 'gradle/java6-compatibility.gradle'
 apply from: 'gradle/precommit.gradle'
 
 apply plugin: 'org.shipkit.gradle-plugin'
+apply plugin: 'com.gradle.plugin-publish'
 apply from: 'gradle/upgrade-downstream.gradle'
 
 sourceCompatibility = 1.6

--- a/src/main/groovy/org/shipkit/internal/gradle/plugin/GradlePortalPublishPlugin.java
+++ b/src/main/groovy/org/shipkit/internal/gradle/plugin/GradlePortalPublishPlugin.java
@@ -1,0 +1,95 @@
+package org.shipkit.internal.gradle.plugin;
+
+import org.gradle.api.Plugin;
+import org.gradle.api.Project;
+import org.gradle.api.Task;
+import org.gradle.api.logging.Logger;
+import org.gradle.api.logging.Logging;
+import org.gradle.api.specs.Spec;
+import org.shipkit.gradle.configuration.ShipkitConfiguration;
+import org.shipkit.internal.gradle.configuration.BasicValidator;
+import org.shipkit.internal.gradle.configuration.LazyConfiguration;
+import org.shipkit.internal.gradle.configuration.ShipkitConfigurationPlugin;
+import org.shipkit.internal.util.EnvVariables;
+
+import javax.inject.Inject;
+
+import static org.shipkit.internal.gradle.util.StringUtil.isEmpty;
+
+/**
+ * Helps publishing to Gradle plugin portal.
+ * Uses env variables to configure key and secret (requirements for publication).
+ * Disables publication task in dry run mode.
+ * Intended to be applied in a submodule that hosts Gradle plugin code to be published.
+ *
+ * Applies:
+ * <ul>
+ *     <li>{@link ShipkitConfigurationPlugin}</li>
+ *     <li>com.gradle.plugin-publish</li>
+ * </ul>
+ *
+ * <ul>
+ *     <li>Sets 'gradle.publish.key', 'gradle.publish.secret' project properties based on env variables:
+ *          GRADLE_PUBLISH_KEY, GRADLE_PUBLISH_SECRET</li>
+ *     <li>Validates presence of publish key and secret if 'publishPlugins' task is in the task graph</li>
+ *     <li>Skips 'publishPlugins' task if dryRun is enabled, see {@link ShipkitConfiguration#dryRun}</li>
+ * </ul>
+ *
+ */
+public class GradlePortalPublishPlugin implements Plugin<Project> {
+
+    private final static Logger LOG = Logging.getLogger(GradlePortalPublishPlugin.class);
+
+    final static String PUBLISH_KEY_ENV = "GRADLE_PUBLISH_KEY";
+    final static String PUBLISH_SECRET_ENV = "GRADLE_PUBLISH_SECRET";
+    final static String PUBLISH_KEY_PROPERTY = "gradle.publish.key";
+    final static String PUBLISH_SECRET_PROPERTY = "gradle.publish.secret";
+
+    private final EnvVariables envVariables;
+    public final static String PUBLISH_PLUGINS_TASK = "publishPlugins";
+
+    GradlePortalPublishPlugin(EnvVariables envVariables) {
+        this.envVariables = envVariables;
+    }
+
+    @Inject public GradlePortalPublishPlugin() {
+        this(new EnvVariables());
+    }
+
+    @Override
+    public void apply(final Project project) {
+        final ShipkitConfiguration conf = project.getPlugins().apply(ShipkitConfigurationPlugin.class).getConfiguration();
+        project.getPlugins().apply("com.gradle.plugin-publish");
+
+        final Task publishPlugins = project.getTasks().getByName(PUBLISH_PLUGINS_TASK);
+
+        LazyConfiguration.lazyConfiguration(publishPlugins, new Runnable() {
+            @Override
+            public void run() {
+                authenticate(PUBLISH_KEY_PROPERTY, project, PUBLISH_KEY_ENV, envVariables);
+                authenticate(PUBLISH_SECRET_PROPERTY, project, PUBLISH_SECRET_ENV, envVariables);
+            }
+        });
+
+        publishPlugins.onlyIf(new Spec<Task>() {
+            @Override
+            public boolean isSatisfiedBy(Task t) {
+                if (conf.isDryRun()) {
+                    LOG.info("dryRun is enabled, skipping '{}' using 'onlyIf'", t.getName());
+                }
+                return !conf.isDryRun();
+            }
+        });
+    }
+
+    private static void authenticate(String projectProperty, Project project, String envVarName, EnvVariables envVariables) {
+        Object value = project.findProperty(projectProperty);
+        if (isEmpty(value)) {
+            value = envVariables.getNonEmptyEnv(envVarName);
+            BasicValidator.notNull(value, "Gradle Plugin Portal '" + projectProperty + "' is required. Options:\n" +
+                " - export '" + envVarName + "' env var (recommended for CI, don't commit secrets to VCS!)\n" +
+                " - use '" + projectProperty + "' project property");
+            project.getExtensions().getExtraProperties().set(projectProperty, value);
+        }
+    }
+}

--- a/src/main/groovy/org/shipkit/internal/gradle/plugin/PluginDiscoveryPlugin.java
+++ b/src/main/groovy/org/shipkit/internal/gradle/plugin/PluginDiscoveryPlugin.java
@@ -17,6 +17,11 @@ import static org.shipkit.internal.gradle.plugin.GradlePortalPublishPlugin.PUBLI
  * will automatically pick up available gradle plugins (discovered via properties files in META-INF/gradle-plugins) and
  * will configure the pluginBundle extension (provided via 'com.gradle.plugin-publish' plugin) accordingly.
  *
+ * Applies plugins:
+ * <ul>
+ *     <li>com.gradle.plugin-publish</li>
+ * </ul>
+ *
  * Adds tasks:
  * <ul>
  *     <li>'discoverPlugins' - of type {@link PluginDiscoveryTask}.
@@ -29,22 +34,16 @@ public class PluginDiscoveryPlugin implements Plugin<Project> {
 
     @Override
     public void apply(final Project project) {
-        project.getPlugins().withId("com.gradle.plugin-publish", new Action<Plugin>() {
-
+        project.getPlugins().apply("com.gradle.plugin-publish");
+        final Task task = TaskMaker.task(project, DISCOVER_PLUGINS, PluginDiscoveryTask.class, new Action<PluginDiscoveryTask>() {
             @Override
-            public void execute(final Plugin plugin) {
-                final Task task = TaskMaker.task(project, DISCOVER_PLUGINS, PluginDiscoveryTask.class, new Action<PluginDiscoveryTask>() {
-                    @Override
-                    public void execute(final PluginDiscoveryTask task) {
-                        task.setDescription("discover gradle plugins");
-                    }
-                });
-
-                final Task publishPlugins = project.getTasks().getByName(PUBLISH_PLUGINS_TASK);
-                publishPlugins.dependsOn(task);
+            public void execute(final PluginDiscoveryTask task) {
+                task.setDescription("discover gradle plugins");
             }
-
         });
+
+        final Task publishPlugins = project.getTasks().getByName(PUBLISH_PLUGINS_TASK);
+        publishPlugins.dependsOn(task);
     }
 
 }

--- a/src/main/groovy/org/shipkit/internal/gradle/plugin/PluginDiscoveryPlugin.java
+++ b/src/main/groovy/org/shipkit/internal/gradle/plugin/PluginDiscoveryPlugin.java
@@ -8,7 +8,7 @@ import org.gradle.api.Task;
 import org.shipkit.gradle.plugin.PluginDiscoveryTask;
 import org.shipkit.internal.gradle.util.TaskMaker;
 
-import static org.shipkit.internal.gradle.release.GradlePortalReleasePlugin.PUBLISH_PLUGINS_TASK;
+import static org.shipkit.internal.gradle.plugin.GradlePortalPublishPlugin.PUBLISH_PLUGINS_TASK;
 
 /**
  * This plugin discovers gradle plugins and adds them to the {@link PluginBundleExtension}.

--- a/src/main/groovy/org/shipkit/internal/gradle/plugin/ShipkitGradlePlugin.java
+++ b/src/main/groovy/org/shipkit/internal/gradle/plugin/ShipkitGradlePlugin.java
@@ -16,7 +16,7 @@ import org.shipkit.internal.gradle.release.TravisPlugin;
  *     <li>{@link PluginDiscoveryPlugin}</li>
  *     <li>{@link PluginValidationPlugin}</li>
  *     <li>{@link CiReleasePlugin}</li>
- *     <li>{@link GradlePortalReleasePlugin}</li>
+ *     <li>{@link GradlePortalPublishPlugin}</li>
  * </ul>
  */
 public class ShipkitGradlePlugin implements Plugin<Project> {

--- a/src/main/groovy/org/shipkit/internal/gradle/plugin/ShipkitGradlePlugin.java
+++ b/src/main/groovy/org/shipkit/internal/gradle/plugin/ShipkitGradlePlugin.java
@@ -13,10 +13,8 @@ import org.shipkit.internal.gradle.release.TravisPlugin;
  *
  * <ul>
  *     <li>{@link TravisPlugin}</li>
- *     <li>{@link PluginDiscoveryPlugin}</li>
- *     <li>{@link PluginValidationPlugin}</li>
  *     <li>{@link CiReleasePlugin}</li>
- *     <li>{@link GradlePortalPublishPlugin}</li>
+ *     <li>{@link GradlePortalReleasePlugin}</li>
  * </ul>
  */
 public class ShipkitGradlePlugin implements Plugin<Project> {
@@ -24,8 +22,6 @@ public class ShipkitGradlePlugin implements Plugin<Project> {
     @Override
     public void apply(Project project) {
         project.getPlugins().apply(TravisPlugin.class);
-        project.getPlugins().apply(PluginDiscoveryPlugin.class);
-        project.getPlugins().apply(PluginValidationPlugin.class);
         project.getPlugins().apply(CiReleasePlugin.class);
         project.getPlugins().apply(GradlePortalReleasePlugin.class);
     }

--- a/src/main/groovy/org/shipkit/internal/gradle/release/GradlePortalReleasePlugin.java
+++ b/src/main/groovy/org/shipkit/internal/gradle/release/GradlePortalReleasePlugin.java
@@ -6,6 +6,8 @@ import org.gradle.api.Project;
 import org.gradle.api.Task;
 import org.shipkit.internal.gradle.git.GitPlugin;
 import org.shipkit.internal.gradle.plugin.GradlePortalPublishPlugin;
+import org.shipkit.internal.gradle.plugin.PluginDiscoveryPlugin;
+import org.shipkit.internal.gradle.plugin.PluginValidationPlugin;
 
 /**
  * Automated releases to Gradle Plugin portal.
@@ -15,7 +17,13 @@ import org.shipkit.internal.gradle.plugin.GradlePortalPublishPlugin;
  * Applies:
  * <ul>
  *     <li>{@link ReleasePlugin}</li>
- *     <li>{@link GradlePortalPublishPlugin} to every subproject with "com.gradle.plugin-publish" plugin</li>
+ * </ul>
+ *
+ * Applies to every subproject with "com.gradle.plugin-publish" plugin:
+ * <ul>
+ *     <li>{@link GradlePortalPublishPlugin}</li>
+ *     <li>{@link PluginDiscoveryPlugin}</li>
+ *     <li>{@link PluginValidationPlugin}</li>
  * </ul>
  *
  * Behavior:
@@ -37,7 +45,10 @@ public class GradlePortalReleasePlugin implements Plugin<Project> {
                 subproject.getPlugins().withId("com.gradle.plugin-publish", new Action<Plugin>() {
                     @Override
                     public void execute(Plugin plugin) {
+                        subproject.getPlugins().apply(PluginDiscoveryPlugin.class);
+                        subproject.getPlugins().apply(PluginValidationPlugin.class);
                         subproject.getPlugins().apply(GradlePortalPublishPlugin.class);
+
                         Task publishPlugins = project.getTasks().getByName(GradlePortalPublishPlugin.PUBLISH_PLUGINS_TASK);
 
                         performRelease.dependsOn(publishPlugins); //perform release will actually publish the plugins

--- a/src/main/groovy/org/shipkit/internal/gradle/release/GradlePortalReleasePlugin.java
+++ b/src/main/groovy/org/shipkit/internal/gradle/release/GradlePortalReleasePlugin.java
@@ -1,104 +1,54 @@
 package org.shipkit.internal.gradle.release;
 
+import org.gradle.api.Action;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.Task;
-import org.gradle.api.logging.Logger;
-import org.gradle.api.logging.Logging;
-import org.gradle.api.specs.Spec;
-import org.shipkit.gradle.configuration.ShipkitConfiguration;
-import org.shipkit.internal.gradle.configuration.BasicValidator;
-import org.shipkit.internal.gradle.configuration.LazyConfiguration;
-import org.shipkit.internal.gradle.configuration.ShipkitConfigurationPlugin;
 import org.shipkit.internal.gradle.git.GitPlugin;
-import org.shipkit.internal.util.EnvVariables;
-
-import javax.inject.Inject;
-
-import static org.shipkit.internal.gradle.util.StringUtil.isEmpty;
+import org.shipkit.internal.gradle.plugin.GradlePortalPublishPlugin;
 
 /**
  * Automated releases to Gradle Plugin portal.
  * Sets up task dependencies and applies configuration needed for automated releases of Gradle plugins.
+ * Intended to be applied to the root project.
  *
  * Applies:
  * <ul>
  *     <li>{@link ReleasePlugin}</li>
- *     <li>com.gradle.plugin-publish</li>
+ *     <li>{@link GradlePortalPublishPlugin} to every subproject with "com.gradle.plugin-publish" plugin</li>
  * </ul>
  *
+ * Behavior:
  * <ul>
- *     <li>Sets 'gradle.publish.key', 'gradle.publish.secret' project properties based on env variables:
- *          GRADLE_PUBLISH_KEY, GRADLE_PUBLISH_SECRET</li>
- *     <li>Validates presence of publish key and secret if 'publishPlugins' task is in the task graph</li>
- *     <li>Skips 'publishPlugins' task if dryRun is enabled, see {@link ShipkitConfiguration#dryRun}</li>
+ *     <li>Hooks up task dependencies so that performing release will publish all plugins from all subprojects</li>
  * </ul>
  */
 public class GradlePortalReleasePlugin implements Plugin<Project> {
 
-    private final static Logger LOG = Logging.getLogger(GradlePortalReleasePlugin.class);
-
-    final static String PUBLISH_KEY_ENV = "GRADLE_PUBLISH_KEY";
-    final static String PUBLISH_SECRET_ENV = "GRADLE_PUBLISH_SECRET";
-    final static String PUBLISH_KEY_PROPERTY = "gradle.publish.key";
-    final static String PUBLISH_SECRET_PROPERTY = "gradle.publish.secret";
-
-    private final EnvVariables envVariables;
-    public final static String PUBLISH_PLUGINS_TASK = "publishPlugins";
-
-    GradlePortalReleasePlugin(EnvVariables envVariables) {
-        this.envVariables = envVariables;
-    }
-
-    @Inject public GradlePortalReleasePlugin() {
-        this(new EnvVariables());
-    }
-
     @Override
     public void apply(final Project project) {
-        final ShipkitConfiguration conf = project.getPlugins().apply(ShipkitConfigurationPlugin.class).getConfiguration();
         project.getPlugins().apply(ReleasePlugin.class);
-        project.getPlugins().apply("com.gradle.plugin-publish");
+        final Task performRelease = project.getTasks().getByName(ReleasePlugin.PERFORM_RELEASE_TASK);
+        final Task gitPush = project.getTasks().getByName(GitPlugin.GIT_PUSH_TASK);
 
-        final Task publishPlugins = project.getTasks().getByName(PUBLISH_PLUGINS_TASK);
-
-        LazyConfiguration.lazyConfiguration(publishPlugins, new Runnable() {
+        project.allprojects(new Action<Project>() {
             @Override
-            public void run() {
-                authenticate(PUBLISH_KEY_PROPERTY, project, PUBLISH_KEY_ENV, envVariables);
-                authenticate(PUBLISH_SECRET_PROPERTY, project, PUBLISH_SECRET_ENV, envVariables);
+            public void execute(final Project subproject) {
+                subproject.getPlugins().withId("com.gradle.plugin-publish", new Action<Plugin>() {
+                    @Override
+                    public void execute(Plugin plugin) {
+                        subproject.getPlugins().apply(GradlePortalPublishPlugin.class);
+                        Task publishPlugins = project.getTasks().getByName(GradlePortalPublishPlugin.PUBLISH_PLUGINS_TASK);
+
+                        performRelease.dependsOn(publishPlugins); //perform release will actually publish the plugins
+                        publishPlugins.mustRunAfter(gitPush);     //git push is easier to revert than perform release
+
+                        //so that we first build plugins to be published, then do git push, we're using 'buildArchives' for that
+                        publishPlugins.dependsOn("buildArchives");
+                        gitPush.mustRunAfter("buildArchives");
+                    }
+                });
             }
         });
-
-        Task performRelease = project.getTasks().getByName(ReleasePlugin.PERFORM_RELEASE_TASK);
-        Task gitPush = project.getTasks().getByName(GitPlugin.GIT_PUSH_TASK);
-
-        performRelease.dependsOn(publishPlugins); //perform release will actually publish the plugins
-        publishPlugins.mustRunAfter(gitPush);     //git push is easier to revert than perform release
-
-        //so that we first build plugins to be published, then do git push, we're using 'buildArchives' for that
-        publishPlugins.dependsOn("buildArchives");
-        gitPush.mustRunAfter("buildArchives");
-
-        publishPlugins.onlyIf(new Spec<Task>() {
-            @Override
-            public boolean isSatisfiedBy(Task t) {
-                if (conf.isDryRun()) {
-                    LOG.info("dryRun is enabled, skipping '{}' using 'onlyIf'", t.getName());
-                }
-                return !conf.isDryRun();
-            }
-        });
-    }
-
-    private static void authenticate(String projectProperty, Project project, String envVarName, EnvVariables envVariables) {
-        Object value = project.findProperty(projectProperty);
-        if (isEmpty(value)) {
-            value = envVariables.getNonEmptyEnv(envVarName);
-            BasicValidator.notNull(value, "Gradle Plugin Portal '" + projectProperty + "' is required. Options:\n" +
-                " - export '" + envVarName + "' env var (recommended for CI, don't commit secrets to VCS!)\n" +
-                " - use '" + projectProperty + "' project property");
-            project.getExtensions().getExtraProperties().set(projectProperty, value);
-        }
     }
 }

--- a/src/test/groovy/org/shipkit/gradle/ShipkitGradlePluginIntegTest.groovy
+++ b/src/test/groovy/org/shipkit/gradle/ShipkitGradlePluginIntegTest.groovy
@@ -15,6 +15,7 @@ class ShipkitGradlePluginIntegTest extends GradleSpecification {
 
         buildFile << """
             apply plugin: "org.shipkit.gradle-plugin"
+            apply plugin: "com.gradle.plugin-publish"
             ext.'gradle.publish.key' = 'key'
             ext.'gradle.publish.secret' = 'secret'
         """

--- a/src/test/groovy/org/shipkit/internal/gradle/plugin/GradlePortalPublishPluginTest.groovy
+++ b/src/test/groovy/org/shipkit/internal/gradle/plugin/GradlePortalPublishPluginTest.groovy
@@ -1,0 +1,73 @@
+package org.shipkit.internal.gradle.plugin
+
+import org.gradle.api.GradleException
+import org.shipkit.internal.gradle.configuration.LazyConfiguration
+import org.shipkit.internal.util.EnvVariables
+import testutil.PluginSpecification
+
+import static org.shipkit.internal.gradle.plugin.GradlePortalPublishPlugin.PUBLISH_PLUGINS_TASK
+
+class GradlePortalPublishPluginTest extends PluginSpecification {
+
+    def env = Mock(EnvVariables)
+
+    def "validates publish key"() {
+        new GradlePortalPublishPlugin(env).apply(project)
+
+        when:
+        LazyConfiguration.forceConfiguration(project.tasks[PUBLISH_PLUGINS_TASK])
+
+        then:
+        def ex = thrown(GradleException)
+        ex.message == """Gradle Plugin Portal 'gradle.publish.key' is required. Options:
+ - export 'GRADLE_PUBLISH_KEY' env var (recommended for CI, don't commit secrets to VCS!)
+ - use 'gradle.publish.key' project property"""
+    }
+
+    def "validates publish secret"() {
+        new GradlePortalPublishPlugin(env).apply(project)
+        project.ext.set(GradlePortalPublishPlugin.PUBLISH_KEY_PROPERTY, "key")
+
+        when:
+        LazyConfiguration.forceConfiguration(project.tasks[PUBLISH_PLUGINS_TASK])
+
+        then:
+        def ex = thrown(GradleException)
+        ex.message == """Gradle Plugin Portal 'gradle.publish.secret' is required. Options:
+ - export 'GRADLE_PUBLISH_SECRET' env var (recommended for CI, don't commit secrets to VCS!)
+ - use 'gradle.publish.secret' project property"""
+    }
+
+    def "uses existing project properties"() {
+        new GradlePortalPublishPlugin(env).apply(project)
+        project.ext.set(GradlePortalPublishPlugin.PUBLISH_KEY_PROPERTY, "key")
+        project.ext.set(GradlePortalPublishPlugin.PUBLISH_SECRET_PROPERTY, "secret")
+
+        expect: //no exception thrown
+        LazyConfiguration.forceConfiguration(project.tasks[PUBLISH_PLUGINS_TASK])
+    }
+
+    def "sets key based on env var"() {
+        env.getNonEmptyEnv(GradlePortalPublishPlugin.PUBLISH_KEY_ENV) >> "123"
+        env.getNonEmptyEnv(GradlePortalPublishPlugin.PUBLISH_SECRET_ENV) >> "abc"
+
+        when:
+        new GradlePortalPublishPlugin(env).apply(project)
+        LazyConfiguration.forceConfiguration(project.tasks[PUBLISH_PLUGINS_TASK])
+
+        then:
+        project.ext.get(GradlePortalPublishPlugin.PUBLISH_KEY_PROPERTY) == "123"
+        project.ext.get(GradlePortalPublishPlugin.PUBLISH_SECRET_PROPERTY) == "abc"
+    }
+
+    def "dry run effectively disables the task"() {
+        project.shipkit.dryRun = true
+        project.plugins.apply(GradlePortalPublishPlugin.class)
+
+        when:
+        project.tasks[PUBLISH_PLUGINS_TASK].execute()
+
+        then:
+        noExceptionThrown() //normally the task would fail because it is not configured
+    }
+}

--- a/src/test/groovy/org/shipkit/internal/gradle/plugin/PluginDiscoveryPluginTest.groovy
+++ b/src/test/groovy/org/shipkit/internal/gradle/plugin/PluginDiscoveryPluginTest.groovy
@@ -20,7 +20,6 @@ class PluginDiscoveryPluginTest extends PluginSpecification {
         project.file("src/main/resources/test.properties") << "properties file in src/main/resources"
         project.file("another.properties") << "just another properties file"
         when:
-        project.plugins.apply("com.gradle.plugin-publish")
         project.plugins.apply(PluginDiscoveryPlugin)
         project.tasks[PluginDiscoveryPlugin.DISCOVER_PLUGINS].execute()
         then:

--- a/src/test/groovy/org/shipkit/internal/gradle/release/GradlePortalReleasePluginTest.groovy
+++ b/src/test/groovy/org/shipkit/internal/gradle/release/GradlePortalReleasePluginTest.groovy
@@ -1,73 +1,12 @@
 package org.shipkit.internal.gradle.release
 
-import org.gradle.api.GradleException
-import org.shipkit.internal.gradle.configuration.LazyConfiguration
-import org.shipkit.internal.util.EnvVariables
 import testutil.PluginSpecification
-
-import static org.shipkit.internal.gradle.release.GradlePortalReleasePlugin.PUBLISH_PLUGINS_TASK
 
 class GradlePortalReleasePluginTest extends PluginSpecification {
 
-    def env = Mock(EnvVariables)
-
-    def "validates publish key"() {
-        new GradlePortalReleasePlugin(env).apply(project)
-
-        when:
-        LazyConfiguration.forceConfiguration(project.tasks[PUBLISH_PLUGINS_TASK])
-
-        then:
-        def ex = thrown(GradleException)
-        ex.message == """Gradle Plugin Portal 'gradle.publish.key' is required. Options:
- - export 'GRADLE_PUBLISH_KEY' env var (recommended for CI, don't commit secrets to VCS!)
- - use 'gradle.publish.key' project property"""
-    }
-
-    def "validates publish secret"() {
-        new GradlePortalReleasePlugin(env).apply(project)
-        project.ext.set(GradlePortalReleasePlugin.PUBLISH_KEY_PROPERTY, "key")
-
-        when:
-        LazyConfiguration.forceConfiguration(project.tasks[PUBLISH_PLUGINS_TASK])
-
-        then:
-        def ex = thrown(GradleException)
-        ex.message == """Gradle Plugin Portal 'gradle.publish.secret' is required. Options:
- - export 'GRADLE_PUBLISH_SECRET' env var (recommended for CI, don't commit secrets to VCS!)
- - use 'gradle.publish.secret' project property"""
-    }
-
-    def "uses existing project properties"() {
-        new GradlePortalReleasePlugin(env).apply(project)
-        project.ext.set(GradlePortalReleasePlugin.PUBLISH_KEY_PROPERTY, "key")
-        project.ext.set(GradlePortalReleasePlugin.PUBLISH_SECRET_PROPERTY, "secret")
-
-        expect: //no exception thrown
-        LazyConfiguration.forceConfiguration(project.tasks[PUBLISH_PLUGINS_TASK])
-    }
-
-    def "sets key based on env var"() {
-        env.getNonEmptyEnv(GradlePortalReleasePlugin.PUBLISH_KEY_ENV) >> "123"
-        env.getNonEmptyEnv(GradlePortalReleasePlugin.PUBLISH_SECRET_ENV) >> "abc"
-
-        when:
-        new GradlePortalReleasePlugin(env).apply(project)
-        LazyConfiguration.forceConfiguration(project.tasks[PUBLISH_PLUGINS_TASK])
-
-        then:
-        project.ext.get(GradlePortalReleasePlugin.PUBLISH_KEY_PROPERTY) == "123"
-        project.ext.get(GradlePortalReleasePlugin.PUBLISH_SECRET_PROPERTY) == "abc"
-    }
-
-    def "dry run effectively disables the task"() {
-        project.shipkit.dryRun = true
+    def "applies"() {
+        expect:
         project.plugins.apply(GradlePortalReleasePlugin.class)
-
-        when:
-        project.tasks[PUBLISH_PLUGINS_TASK].execute()
-
-        then:
-        noExceptionThrown() //normally the task would fail because it is not configured
+        project.plugins.apply("com.gradle.plugin-publish")
     }
 }


### PR DESCRIPTION
Changed the plugin hierarchy so that we can apply plugins in submodules. Now the user can publish Gradle plugin from a submodule. Needed for #360

 - Instead of applying publication-specific plugins directly to root, we ask the user to apply "com.gradle.plugin-publish" plugin. Shipkit will automatically configure every submodule that uses "com.gradle.plugin-publish" plugin. This is the same strategy that we have for "java" plugin.

Tested by running the build and trusting our integration test :)