### PR TITLE
ComparePublications working for Gradle plugins #419

### DIFF
--- a/subprojects/shipkit/shipkit.gradle
+++ b/subprojects/shipkit/shipkit.gradle
@@ -8,6 +8,9 @@ apply plugin: 'com.gradle.plugin-publish'
 
 apply from: "$rootDir/gradle/upgrade-downstream.gradle"
 
+//TODO: WW uncomment when GradlePluginArtifactUrlResolver is released
+//apply plugin: 'org.shipkit.compare-publications'
+
 checkstyle {
     configFile = file("${rootDir}/config/checkstyle/checkstyle.xml")
 }

--- a/subprojects/shipkit/src/main/groovy/org/shipkit/internal/comparison/artifact/DefaultArtifactUrlResolverFactory.java
+++ b/subprojects/shipkit/src/main/groovy/org/shipkit/internal/comparison/artifact/DefaultArtifactUrlResolverFactory.java
@@ -2,12 +2,15 @@ package org.shipkit.internal.comparison.artifact;
 
 import org.gradle.api.Project;
 import org.shipkit.internal.gradle.bintray.ShipkitBintrayPlugin;
+import org.shipkit.internal.gradle.plugin.GradlePortalPublishPlugin;
 
 public class DefaultArtifactUrlResolverFactory {
 
     public DefaultArtifactUrlResolver getDefaultResolver(Project project, String artifactBaseName, String previousVersion) {
         if (project.getPlugins().hasPlugin(ShipkitBintrayPlugin.class)) {
             return new BintrayDefaultArtifactUrlResolver(project, artifactBaseName, previousVersion);
+        } else if (project.getPlugins().hasPlugin(GradlePortalPublishPlugin.class)) {
+            return new GradlePluginArtifactUrlResolver(project.getGroup().toString(), artifactBaseName, previousVersion);
         }
         return null;
     }

--- a/subprojects/shipkit/src/main/groovy/org/shipkit/internal/comparison/artifact/GradlePluginArtifactUrlResolver.java
+++ b/subprojects/shipkit/src/main/groovy/org/shipkit/internal/comparison/artifact/GradlePluginArtifactUrlResolver.java
@@ -1,0 +1,39 @@
+package org.shipkit.internal.comparison.artifact;
+
+public class GradlePluginArtifactUrlResolver implements DefaultArtifactUrlResolver {
+
+    /**
+     * Group of the project, eg. "org.shipkit"
+     */
+    private String projectGroup;
+    /**
+     * Name of the artifact, usually the same as the name of jar without the version suffix,
+     * eg. if jar is named "shipkit-0.4.3.jar", baseName is "shipkit"
+     */
+    private String artifactBaseName;
+    /**
+     * Version of the artifact
+     */
+    private String version;
+
+    public GradlePluginArtifactUrlResolver(String projectGroup, String artifactBaseName, String version) {
+        this.projectGroup = projectGroup;
+        this.artifactBaseName = artifactBaseName;
+        this.version = version;
+    }
+
+    /**
+     * Returns gradle plugin URL, in format eg.:
+     * https://plugins.gradle.org/m2/org/shipkit/shipkit/0.9.84/shipkit-0.9.84.pom
+     */
+    @Override
+    public String getDefaultUrl(String extension) {
+        return String.format("https://plugins.gradle.org/m2/%s/%s/%s/%s-%s%s",
+            projectGroup.replace('.', '/'),
+            artifactBaseName,
+            version,
+            artifactBaseName,
+            version,
+            extension);
+    }
+}

--- a/subprojects/shipkit/src/test/groovy/org/shipkit/internal/comparison/artifact/DefaultArtifactUrlResolverFactoryTest.groovy
+++ b/subprojects/shipkit/src/test/groovy/org/shipkit/internal/comparison/artifact/DefaultArtifactUrlResolverFactoryTest.groovy
@@ -4,6 +4,7 @@ import org.apache.commons.lang.builder.EqualsBuilder
 import org.gradle.api.Project
 import org.gradle.api.plugins.PluginContainer
 import org.shipkit.internal.gradle.bintray.ShipkitBintrayPlugin
+import org.shipkit.internal.gradle.plugin.GradlePortalPublishPlugin
 import spock.lang.Specification
 
 class DefaultArtifactUrlResolverFactoryTest extends Specification {
@@ -32,4 +33,17 @@ class DefaultArtifactUrlResolverFactoryTest extends Specification {
         EqualsBuilder.reflectionEquals(result, new BintrayDefaultArtifactUrlResolver(project, "artifactName", "0.0.1"))
     }
 
+    def "returns Gradle plugin resolver when GradlePortalPublishPlugin is applied to the project"() {
+        given:
+        def pluginContainer = Mock(PluginContainer)
+        project.plugins >> pluginContainer
+        project.group >> "testGroup"
+        pluginContainer.hasPlugin(GradlePortalPublishPlugin) >> true
+
+        when:
+        def result = underTest.getDefaultResolver(project, "artifactName", "0.0.1")
+
+        then:
+        EqualsBuilder.reflectionEquals(result, new GradlePluginArtifactUrlResolver("testGroup", "artifactName", "0.0.1"))
+    }
 }

--- a/subprojects/shipkit/src/test/groovy/org/shipkit/internal/comparison/artifact/GradlePluginArtifactUrlResolverTest.groovy
+++ b/subprojects/shipkit/src/test/groovy/org/shipkit/internal/comparison/artifact/GradlePluginArtifactUrlResolverTest.groovy
@@ -1,0 +1,21 @@
+package org.shipkit.internal.comparison.artifact
+
+import org.gradle.api.Project
+import spock.lang.Specification
+
+class GradlePluginArtifactUrlResolverTest extends Specification {
+
+    GradlePluginArtifactUrlResolver underTest
+    def project = Mock(Project)
+
+    def "concatenates default url correctly"() {
+        given:
+        underTest = new GradlePluginArtifactUrlResolver("test.group", "api", "0.0.1")
+
+        when:
+        def result = underTest.getDefaultUrl("-sources.jar")
+
+        then:
+        result == "https://plugins.gradle.org/m2/test/group/api/0.0.1/api-0.0.1-sources.jar"
+    }
+}


### PR DESCRIPTION
I tested it locally. It seems that there is always a difference in poms but since this is not a critical situation, we can test if the same problem occurs on Travis. 