### PR TITLE
Missing unit test, documentation

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -70,7 +70,7 @@ shipkit {
 Property **github.repository** is by default filled with your remote origin URL, while **github.readOnlyAuthToken** is set to the token for generic [shipkit-org](https://github.com/shipkit-org) account.
 It is sufficient to test release locally.
 To perform write operations (like git push) you would need a write token but if you don't specify it Shipkit will use your local GitHub authentication.
-See [here for more information](https://github.com/mockito/shipkit/wiki/Getting-started-with-Shipkit#github)
+GitHub configuration is covered in more detail later in this document.
 
 ### Bintray configuration
 

--- a/gradle/upgrade-downstream.gradle
+++ b/gradle/upgrade-downstream.gradle
@@ -1,5 +1,5 @@
 apply plugin: 'org.shipkit.ci-upgrade-downstream'
 
 upgradeDownstream {
-    repositories = ['mockito/shipkit-example', 'mockito/shipkit-bootstrap', 'mockito/shipkit']
+    repositories = ['mockito/shipkit-example', 'mockito/shipkit']
 }

--- a/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/configuration/ShipkitConfigurationPlugin.java
+++ b/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/configuration/ShipkitConfigurationPlugin.java
@@ -78,7 +78,7 @@ public class ShipkitConfigurationPlugin implements Plugin<Project> {
             conf.getGitHub().setRepository("unspecified");
             conf.getGitHub().setReadOnlyAuthToken("unspecified");
             LOG.lifecycle("  Configuration file '{}' does not exist. '{}' task can be used to bootstrap Shipkit.\n" +
-                "  Getting Started Guide: https://github.com/mockito/shipkit/wiki/Getting-started-with-Shipkit", shipkitFile.getName(), InitPlugin.INIT_SHIPKIT_TASK);
+                "  Getting Started Guide: https://github.com/mockito/shipkit/blob/master/docs/getting-started.md", shipkitFile.getName(), InitPlugin.INIT_SHIPKIT_TASK);
         } else {
             // apply configuration properties from config file
             rootProject.apply(new Action<ObjectConfigurationAction>() {

--- a/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/init/InitPlugin.java
+++ b/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/init/InitPlugin.java
@@ -95,7 +95,7 @@ public class InitPlugin implements Plugin<Project> {
                     public void execute(Task task) {
                         LOG.lifecycle("  Initialization complete. Thank you for using Shipkit!\n" +
                             "  Please review auto-generated default files before checking them in.\n" +
-                            "  Guide: https://github.com/mockito/shipkit/wiki/Getting-started-with-Shipkit");
+                            "  Guide: https://github.com/mockito/shipkit/blob/master/docs/getting-started.md");
                     }
                 });
             }

--- a/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/init/tasks/InitShipkitFile.java
+++ b/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/init/tasks/InitShipkitFile.java
@@ -46,7 +46,7 @@ public class InitShipkitFile {
         "//This default Shipkit configuration file was created automatically and is intended to be checked-in.\n" +
             "//Default configuration is sufficient for local testing and trying out Shipkit.\n" +
             "//To leverage Shipkit fully, please fix the TODO items, refer to our Getting Started Guide for help:\n" +
-            "// https://github.com/mockito/shipkit/wiki/Getting-started-with-Shipkit\n" +
+            "// https://github.com/mockito/shipkit/blob/master/docs/getting-started.md\n" +
             "shipkit {\n" +
             "   //TODO is the repository correct?\n" +
             "   gitHub.repository = \"@gitHub.repository@\"\n" +

--- a/subprojects/shipkit/src/test/groovy/org/shipkit/internal/gradle/bintray/BintrayReleasePluginTest.groovy
+++ b/subprojects/shipkit/src/test/groovy/org/shipkit/internal/gradle/bintray/BintrayReleasePluginTest.groovy
@@ -1,17 +1,25 @@
 package org.shipkit.internal.gradle.bintray
 
-import org.gradle.testfixtures.ProjectBuilder
+import org.shipkit.gradle.notes.UpdateReleaseNotesTask
 import org.shipkit.internal.gradle.java.JavaBintrayPlugin
-import spock.lang.Specification
+import org.shipkit.internal.gradle.notes.ReleaseNotesPlugin
+import testutil.PluginSpecification
 
-class BintrayReleasePluginTest extends Specification {
+class BintrayReleasePluginTest extends PluginSpecification {
 
-    def project = new ProjectBuilder().build()
-
-    def "applies"() {
-        expect:
+    def "configures tasks"() {
         project.plugins.apply(BintrayReleasePlugin)
         project.plugins.apply(JavaBintrayPlugin)
+
+        project.bintray.pkg.userOrg = "some-org"
+        project.bintray.pkg.repo = "some-repo"
+        project.bintray.pkg.name = "some-pkg"
+
+        when:
         project.evaluate()
+
+        then:
+        UpdateReleaseNotesTask updateNotes = project.tasks.getByName(ReleaseNotesPlugin.UPDATE_NOTES_TASK)
+        updateNotes.publicationRepository == "https://bintray.com/some-org/some-repo/some-pkg"
     }
 }

--- a/subprojects/shipkit/src/test/groovy/org/shipkit/internal/gradle/init/tasks/InitShipkitFileTest.groovy
+++ b/subprojects/shipkit/src/test/groovy/org/shipkit/internal/gradle/init/tasks/InitShipkitFileTest.groovy
@@ -32,7 +32,7 @@ class InitShipkitFileTest extends Specification {
             """//This default Shipkit configuration file was created automatically and is intended to be checked-in.
 //Default configuration is sufficient for local testing and trying out Shipkit.
 //To leverage Shipkit fully, please fix the TODO items, refer to our Getting Started Guide for help:
-// https://github.com/mockito/shipkit/wiki/Getting-started-with-Shipkit
+// https://github.com/mockito/shipkit/blob/master/docs/getting-started.md
 shipkit {
    //TODO is the repository correct?
    gitHub.repository = "mockito/mockito"

--- a/subprojects/shipkit/src/test/groovy/testutil/PluginSpecification.groovy
+++ b/subprojects/shipkit/src/test/groovy/testutil/PluginSpecification.groovy
@@ -16,14 +16,14 @@ import spock.lang.Specification
  * that is required by {@link org.shipkit.internal.gradle.configuration.ShipkitConfigurationPlugin}
  * Configuration methods are overridable, so you don't have to rely on this behaviour if you don't need it.
  */
-class PluginSpecification extends Specification{
+class PluginSpecification extends Specification {
     @Rule
     TemporaryFolder tmp = new TemporaryFolder()
 
     Project project
     ShipkitConfiguration conf
 
-    void setup(){
+    void setup() {
         initProject()
         createShipkitFile()
         createShipkitConfiguration()
@@ -34,18 +34,18 @@ class PluginSpecification extends Specification{
         project.version = "1.5.23"
     }
 
-    void createShipkitFile(){
+    void createShipkitFile() {
         def rootPath = tmp.root.absolutePath
         def shipkitFile = new File(rootPath + "/gradle/shipkit.gradle");
         IOUtil.createParentDirectory(shipkitFile)
         shipkitFile << "shipkit { }"
     }
 
-    ShipkitConfiguration applyShipkitConfiguration(){
+    ShipkitConfiguration applyShipkitConfiguration() {
         return project.plugins.apply(ShipkitConfigurationPlugin).configuration
     }
 
-    void createShipkitConfiguration(){
+    void createShipkitConfiguration() {
         conf = applyShipkitConfiguration()
         this.conf.gitHub.readOnlyAuthToken = "token"
         this.conf.gitHub.repository = "repo"


### PR DESCRIPTION
- Updated documentation. We should link to source code instead of the wiki.
- Added missing unit test. The goal is to help @StefMa with #446.
- Some whitespace fixes (reopened #22)
- Removed shipkit-bootstrap from automated upgrades. Shipkit bootstrap project is changing into vanilla Java project that we apply "initShipkit" on. We no longer can automatically upgrade Shipkit because the project will not use Shpikit. See mockito/shipkit-bootstrap#19. Bootstrap will be so much better if we combine shipkit init + getting started guide by @wwilk!

Please review :) The documentation is getting better. Soon we will be ready for 1.0