### PR TITLE
fix upgrade-downstream

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,11 +17,14 @@ apply plugin: 'org.shipkit.gradle-plugin'
 
 apply from: "$rootDir/gradle/upgrade-downstream.gradle"
 
+allprojects {
+    group = 'org.shipkit'
+}
+
 subprojects {
     repositories {
         jcenter()
         maven { url "https://plugins.gradle.org/m2/" }
     }
-    group = 'org.shipkit'
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -17,9 +17,7 @@ apply plugin: 'org.shipkit.gradle-plugin'
 
 allprojects {
     group = 'org.shipkit'
-}
 
-subprojects {
     repositories {
         jcenter()
         maven { url "https://plugins.gradle.org/m2/" }

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         maven { url "https://plugins.gradle.org/m2/" }
     }
     dependencies {
-        classpath "org.shipkit:shipkit:0.9.82"
+        classpath "org.shipkit:shipkit:0.9.83"
         classpath 'ru.vyarus:gradle-animalsniffer-plugin:1.3.0'
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         maven { url "https://plugins.gradle.org/m2/" }
     }
     dependencies {
-        classpath "org.shipkit:shipkit:0.9.81"
+        classpath "org.shipkit:shipkit:0.9.82"
         classpath 'ru.vyarus:gradle-animalsniffer-plugin:1.3.0'
     }
 }
@@ -14,8 +14,6 @@ apply from: "$rootDir/gradle/java6-compatibility.gradle"
 apply from: "$rootDir/gradle/precommit.gradle"
 
 apply plugin: 'org.shipkit.gradle-plugin'
-
-apply from: "$rootDir/gradle/upgrade-downstream.gradle"
 
 allprojects {
     group = 'org.shipkit'

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         maven { url "https://plugins.gradle.org/m2/" }
     }
     dependencies {
-        classpath "org.shipkit:shipkit:0.9.83"
+        classpath 'org.shipkit:shipkit:0.9.83'
         classpath 'ru.vyarus:gradle-animalsniffer-plugin:1.3.0'
     }
 }

--- a/gradle/upgrade-downstream.gradle
+++ b/gradle/upgrade-downstream.gradle
@@ -1,6 +1,5 @@
 apply plugin: 'org.shipkit.ci-upgrade-downstream'
 
 upgradeDownstream {
-    //repositories = ['mockito/shipkit-example', 'mockito/shipkit-bootstrap', 'mockito/shipkit']
-    repositories = []
+    repositories = ['mockito/shipkit-example', 'mockito/shipkit-bootstrap', 'mockito/shipkit']
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,6 +1,8 @@
 include "shipkit"
 include "testDownstream"
 
+rootProject.name = "shipkit-root"
+
 rootProject.children.each { project ->
     String projectDirName = "subprojects/$project.name"
     project.projectDir = new File(settingsDir, projectDirName)

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,5 +1,3 @@
-rootProject.name = 'shipkit'
-
 include "shipkit"
 include "testDownstream"
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,3 +1,5 @@
+rootProject.name = 'shipkit'
+
 include "shipkit"
 include "testDownstream"
 

--- a/subprojects/shipkit/shipkit.gradle
+++ b/subprojects/shipkit/shipkit.gradle
@@ -6,6 +6,8 @@ apply plugin: 'codenarc'
 
 apply plugin: 'com.gradle.plugin-publish'
 
+apply from: "$rootDir/gradle/upgrade-downstream.gradle"
+
 checkstyle {
     configFile = file("${rootDir}/config/checkstyle/checkstyle.xml")
 }

--- a/subprojects/shipkit/shipkit.gradle
+++ b/subprojects/shipkit/shipkit.gradle
@@ -53,7 +53,6 @@ if (JavaVersion.current().isJava8Compatible()) {
     }
 }
 
-
 task fastInstall { Task t ->
     description = "Fast installation for quick local testing."
     t.dependsOn install

--- a/subprojects/shipkit/shipkit.gradle
+++ b/subprojects/shipkit/shipkit.gradle
@@ -1,4 +1,3 @@
-
 apply plugin: 'maven'
 apply plugin: 'idea'
 apply plugin: 'groovy'


### PR DESCRIPTION
basically, fixing the group name for the root project and make sure that the name of the rootproject is shipkit, reenable upgrade-downstream

fixes #403