### PR TITLE
Documentation, upgrades tidy-ups

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,9 +22,11 @@ This will install the artifacts in local maven repository for easy sharing.
 Notice the version you're building in the build output.
 2. Clone shipkit-example repo and ensure that 'shipkit-example/build.gradle' file uses the correct version of shipkit (declared at the top of build.gradle).
 It should use the same version that was built in the previous step.
-3. Basic testing (for most contributors):
- - Smoke test (no tasks are run): ```./gradlew testRelease -m```
- - Test most things, without actually making any code pushes/publications: ```./gradlew testRelease -x gitPush -x bintrayUpload```
+3. Basic testing for contributors:
+ - Smoke test (no tasks are run): ```./gradlew performRelease -m```
+ - Test most things, without actually making any code pushes/publications:
+ ```./gradlew releaseNeeded performRelease releaseCleanUp -x gitPush -x bintrayUpload -PdryRun```
+ TODO: add "contributorTestRelease" task that wraps above similar to "testRelease" task.
  - Release notes content: ```./gradlew updateReleaseNotes -Ppreview```
     To generate sizable release notes content, before running 'updateReleaseNotes' you can downgrade the 'previousVersion' in 'version.properties'.
     Release notes are generated from 'previousVersion' to current 'version' as declared in 'version.properties' file.

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         maven { url "https://plugins.gradle.org/m2/" }
     }
     dependencies {
-        classpath "org.shipkit:shipkit:0.9.65"
+        classpath "org.shipkit:shipkit:0.9.81"
         classpath 'ru.vyarus:gradle-animalsniffer-plugin:1.3.0'
     }
 }

--- a/subprojects/testDownstream/testDownstream.gradle
+++ b/subprojects/testDownstream/testDownstream.gradle
@@ -3,5 +3,4 @@ apply plugin: 'base' // for clean task, TODO ms: push it to the plugin, make 'ch
 apply plugin: 'org.shipkit.test-downstream'
 
 testDownstream.addRepository("https://github.com/mockito/shipkit-example")
-testDownstream.addRepository("https://github.com/mockito/shipkit-bootstrap")
 testDownstream.addRepository("https://github.com/mockito/mockito")


### PR DESCRIPTION
- Updated CONTRIBUTING information based on feedback, fixes #415, follow-up planned in #437 (please-contribute ticket)
- Bumped Shipkit because I hoped that we can re-enabled downstream testing but it is not quite working yet (#403 is not quite fixed yet)
- Removed bootstrap repo because I plan to change this repo to leverage @wwilk getting started guide