### PR TITLE
Made shipkit.gitHub.repository optional

### DIFF
--- a/subprojects/shipkit/src/main/groovy/org/shipkit/gradle/configuration/ShipkitConfiguration.java
+++ b/subprojects/shipkit/src/main/groovy/org/shipkit/gradle/configuration/ShipkitConfiguration.java
@@ -140,8 +140,11 @@ public class ShipkitConfiguration {
 
         /**
          * GitHub repository name, for example: "mockito/shipkit"
+         *
+         * //TODO SF Javadoc about getRepository() throughout the project need to include information how we obtain this repo automatically
          */
         public String getRepository() {
+            //TODO SF we need a custom exception message that explains how we detect repository automatically and how to use it
             return store.getString("gitHub.repository");
         }
 

--- a/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/bintray/ShipkitBintrayPlugin.java
+++ b/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/bintray/ShipkitBintrayPlugin.java
@@ -11,6 +11,7 @@ import org.gradle.api.logging.Logging;
 import org.shipkit.gradle.configuration.ShipkitConfiguration;
 import org.shipkit.internal.gradle.configuration.LazyConfiguration;
 import org.shipkit.internal.gradle.configuration.ShipkitConfigurationPlugin;
+import org.shipkit.internal.gradle.git.GitAuthPlugin;
 
 import static org.shipkit.internal.gradle.configuration.BasicValidator.notNull;
 import static org.shipkit.internal.gradle.configuration.DeferredConfiguration.deferredConfiguration;
@@ -81,17 +82,23 @@ public class ShipkitBintrayPlugin implements Plugin<Project> {
                 if (pkg.getVersion().getVcsTag() == null) {
                     pkg.getVersion().setVcsTag(conf.getGit().getTagPrefix() + project.getVersion());
                 }
+            }
+        });
 
+        project.getPlugins().apply(GitAuthPlugin.class).provideAuthTo(bintrayUpload, new Action<GitAuthPlugin.GitAuth>() {
+            @Override
+            public void execute(GitAuthPlugin.GitAuth gitAuth) {
+                LOG.lifecycle("  Configuring website, issue tracker and vcs urls for Bintray package");
                 if (pkg.getWebsiteUrl() == null) {
-                    pkg.setWebsiteUrl(conf.getGitHub().getUrl() + "/" + conf.getGitHub().getRepository());
+                    pkg.setWebsiteUrl(conf.getGitHub().getUrl() + "/" + gitAuth.getRepositoryName());
                 }
 
                 if (pkg.getIssueTrackerUrl() == null) {
-                    pkg.setIssueTrackerUrl(conf.getGitHub().getUrl() + "/" + conf.getGitHub().getRepository() + "/issues");
+                    pkg.setIssueTrackerUrl(conf.getGitHub().getUrl() + "/" + gitAuth.getRepositoryName() + "/issues");
                 }
 
                 if (pkg.getVcsUrl() == null) {
-                    pkg.setVcsUrl(conf.getGitHub().getUrl() + "/" + conf.getGitHub().getRepository() + ".git");
+                    pkg.setVcsUrl(conf.getGitHub().getUrl() + "/" + gitAuth.getRepositoryName() + ".git");
                 }
             }
         });

--- a/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/bintray/ShipkitBintrayPlugin.java
+++ b/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/bintray/ShipkitBintrayPlugin.java
@@ -85,9 +85,10 @@ public class ShipkitBintrayPlugin implements Plugin<Project> {
             }
         });
 
