### PR TITLE
Fixed problem with downstream upgrade, improved logging

### DIFF
--- a/gradle/shipkit.gradle
+++ b/gradle/shipkit.gradle
@@ -12,3 +12,5 @@ afterEvaluate {
 
     tasks.check.dependsOn validatePlugins
 }
+
+apply plugin: 'org.shipkit.upgrade-dependency'

--- a/src/main/groovy/org/shipkit/internal/gradle/exec/ExecCommandFactory.java
+++ b/src/main/groovy/org/shipkit/internal/gradle/exec/ExecCommandFactory.java
@@ -10,7 +10,7 @@ import org.gradle.process.ExecSpec;
 import org.shipkit.gradle.exec.ExecCommand;
 
 import java.io.File;
-import java.util.Collection;
+import java.util.List;
 
 import static java.util.Arrays.asList;
 
@@ -66,30 +66,29 @@ public class ExecCommandFactory {
      * Exec command that will throw the exception when the command line fails.
      * This is the most typical kind of exec command.
      */
-    public static ExecCommand execCommand(String description, Collection<String> commandLine) {
+    public static ExecCommand execCommand(String description, List<String> commandLine) {
         String prefix = defaultPrefix(commandLine);
         return new ExecCommand(prefix, description, commandLine, ignoreResult(), ensureSucceeded(prefix));
     }
 
     /**
-     * See {@link #execCommand(String, Collection)}
+     * See {@link #execCommand(String, List)}
      */
     public static ExecCommand execCommand(String description, String ... commandLine) {
         return execCommand(description, asList(commandLine));
     }
 
     /**
-     * See {@link #execCommand(String, Collection)}
+     * See {@link #execCommand(String, List)}
      */
     public static ExecCommand execCommand(String description, File workingDir, String ... commandLine) {
-        Collection<String> cmd = asList(commandLine);
+        List<String> cmd = asList(commandLine);
         String prefix = defaultPrefix(cmd);
         return new ExecCommand(prefix, description, cmd, ignoreResult(workingDir), ensureSucceeded(prefix));
     }
 
-    private static String defaultPrefix(Collection<String> commandLine) {
-        //by default, we are using the first argument as prefix
-        return "[" + commandLine.iterator().next() + "] ";
+    private static String defaultPrefix(List<String> commandLine) {
+        return "[" + commandLine.get(0) + "] ";
     }
 
     /**
@@ -97,7 +96,7 @@ public class ExecCommandFactory {
      * Useful if the user needs custom behavior when command line finishes executing.
      * For example, we can ignore the failure.
      */
-    public static ExecCommand execCommand(String description, Collection<String> commandLine, Action<ExecResult> resultAction) {
+    public static ExecCommand execCommand(String description, List<String> commandLine, Action<ExecResult> resultAction) {
         return new ExecCommand(defaultPrefix(commandLine), description, commandLine, ignoreResult(), resultAction);
     }
 }

--- a/src/main/groovy/org/shipkit/internal/gradle/exec/ExecCommandFactory.java
+++ b/src/main/groovy/org/shipkit/internal/gradle/exec/ExecCommandFactory.java
@@ -87,8 +87,9 @@ public class ExecCommandFactory {
         return new ExecCommand(prefix, description, cmd, ignoreResult(workingDir), ensureSucceeded(prefix));
     }
 
-    private static String defaultPrefix(List<String> commandLine) {
-        return "[" + commandLine.get(0) + "] ";
+    static String defaultPrefix(List<String> commandLine) {
+        String prefix = commandLine.size() > 1 ? commandLine.get(1) : commandLine.get(0);
+        return "[" + prefix + "] ";
     }
 
     /**

--- a/src/test/groovy/org/shipkit/gradle/exec/ShipkitExecTaskTest.groovy
+++ b/src/test/groovy/org/shipkit/gradle/exec/ShipkitExecTaskTest.groovy
@@ -36,7 +36,7 @@ class ShipkitExecTaskTest extends Specification {
         then:
         def ex = thrown(TaskExecutionException.class)
         ex.cause.message.startsWith "External process failed with exit code"
-        ex.cause.message.endsWith "\nPlease inspect the command output prefixed with '[ls]' the build log."
+        ex.cause.message.endsWith "\nPlease inspect the command output prefixed with '[missing file]' the build log."
     }
 
     def "when first command is configured to stop execution, second command will not fail the entire task"() {

--- a/src/test/groovy/org/shipkit/internal/gradle/exec/ExecCommandFactoryTest.groovy
+++ b/src/test/groovy/org/shipkit/internal/gradle/exec/ExecCommandFactoryTest.groovy
@@ -52,4 +52,10 @@ Please inspect the command output prefixed with '[git]' the build log."""
         then:
         1 * execSpec.setIgnoreExitValue(true)
     }
+
+    def "default prefix"() {
+        expect:
+        ExecCommandFactory.defaultPrefix(["git"]) == "[git] "
+        ExecCommandFactory.defaultPrefix(["git", "status"]) == "[status] "
+    }
 }


### PR DESCRIPTION
- Fixed problem with 'downstreamUpgrade' task of Shipkit. Adding this plugin allows Shipkit project to automatically send PRs to this project with version bumps of Shipkit.  See: #390
- Improved the default prefix of forked processes …I found it not easy to debug if the default prefix was the same for every invocation. Now, instead of [./gradlew] we will see [performRelease], instead of [git] (git status) we will see [status]. I think it is a better default, it will be easier to debug Travis CI builds. Example of a build log to debug is in #390

