### PR TITLE
make use of generic git user and email in upgrade-downstream plugin

### DIFF
--- a/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/versionupgrade/UpgradeDependencyPlugin.java
+++ b/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/versionupgrade/UpgradeDependencyPlugin.java
@@ -14,6 +14,7 @@ import org.shipkit.internal.gradle.git.GitOriginPlugin;
 import org.shipkit.internal.gradle.git.GitUrlInfo;
 import org.shipkit.internal.gradle.git.tasks.GitCheckOutTask;
 import org.shipkit.internal.gradle.git.tasks.GitPullTask;
+import org.shipkit.internal.gradle.util.GitUtil;
 import org.shipkit.internal.gradle.util.TaskMaker;
 import org.shipkit.internal.util.IncubatingWarning;
 
@@ -158,7 +159,8 @@ public class UpgradeDependencyPlugin implements Plugin<Project> {
                     public void run() {
                         String message = String.format("%s version upgraded to %s", upgradeDependencyExtension.getDependencyName(), upgradeDependencyExtension.getNewVersion());
                         exec.execCommand(execCommand("Committing build file",
-                            "git", "commit", "-m", message, upgradeDependencyExtension.getBuildFile().getAbsolutePath()));
+                            "git", "commit", "--author", GitUtil.getGitGenericUserNotation(conf.getGit().getUser(), conf.getGit().getEmail()),
+                            "-m", message, upgradeDependencyExtension.getBuildFile().getAbsolutePath()));
                     }
                 });
                 exec.onlyIf(wasBuildFileUpdatedSpec(replaceVersionTask));

--- a/subprojects/shipkit/src/test/groovy/org/shipkit/internal/gradle/versionupgrade/UpgradeDependencyPluginTest.groovy
+++ b/subprojects/shipkit/src/test/groovy/org/shipkit/internal/gradle/versionupgrade/UpgradeDependencyPluginTest.groovy
@@ -144,7 +144,7 @@ class UpgradeDependencyPluginTest extends PluginSpecification {
 
         then:
         task.execCommands[0].commandLine ==
-            ["git", "commit", "-m", "shipkit version upgraded to 1.2.30", dependencyFile.absolutePath]
+            ["git", "commit", "--author", "shipkit-org <<shipkit.org@gmail.com>>", "-m", "shipkit version upgraded to 1.2.30", dependencyFile.absolutePath]
     }
 
     def "should configure pushVersionUpgrade"() {


### PR DESCRIPTION
fixes #386 