-        project.getPlugins().apply(GitAuthPlugin.class).provideAuthTo(bintrayUpload, new Action<GitAuthPlugin.GitAuth>() {
+        project.getRootProject().getPlugins().apply(GitAuthPlugin.class).provideAuthTo(bintrayUpload, new Action<GitAuthPlugin.GitAuth>() {
             @Override
             public void execute(GitAuthPlugin.GitAuth gitAuth) {
+                //TODO SF add unit test coverage
                 LOG.lifecycle("  Configuring website, issue tracker and vcs urls for Bintray package");
                 if (pkg.getWebsiteUrl() == null) {
                     pkg.setWebsiteUrl(conf.getGitHub().getUrl() + "/" + gitAuth.getRepositoryName());

--- a/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/contributors/github/GitHubContributorsPlugin.java
+++ b/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/contributors/github/GitHubContributorsPlugin.java
@@ -45,7 +45,7 @@ public class GitHubContributorsPlugin implements Plugin<Project> {
         task.setApiUrl(conf.getGitHub().getApiUrl());
         task.setReadOnlyAuthToken(conf.getGitHub().getReadOnlyAuthToken());
 
-        project.getPlugins().apply(GitAuthPlugin.class).provideAuthTo(task, new Action<GitAuthPlugin.GitAuth>() {
+        project.getRootProject().getPlugins().apply(GitAuthPlugin.class).provideAuthTo(task, new Action<GitAuthPlugin.GitAuth>() {
             @Override
             public void execute(GitAuthPlugin.GitAuth gitAuth) {
                 task.setRepository(gitAuth.getRepositoryName());

--- a/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/contributors/github/GitHubContributorsPlugin.java
+++ b/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/contributors/github/GitHubContributorsPlugin.java
@@ -6,6 +6,7 @@ import org.gradle.api.Project;
 import org.shipkit.gradle.configuration.ShipkitConfiguration;
 import org.shipkit.gradle.notes.FetchGitHubContributorsTask;
 import org.shipkit.internal.gradle.configuration.ShipkitConfigurationPlugin;
+import org.shipkit.internal.gradle.git.GitAuthPlugin;
 import org.shipkit.internal.gradle.util.TaskMaker;
 
 import static org.shipkit.internal.gradle.util.BuildConventions.contributorsFile;
@@ -40,13 +41,15 @@ public class GitHubContributorsPlugin implements Plugin<Project> {
 
             }
         });
-        configureGithub(conf, task);
-    }
-
-    private void configureGithub(ShipkitConfiguration conf, FetchGitHubContributorsTask task) {
         task.setDescription("Fetch info about all project contributors from GitHub and store it in file");
         task.setApiUrl(conf.getGitHub().getApiUrl());
         task.setReadOnlyAuthToken(conf.getGitHub().getReadOnlyAuthToken());
-        task.setRepository(conf.getGitHub().getRepository());
+
+        project.getPlugins().apply(GitAuthPlugin.class).provideAuthTo(task, new Action<GitAuthPlugin.GitAuth>() {
+            @Override
+            public void execute(GitAuthPlugin.GitAuth gitAuth) {
+                task.setRepository(gitAuth.getRepositoryName());
+            }
+        });
     }
 }

--- a/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/git/GitAuthPlugin.java
+++ b/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/git/GitAuthPlugin.java
@@ -32,22 +32,24 @@ public class GitAuthPlugin implements Plugin<Project> {
 
     @Override
     public void apply(Project project) {
+        project.getPlugins().apply(ShipkitConfigurationPlugin.class);
+
         identifyTask = TaskMaker.task(project, IDENTIFY_GIT_ORIGIN_TASK, IdentifyGitOriginRepoTask.class, new Action<IdentifyGitOriginRepoTask>() {
             public void execute(IdentifyGitOriginRepoTask t) {
                 t.setDescription("Identifies current git origin repo.");
             }
         });
-        project.getPlugins().apply(ShipkitConfigurationPlugin.class);
     }
 
+    //TODO SF rename this method and surrounding types. This method provides more than just auth.
     public void provideAuthTo(Task t, final Action<GitAuth> action) {
         t.dependsOn(identifyTask);
         identifyTask.doLast(new Action<Task>() {
             public void execute(Task task) {
                 ShipkitConfiguration conf = identifyTask.getProject().getPlugins().getPlugin(ShipkitConfigurationPlugin.class).getConfiguration();
-                String repoUrl = getGitHubUrl(identifyTask.getOriginRepo(), conf);
+                String repoUrl = getGitHubUrl(identifyTask.getRepository(), conf);
                 String writeToken = conf.getLenient().getGitHub().getWriteAuthToken();
-                action.execute(new GitAuth(repoUrl, writeToken, identifyTask.getOriginRepo()));
+                action.execute(new GitAuth(repoUrl, writeToken, identifyTask.getRepository()));
             }
         });
     }

--- a/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/git/GitPlugin.java
+++ b/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/git/GitPlugin.java
@@ -85,7 +85,7 @@ public class GitPlugin implements Plugin<Project> {
                 t.getTargets().add(GitUtil.getTag(conf, project));
                 t.setDryRun(conf.isDryRun());
 
-                project.getPlugins().apply(GitAuthPlugin.class).provideAuthTo(t, new Action<GitAuthPlugin.GitAuth>() {
+                project.getRootProject().getPlugins().apply(GitAuthPlugin.class).provideAuthTo(t, new Action<GitAuthPlugin.GitAuth>() {
                     public void execute(GitAuthPlugin.GitAuth gitAuth) {
                         t.setUrl(gitAuth.getRepositoryUrl());
                         t.setSecretValue(gitAuth.getSecretValue());

--- a/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/init/InitPlugin.java
+++ b/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/init/InitPlugin.java
@@ -50,7 +50,7 @@ public class InitPlugin implements Plugin<Project> {
     public void apply(final Project project) {
         project.getPlugins().apply(VersioningPlugin.class);
         project.getPlugins().apply(ShipkitConfigurationPlugin.class);
-        final GitAuthPlugin gitAuthPlugin = project.getPlugins().apply(GitAuthPlugin.class);
+        final GitAuthPlugin gitAuthPlugin = project.getRootProject().getPlugins().apply(GitAuthPlugin.class);
 
         TaskMaker.task(project, INIT_TRAVIS_TASK, InitTravisTask.class, new Action<InitTravisTask>() {
             public void execute(InitTravisTask t) {

--- a/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/notes/ReleaseNotesPlugin.java
+++ b/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/notes/ReleaseNotesPlugin.java
@@ -47,7 +47,7 @@ public class ReleaseNotesPlugin implements Plugin<Project> {
         final ShipkitConfiguration conf = project.getPlugins().apply(ShipkitConfigurationPlugin.class).getConfiguration();
         project.getPlugins().apply(VersioningPlugin.class);
         project.getPlugins().apply(GitHubContributorsPlugin.class);
-        GitAuthPlugin authPlugin = project.getPlugins().apply(GitAuthPlugin.class);
+        GitAuthPlugin authPlugin = project.getRootProject().getPlugins().apply(GitAuthPlugin.class);
 
         releaseNotesTasks(project, conf, authPlugin);
     }

--- a/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/notes/ReleaseNotesPlugin.java
+++ b/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/notes/ReleaseNotesPlugin.java
@@ -9,6 +9,7 @@ import org.shipkit.gradle.notes.FetchReleaseNotesTask;
 import org.shipkit.gradle.notes.UpdateReleaseNotesTask;
 import org.shipkit.internal.gradle.configuration.ShipkitConfigurationPlugin;
 import org.shipkit.internal.gradle.contributors.github.GitHubContributorsPlugin;
+import org.shipkit.internal.gradle.git.GitAuthPlugin;
 import org.shipkit.internal.gradle.git.GitPlugin;
 import org.shipkit.internal.gradle.util.TaskMaker;
 import org.shipkit.internal.gradle.version.VersioningPlugin;
@@ -46,18 +47,25 @@ public class ReleaseNotesPlugin implements Plugin<Project> {
         final ShipkitConfiguration conf = project.getPlugins().apply(ShipkitConfigurationPlugin.class).getConfiguration();
         project.getPlugins().apply(VersioningPlugin.class);
         project.getPlugins().apply(GitHubContributorsPlugin.class);
+        GitAuthPlugin authPlugin = project.getPlugins().apply(GitAuthPlugin.class);
 
-        releaseNotesTasks(project, conf);
+        releaseNotesTasks(project, conf, authPlugin);
     }
 
-    private static void releaseNotesTasks(final Project project, final ShipkitConfiguration conf) {
+    private static void releaseNotesTasks(final Project project, final ShipkitConfiguration conf, final GitAuthPlugin authPlugin) {
         final FetchReleaseNotesTask releaseNotesFetcher = TaskMaker.task(project, FETCH_NOTES_TASK, FetchReleaseNotesTask.class, new Action<FetchReleaseNotesTask>() {
             public void execute(final FetchReleaseNotesTask t) {
                 t.setDescription("Fetches release notes data from Git and GitHub and serializes them to a file");
                 t.setOutputFile(new File(project.getBuildDir(), "detailed-release-notes.ser"));
                 t.setGitHubApiUrl(conf.getGitHub().getApiUrl());
                 t.setGitHubReadOnlyAuthToken(conf.getGitHub().getReadOnlyAuthToken());
-                t.setGitHubRepository(conf.getGitHub().getRepository());
+
+                authPlugin.provideAuthTo(t, new Action<GitAuthPlugin.GitAuth>() {
+                    public void execute(GitAuthPlugin.GitAuth gitAuth) {
+                        t.setGitHubRepository(gitAuth.getRepositoryName());
+                    }
+                });
+
                 t.setPreviousVersion(conf.getPreviousReleaseVersion());
                 t.setTagPrefix(conf.getGit().getTagPrefix());
                 t.setIgnoreCommitsContaining(conf.getReleaseNotes().getIgnoreCommitsContaining());
@@ -81,6 +89,12 @@ public class ReleaseNotesPlugin implements Plugin<Project> {
                         singletonList(releaseNotesFile), "release notes updated", t);
                     t.getOutputs().file(releaseNotesFile);
                 }
+
+                authPlugin.provideAuthTo(t, new Action<GitAuthPlugin.GitAuth>() {
+                    public void execute(GitAuthPlugin.GitAuth gitAuth) {
+                        t.setGitHubRepository(gitAuth.getRepositoryName());
+                    }
+                });
             }
         });
     }
@@ -101,7 +115,6 @@ public class ReleaseNotesPlugin implements Plugin<Project> {
         task.setGitHubLabelMapping(conf.getReleaseNotes().getLabelMapping());
         task.setReleaseNotesFile(project.file(conf.getReleaseNotes().getFile()));
         task.setGitHubUrl(conf.getGitHub().getUrl());
-        task.setGitHubRepository(conf.getGitHub().getRepository());
         task.setPreviousVersion(project.getExtensions().getByType(VersionInfo.class).getPreviousVersion());
 
         task.setReleaseNotesData(releaseNotesFetcher.getOutputFile());

--- a/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/versionupgrade/UpgradeDependencyPlugin.java
+++ b/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/versionupgrade/UpgradeDependencyPlugin.java
@@ -195,12 +195,24 @@ public class UpgradeDependencyPlugin implements Plugin<Project> {
                 task.setAuthToken(conf.getLenient().getGitHub().getWriteAuthToken());
                 task.setVersionBranch(getVersionBranchName(upgradeDependencyExtension));
                 task.setVersionUpgrade(upgradeDependencyExtension);
-                task.setUpstreamRepositoryName(conf.getGitHub().getRepository());
 
                 gitAuthPlugin.provideAuthTo(task, new Action<GitAuthPlugin.GitAuth>() {
                     @Override
                     public void execute(GitAuthPlugin.GitAuth gitAuth) {
                         task.setForkRepositoryName(gitAuth.getRepositoryName());
+                        String repoName = gitAuth.getRepositoryName().split("/")[1];
+
+                        /*
+                        TODO SF We need to change creation of pull requests because they require shipkit.gitHub.repository to be set.
+                        Let's create ticket for this.
+                        I am currently working on making this configuration setting optional.
+                        I need this for bootstrap scenarios and it will make the configuration simpler, too.
+
+                        Most likely, we will implement it by passing and additional parameter to version upgrade plugin
+
+                        Below is a temporary hack
+                        */
+                        task.setUpstreamRepositoryName("mockito/" + repoName);
                     }
                 });
 

--- a/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/versionupgrade/UpgradeDependencyPlugin.java
+++ b/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/versionupgrade/UpgradeDependencyPlugin.java
@@ -77,7 +77,7 @@ public class UpgradeDependencyPlugin implements Plugin<Project> {
     @Override
     public void apply(final Project project) {
         IncubatingWarning.warn("upgrade-dependency plugin");
-        final GitAuthPlugin gitAuthPlugin = project.getPlugins().apply(GitAuthPlugin.class);
+        final GitAuthPlugin gitAuthPlugin = project.getRootProject().getPlugins().apply(GitAuthPlugin.class);
         final ShipkitConfiguration conf = project.getPlugins().apply(ShipkitConfigurationPlugin.class).getConfiguration();
 
         upgradeDependencyExtension = project.getExtensions().create("upgradeDependency", UpgradeDependencyExtension.class);

--- a/subprojects/shipkit/src/test/groovy/org/shipkit/gradle/ShipkitGradlePluginIntegTest.groovy
+++ b/subprojects/shipkit/src/test/groovy/org/shipkit/gradle/ShipkitGradlePluginIntegTest.groovy
@@ -30,6 +30,7 @@ class ShipkitGradlePluginIntegTest extends GradleSpecification {
         expect:
         BuildResult result = pass("performRelease", "-m", "-s")
         skippedTaskPathsGradleBugWorkaround(result.output).join("\n") == """:bumpVersionFile
+:identifyGitOrigin
 :fetchContributors
 :fetchReleaseNotes
 :updateReleaseNotes
@@ -44,7 +45,6 @@ class ShipkitGradlePluginIntegTest extends GradleSpecification {
 :buildArchives
 :gitTag
 :identifyGitBranch
-:identifyGitOrigin
 :gitPush
 :performGitPush
 :discoverPlugins

--- a/subprojects/shipkit/src/test/groovy/org/shipkit/gradle/ShipkitJavaIntegTest.groovy
+++ b/subprojects/shipkit/src/test/groovy/org/shipkit/gradle/ShipkitJavaIntegTest.groovy
@@ -58,6 +58,7 @@ class ShipkitJavaIntegTest extends GradleSpecification {
         BuildResult result = pass("performRelease", "-m", "-s")
         //git push and bintray upload tasks should run as late as possible
         skippedTaskPathsGradleBugWorkaround(result.output).join("\n") == """:bumpVersionFile
+:identifyGitOrigin
 :fetchContributors
 :fetchReleaseNotes
 :updateReleaseNotes
@@ -82,7 +83,6 @@ class ShipkitJavaIntegTest extends GradleSpecification {
 :impl:sourcesJar
 :impl:publishJavaLibraryPublicationToMavenLocal
 :identifyGitBranch
-:identifyGitOrigin
 :gitPush
 :performGitPush
 :api:bintrayUpload

--- a/subprojects/shipkit/src/test/groovy/org/shipkit/internal/gradle/ShipkitBintrayPluginTest.groovy
+++ b/subprojects/shipkit/src/test/groovy/org/shipkit/internal/gradle/ShipkitBintrayPluginTest.groovy
@@ -27,9 +27,6 @@ class ShipkitBintrayPluginTest extends PluginSpecification {
         then:
         project.bintray.pkg.version.vcsTag == "v1.0"
         project.bintray.dryRun == true
-        project.bintray.pkg.vcsUrl == "https://github.com/repo.git"
-        project.bintray.pkg.issueTrackerUrl == "https://github.com/repo/issues"
-        project.bintray.pkg.websiteUrl == "https://github.com/repo"
         project.bintray.pkg.desc == "some proj"
         project.bintray.pkg.name == "org.shipkit"
     }

--- a/subprojects/shipkit/src/test/groovy/org/shipkit/internal/gradle/versionupgrade/UpgradeDependencyPluginTest.groovy
+++ b/subprojects/shipkit/src/test/groovy/org/shipkit/internal/gradle/versionupgrade/UpgradeDependencyPluginTest.groovy
@@ -82,7 +82,7 @@ class UpgradeDependencyPluginTest extends PluginSpecification {
     }
 
     def "configures tasks based on git auth"() {
-        conf.gitHub.repository = 'my-repo'
+        conf.gitHub.repository = 'my-org/my-repo'
         conf.gitHub.writeAuthToken = 'foo'
 
         when:
@@ -92,14 +92,15 @@ class UpgradeDependencyPluginTest extends PluginSpecification {
         then:
         GitPullTask pull = project.tasks[PULL_UPSTREAM]
         pull.secretValue == 'foo'
-        pull.url == 'https://dummy:foo@github.com/my-repo.git'
+        pull.url == 'https://dummy:foo@github.com/my-org/my-repo.git'
 
         GitPushTask push = project.tasks[PUSH_VERSION_UPGRADE]
         push.secretValue == 'foo'
-        push.url == 'https://dummy:foo@github.com/my-repo.git'
+        push.url == 'https://dummy:foo@github.com/my-org/my-repo.git'
 
         CreatePullRequestTask pr = project.tasks[CREATE_PULL_REQUEST]
-        pr.forkRepositoryName == 'my-repo'
+        pr.forkRepositoryName == 'my-org/my-repo'
+        pr.upstreamRepositoryName == 'mockito/my-repo'
     }
 
     def "should configure checkoutVersionBranch"() {
@@ -172,6 +173,5 @@ class UpgradeDependencyPluginTest extends PluginSpecification {
         task.authToken == "writeToken"
         task.versionUpgrade == versionUpgrade
         task.versionBranch == "upgrade-shipkit-to-1.2.30"
-        task.upstreamRepositoryName == "mockito/mockito"
     }
 }


### PR DESCRIPTION
- The goal is to reduce amount of configuration, especially if that configuration can be inferred.
This makes the tool easier to use. The cost is extra complexity in the code.
- Instead of accessing the repository directly we use the pattern of "identify" task. If some task needs repository name, it needs to depend on "identifyRepository" task / relevant git plugin.
- Made git auth plugin applied to root project only. This way, we avoid triggering multiple git commands, per each submodule

Forgot to say how I tested it: I did ./gradlew testRelease in shipkit and in release-example