### PR TITLE
Update readme with a better getting started section

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,25 @@ Shipkit enables Mockito to automatically publish new versions to
 
 ### Getting started
 
-See the project [wiki](https://github.com/mockito/shipkit/wiki/Getting-started-with-Shipkit) for more information.
+To start with ShipKit you have to add the plugin first:
+```groovy
+plugins {
+  // the latest version can found at https://github.com/mockito/shipkit/releases
+  id "org.shipkit.java" version "0.9.74" 
+}
+```
+
+Then you are able to `init` ShipKit with
+```
+./gradlew initShipkit
+```
+
+To perfom a release just run 
+```
+./gradlew performRelease
+```
+
+For more and detailed information see the project [wiki](https://github.com/mockito/shipkit/wiki/Getting-started-with-Shipkit).
 
 ### We need help!
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Shipkit enables Mockito to automatically publish new versions to
 
 ### Getting started
 
-To start with ShipKit you have to add the plugin first:
+To start with Shipkit you have to add the plugin first:
 ```groovy
 plugins {
   // the latest version can found at https://github.com/mockito/shipkit/releases
@@ -36,7 +36,7 @@ plugins {
 }
 ```
 
-Then you are able to `init` ShipKit with
+Then you are able to `init` Shipkit with
 ```
 ./gradlew initShipkit
 ```


### PR DESCRIPTION
Because every developer wants to start as soon as possible with some new libs I've increased the getting started section of the readme.
Then some new uses can directly copy/past some code and can directly start with Shipkit...