### PR TITLE
[#420] Travis cache performance enahncements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ install:
  - true
 
 script:
-  - ./gradlew build testDownstream -PcheckJava6Compatibility --daemon -s -i && ./gradlew ciPerformRelease
+  - ./gradlew build testDownstream -PcheckJava6Compatibility --daemon -s -i && ./gradlew ciPerformRelease -s
 
 # Remove often changing files to prevent cache re-upload on no changes in dependencies
 before_cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,7 @@ before_cache:
   - rm -fr $HOME/.gradle/caches/*/scripts-remapped/
   - rm -fr $HOME/.gradle/caches/*/fileHashes/
   - rm -fr $HOME/.gradle/caches/transforms-1/transforms-1.lock
+  - rm -fr $HOME/.gradle/caches/jars-*/*/shipkit-*.jar
 cache:
   directories:
     - $HOME/.gradle/caches/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,6 @@
 # More details on how to configure the Travis build
 # https://docs.travis-ci.com/user/customizing-the-build/
 
-# Speed up build with travis caches
-cache:
-  directories:
-    - $HOME/.gradle/caches/
-    - $HOME/.gradle/wrapper/
-
 language: java
 
 matrix:
@@ -26,4 +20,17 @@ install:
 
 script:
   - ./gradlew build testDownstream -PcheckJava6Compatibility --daemon -s -i && ./gradlew ciPerformRelease
+
+# Remove often changing files to prevent cache re-upload on no changes in dependencies
+before_cache:
+  - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
+  - rm -fr $HOME/.gradle/caches/*/plugin-resolution/
+  - rm -fr $HOME/.gradle/caches/*/scripts/
+  - rm -fr $HOME/.gradle/caches/*/scripts-remapped/
+  - rm -fr $HOME/.gradle/caches/*/fileHashes/
+  - rm -fr $HOME/.gradle/caches/transforms-1/transforms-1.lock
+cache:
+  directories:
+    - $HOME/.gradle/caches/
+    - $HOME/.gradle/wrapper/
 


### PR DESCRIPTION
Travis cache should not be updated (re-uploaded) if there is no changes in project dependencies. With my change all those files are being deleted before cache change detection phase.

It's hard to make any measurements based on Travis builds, however, It should safe up to [60 seconds](https://travis-ci.org/mockito/shipkit/builds/274656727#L2328) per build (minus time needed do rebuild removed files which are updated anyway in every build):
> change detected (content changed, file is created, or file is deleted): - 59.03s

in a situation there are no changes in the project dependencies. Sample results after my change: https://travis-ci.org/mockito/shipkit/builds/276488043#L2108
> nothing changed, not updating cache - 4.70s

It has been working fine (without visible side effects) for a long time in a few my projects built on Travis.