### PR TITLE
Fix javadoc warnings

### DIFF
--- a/subprojects/shipkit/src/main/groovy/org/shipkit/gradle/git/GitCommitTask.java
+++ b/subprojects/shipkit/src/main/groovy/org/shipkit/gradle/git/GitCommitTask.java
@@ -5,7 +5,6 @@ import org.gradle.api.Task;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.SkipWhenEmpty;
 import org.gradle.api.tasks.TaskAction;
-import org.shipkit.gradle.configuration.ShipkitConfiguration;
 import org.shipkit.internal.gradle.git.tasks.GitCommitImpl;
 
 import java.io.File;
@@ -33,9 +32,9 @@ public class GitCommitTask extends DefaultTask {
      * Registers a change to be committed.
      * Invoke this method only in Gradle's configuration phase because this method calls 'dependsOn' automatically.
      *
-     * @param files to be committed
+     * @param files             to be committed
      * @param changeDescription description to be included in commit message
-     * @param taskMakingChange task that makes the change, we will automatically set 'dependsOn' this task
+     * @param taskMakingChange  task that makes the change, we will automatically set 'dependsOn' this task
      */
     public void addChange(List<File> files, String changeDescription, Task taskMakingChange) {
         dependsOn(taskMakingChange);
@@ -44,7 +43,7 @@ public class GitCommitTask extends DefaultTask {
     }
 
     /**
-     * See {@link ShipkitConfiguration.Git#getUser()}
+     * See {@link org.shipkit.gradle.configuration.ShipkitConfiguration.Git#getUser()}
      */
     public String getGitUserName() {
         return gitUserName;
@@ -58,7 +57,7 @@ public class GitCommitTask extends DefaultTask {
     }
 
     /**
-     * See {@link ShipkitConfiguration.Git#getEmail()}
+     * See {@link org.shipkit.gradle.configuration.ShipkitConfiguration.Git#getEmail()}
      */
     public String getGitUserEmail() {
         return gitUserEmail;
@@ -72,7 +71,7 @@ public class GitCommitTask extends DefaultTask {
     }
 
     /**
-     * See {@link ShipkitConfiguration.Git#getCommitMessagePostfix()}
+     * See {@link org.shipkit.gradle.configuration.ShipkitConfiguration.Git#getCommitMessagePostfix()}
      */
     public String getCommitMessagePostfix() {
         return commitMessagePostfix;

--- a/subprojects/shipkit/src/main/groovy/org/shipkit/gradle/notes/FetchGitHubContributorsTask.java
+++ b/subprojects/shipkit/src/main/groovy/org/shipkit/gradle/notes/FetchGitHubContributorsTask.java
@@ -4,7 +4,6 @@ import org.gradle.api.DefaultTask;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.OutputFile;
 import org.gradle.api.tasks.TaskAction;
-import org.shipkit.gradle.configuration.ShipkitConfiguration;
 import org.shipkit.internal.gradle.notes.tasks.FetchContributors;
 
 import java.io.File;
@@ -31,7 +30,7 @@ public class FetchGitHubContributorsTask extends DefaultTask {
     }
 
     /**
-     * See {@link ShipkitConfiguration.GitHub#getApiUrl()}
+     * See {@link org.shipkit.gradle.configuration.ShipkitConfiguration.GitHub#getApiUrl()}
      */
     public String getApiUrl() {
         return apiUrl;
@@ -45,7 +44,7 @@ public class FetchGitHubContributorsTask extends DefaultTask {
     }
 
     /**
-     * See {@link ShipkitConfiguration.GitHub#getRepository()}
+     * See {@link org.shipkit.gradle.configuration.ShipkitConfiguration.GitHub#getRepository()}
      */
     public String getRepository() {
         return repository;
@@ -59,7 +58,7 @@ public class FetchGitHubContributorsTask extends DefaultTask {
     }
 
     /**
-     * See {@link ShipkitConfiguration.GitHub#getReadOnlyAuthToken()}
+     * See {@link org.shipkit.gradle.configuration.ShipkitConfiguration.GitHub#getReadOnlyAuthToken()}
      */
     public String getReadOnlyAuthToken() {
         return readOnlyAuthToken;

--- a/subprojects/shipkit/src/main/groovy/org/shipkit/gradle/notes/FetchReleaseNotesTask.java
+++ b/subprojects/shipkit/src/main/groovy/org/shipkit/gradle/notes/FetchReleaseNotesTask.java
@@ -5,7 +5,6 @@ import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.Optional;
 import org.gradle.api.tasks.OutputFile;
 import org.gradle.api.tasks.TaskAction;
-import org.shipkit.gradle.configuration.ShipkitConfiguration;
 import org.shipkit.internal.gradle.notes.tasks.FetchReleaseNotes;
 
 import java.io.File;
@@ -36,7 +35,7 @@ public class FetchReleaseNotesTask extends DefaultTask {
     }
 
     /**
-     * See {@link ShipkitConfiguration.GitHub#getUrl()}
+     * See {@link org.shipkit.gradle.configuration.ShipkitConfiguration.GitHub#getUrl()}
      */
     public String getGitHubApiUrl() {
         return gitHubApiUrl;
@@ -50,7 +49,7 @@ public class FetchReleaseNotesTask extends DefaultTask {
     }
 
     /**
-     * See {@link ShipkitConfiguration.GitHub#getReadOnlyAuthToken()}
+     * See {@link org.shipkit.gradle.configuration.ShipkitConfiguration.GitHub#getReadOnlyAuthToken()}
      */
     public String getGitHubReadOnlyAuthToken() {
         return gitHubReadOnlyAuthToken;
@@ -64,7 +63,7 @@ public class FetchReleaseNotesTask extends DefaultTask {
     }
 
     /**
-     * See {@link ShipkitConfiguration.GitHub#getRepository()}
+     * See {@link org.shipkit.gradle.configuration.ShipkitConfiguration.GitHub#getRepository()}
      */
     public String getGitHubRepository() {
         return gitHubRepository;
@@ -79,7 +78,7 @@ public class FetchReleaseNotesTask extends DefaultTask {
 
     /**
      * Previous released version we generate the release notes from.
-     * See {@link ShipkitConfiguration#getPreviousReleaseVersion()}
+     * See {@link org.shipkit.gradle.configuration.ShipkitConfiguration#getPreviousReleaseVersion()}
      */
     public String getPreviousVersion() {
         return previousVersion;
@@ -135,7 +134,7 @@ public class FetchReleaseNotesTask extends DefaultTask {
     }
 
     /**
-     * See {@link ShipkitConfiguration.Git#getTagPrefix()}
+     * See {@link org.shipkit.gradle.configuration.ShipkitConfiguration.Git#getTagPrefix()}
      */
     public String getTagPrefix() {
         return tagPrefix;
@@ -179,7 +178,7 @@ public class FetchReleaseNotesTask extends DefaultTask {
     }
 
     /**
-     * See {@link ShipkitConfiguration.ReleaseNotes#getIgnoreCommitsContaining()}
+     * See {@link org.shipkit.gradle.configuration.ShipkitConfiguration.ReleaseNotes#getIgnoreCommitsContaining()}
      */
     public Collection<String> getIgnoreCommitsContaining() {
         return ignoreCommitsContaining;

--- a/subprojects/shipkit/src/main/groovy/org/shipkit/gradle/notes/UpdateReleaseNotesTask.java
+++ b/subprojects/shipkit/src/main/groovy/org/shipkit/gradle/notes/UpdateReleaseNotesTask.java
@@ -5,7 +5,6 @@ import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.InputFile;
 import org.gradle.api.tasks.Optional;
 import org.gradle.api.tasks.TaskAction;
-import org.shipkit.gradle.configuration.ShipkitConfiguration;
 import org.shipkit.internal.gradle.notes.tasks.UpdateReleaseNotes;
 import org.shipkit.internal.notes.header.HeaderProvider;
 import org.shipkit.internal.notes.model.ReleaseNotesData;
@@ -92,7 +91,7 @@ public class UpdateReleaseNotesTask extends DefaultTask {
     }
 
     /**
-     * See {@link ShipkitConfiguration.Git#getTagPrefix()}
+     * See {@link org.shipkit.gradle.configuration.ShipkitConfiguration.Git#getTagPrefix()}
      */
     public String getTagPrefix() {
         return tagPrefix;
@@ -107,7 +106,7 @@ public class UpdateReleaseNotesTask extends DefaultTask {
 
     /**
      * GitHub URL address, for example: https://github.com
-     * See {@link ShipkitConfiguration.GitHub#getUrl()}
+     * See {@link org.shipkit.gradle.configuration.ShipkitConfiguration.GitHub#getUrl()}
      */
     public String getGitHubUrl() {
         return gitHubUrl;
@@ -207,7 +206,7 @@ public class UpdateReleaseNotesTask extends DefaultTask {
     }
 
     /**
-     * Developers as configured in {@link ShipkitConfiguration.Team#getDevelopers()}
+     * Developers as configured in {@link org.shipkit.gradle.configuration.ShipkitConfiguration.Team#getDevelopers()}
      */
     public Collection<String> getDevelopers() {
         return developers;
@@ -221,7 +220,7 @@ public class UpdateReleaseNotesTask extends DefaultTask {
     }
 
     /**
-     * Contributors as configured in {@link ShipkitConfiguration.Team#getContributors()}
+     * Contributors as configured in {@link org.shipkit.gradle.configuration.ShipkitConfiguration.Team#getContributors()}
      */
     public Collection<String> getContributors() {
         return contributors;

--- a/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/git/GitSetupPlugin.java
+++ b/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/git/GitSetupPlugin.java
@@ -32,11 +32,11 @@ import static java.util.Arrays.asList;
  *         Therefore we need to checkout real branch like "master"</li>
  *     <li>
  *         'setGitUserName' - sets generic user name so that CI server can commit code as neatly described robot,
- *         uses value from {@link ShipkitConfiguration.Git#getUser()}
+ *         uses value from {@link org.shipkit.gradle.configuration.ShipkitConfiguration.Git#getUser()}
  *     </li>
  *     <li>
  *         'setGitUserEmail' - sets generic user email so that CI server can commit code as neatly described robot,
- *         uses value from {@link ShipkitConfiguration.Git#getEmail()}
+ *         uses value from {@link org.shipkit.gradle.configuration.ShipkitConfiguration.Git#getEmail()}
  *     </li>
  *     <li>
  *         'ciReleasePrepare' - prepares for release from CI,

--- a/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/release/tasks/GistsApi.java
+++ b/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/release/tasks/GistsApi.java
@@ -13,8 +13,10 @@ public class GistsApi {
     }
 
     /**
-     * Creates a Gist with content {@param #fileContent} and uploads it.
+     * Creates a Gist with the given fileContent and uploads it.
      * Returns the url that you can use to access the uploaded Gist.
+     *
+     * @param fileContent the content which will be uploaded
      */
     public String uploadFile(String fileName, String fileContent) throws Exception {
         String body = getBody(fileName, fileContent);

--- a/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/release/tasks/UploadGistsTask.java
+++ b/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/release/tasks/UploadGistsTask.java
@@ -4,7 +4,6 @@ import org.gradle.api.DefaultTask;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.TaskAction;
-import org.shipkit.gradle.configuration.ShipkitConfiguration;
 
 /**
  * Uploads files as gists to GitHub API.
@@ -37,28 +36,28 @@ public class UploadGistsTask extends DefaultTask {
     }
 
     /**
-     * See {@link ShipkitConfiguration.GitHub#getApiUrl()}
+     * See {@link org.shipkit.gradle.configuration.ShipkitConfiguration.GitHub#getApiUrl()}
      */
     public String getGitHubApiUrl() {
         return gitHubApiUrl;
     }
 
     /**
-     * See {@link ShipkitConfiguration.GitHub#getApiUrl()}
+     * See {@link org.shipkit.gradle.configuration.ShipkitConfiguration.GitHub#getApiUrl()}
      */
     public void setGitHubApiUrl(String gitHubApiUrl) {
         this.gitHubApiUrl = gitHubApiUrl;
     }
 
     /**
-     * See {@link ShipkitConfiguration.GitHub#getWriteAuthToken()}
+     * See {@link org.shipkit.gradle.configuration.ShipkitConfiguration.GitHub#getWriteAuthToken()}
      */
     public String getGitHubWriteToken() {
         return gitHubWriteToken;
     }
 
     /**
-     * See {@link ShipkitConfiguration.GitHub#getWriteAuthToken()}
+     * See {@link org.shipkit.gradle.configuration.ShipkitConfiguration.GitHub#getWriteAuthToken()}
      */
     public void setGitHubWriteToken(String gitHubWriteToken) {
         this.gitHubWriteToken = gitHubWriteToken;

--- a/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/util/team/TeamMember.java
+++ b/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/util/team/TeamMember.java
@@ -1,10 +1,8 @@
 package org.shipkit.internal.gradle.util.team;
 
-import org.shipkit.gradle.configuration.ShipkitConfiguration;
-
 /**
- * Represents team member configurable via {@link ShipkitConfiguration.Team#getDevelopers()}
- * and {@link ShipkitConfiguration.Team#getContributors()}
+ * Represents team member configurable via {@link org.shipkit.gradle.configuration.ShipkitConfiguration.Team#getDevelopers()}
+ * and {@link org.shipkit.gradle.configuration.ShipkitConfiguration.Team#getContributors()}
  */
 public class TeamMember {
     public final String gitHubUser;

--- a/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/util/team/TeamParser.java
+++ b/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/util/team/TeamParser.java
@@ -1,21 +1,20 @@
 package org.shipkit.internal.gradle.util.team;
 
 import org.gradle.api.GradleException;
-import org.shipkit.gradle.configuration.ShipkitConfiguration;
 
 import java.util.Collection;
 
 import static org.shipkit.internal.util.ArgumentValidation.notNull;
 
 /**
- * Parses team members configurable via {@link ShipkitConfiguration.Team#getDevelopers()}
- * and {@link ShipkitConfiguration.Team#getContributors()}
+ * Parses team members configurable via {@link org.shipkit.gradle.configuration.ShipkitConfiguration.Team#getDevelopers()}
+ * and {@link org.shipkit.gradle.configuration.ShipkitConfiguration.Team#getContributors()}
  */
 public class TeamParser {
 
     /**
-     * Validates team memberes configured via {@link ShipkitConfiguration.Team#getDevelopers()}
-     * and {@link ShipkitConfiguration.Team#getContributors()}
+     * Validates team memberes configured via {@link org.shipkit.gradle.configuration.ShipkitConfiguration.Team#getDevelopers()}
+     * and {@link org.shipkit.gradle.configuration.ShipkitConfiguration.Team#getContributors()}
      */
     public static void validateTeamMembers(Collection<String> teamMembers) throws InvalidInput {
         for (String member : teamMembers) {
@@ -25,8 +24,8 @@ public class TeamParser {
 
     /**
      * Thrown when the team members are not configured correctly in
-     * {@link ShipkitConfiguration.Team#getDevelopers()}
-     * or {@link ShipkitConfiguration.Team#getContributors()}
+     * {@link org.shipkit.gradle.configuration.ShipkitConfiguration.Team#getDevelopers()}
+     * or {@link org.shipkit.gradle.configuration.ShipkitConfiguration.Team#getContributors()}
      */
     public static class InvalidInput extends GradleException {
         InvalidInput(String message) {
@@ -35,8 +34,8 @@ public class TeamParser {
     }
 
     /**
-     * Parses single person notation provided via {@link ShipkitConfiguration.Team#getDevelopers()}
-     * and {@link ShipkitConfiguration.Team#getContributors()}
+     * Parses single person notation provided via {@link org.shipkit.gradle.configuration.ShipkitConfiguration.Team#getDevelopers()}
+     * and {@link org.shipkit.gradle.configuration.ShipkitConfiguration.Team#getContributors()}
      */
     public static TeamMember parsePerson(String notation) throws InvalidInput {
         notNull(notation, "Team member notation cannot be null");

--- a/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/versionupgrade/CreatePullRequestTask.java
+++ b/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/versionupgrade/CreatePullRequestTask.java
@@ -3,7 +3,6 @@ package org.shipkit.internal.gradle.versionupgrade;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.TaskAction;
-import org.shipkit.gradle.configuration.ShipkitConfiguration;
 
 import java.io.IOException;
 
@@ -14,7 +13,7 @@ import java.io.IOException;
  *
  * It is assumed that task is performed on fork repository, so {@link CreatePullRequestTask#forkRepositoryName}
  * is based on origin repo, see {@link org.shipkit.internal.gradle.git.tasks.GitOriginRepoProvider}
- * and {@link CreatePullRequestTask#upstreamRepositoryName} is based on {@link ShipkitConfiguration.GitHub#getRepository()}
+ * and {@link CreatePullRequestTask#upstreamRepositoryName} is based on {@link org.shipkit.gradle.configuration.ShipkitConfiguration.GitHub#getRepository()}
  */
 public class CreatePullRequestTask extends DefaultTask {
 
@@ -33,14 +32,14 @@ public class CreatePullRequestTask extends DefaultTask {
     }
 
     /**
-     * See {@link ShipkitConfiguration.GitHub#getRepository()}
+     * See {@link org.shipkit.gradle.configuration.ShipkitConfiguration.GitHub#getRepository()}
      */
     public String getUpstreamRepositoryName() {
         return upstreamRepositoryName;
     }
 
     /**
-     * See {@link ShipkitConfiguration.GitHub#getRepository()}
+     * See {@link org.shipkit.gradle.configuration.ShipkitConfiguration.GitHub#getRepository()}
      */
     public void setUpstreamRepositoryName(String upstreamRepositoryName) {
         this.upstreamRepositoryName = upstreamRepositoryName;
@@ -62,28 +61,28 @@ public class CreatePullRequestTask extends DefaultTask {
     }
 
     /**
-     * See {@link ShipkitConfiguration.GitHub#getApiUrl()}
+     * See {@link org.shipkit.gradle.configuration.ShipkitConfiguration.GitHub#getApiUrl()}
      */
     public String getGitHubApiUrl() {
         return gitHubApiUrl;
     }
 
     /**
-     * See {@link ShipkitConfiguration.GitHub#getApiUrl()}
+     * See {@link org.shipkit.gradle.configuration.ShipkitConfiguration.GitHub#getApiUrl()}
      */
     public void setGitHubApiUrl(String gitHubApiUrl) {
         this.gitHubApiUrl = gitHubApiUrl;
     }
 
     /**
-     * See {@link ShipkitConfiguration.GitHub#getWriteAuthToken()}
+     * See {@link org.shipkit.gradle.configuration.ShipkitConfiguration.GitHub#getWriteAuthToken()}
      */
     public String getAuthToken() {
         return authToken;
     }
 
     /**
-     * See {@link ShipkitConfiguration.GitHub#getWriteAuthToken()}
+     * See {@link org.shipkit.gradle.configuration.ShipkitConfiguration.GitHub#getWriteAuthToken()}
      */
     public void setAuthToken(String authToken) {
         this.authToken = authToken;
@@ -112,14 +111,14 @@ public class CreatePullRequestTask extends DefaultTask {
     }
 
     /**
-     * See {@link ShipkitConfiguration.GitHub#dryRun}
+     * See {@link org.shipkit.gradle.configuration.ShipkitConfiguration.GitHub#dryRun}
      */
     public void setDryRun(boolean dryRun) {
         this.dryRun = dryRun;
     }
 
     /**
-     * See {@link ShipkitConfiguration.GitHub#dryRun}
+     * See {@link org.shipkit.gradle.configuration.ShipkitConfiguration.GitHub#dryRun}
      */
     public boolean isDryRun() {
         return dryRun;

--- a/subprojects/shipkit/src/main/groovy/org/shipkit/internal/util/RepositoryNameUtil.java
+++ b/subprojects/shipkit/src/main/groovy/org/shipkit/internal/util/RepositoryNameUtil.java
@@ -11,6 +11,7 @@ public class RepositoryNameUtil {
      * Formats repositoryName to camel case version of it with the first letter capitalized. Eg.
      * "mockito/shipkit" -> "MockitoShipkit"
      * "mockito/shipkit-example" -> "MockitoShipkitExample"
+     *
      * @param repositoryName GitHub repo name in format "org/repo", eg. "mockito/shipkit"
      */
     public static String repositoryNameToCapitalizedCamelCase(String repositoryName) {
@@ -22,6 +23,7 @@ public class RepositoryNameUtil {
      * Formats repositoryName to camel case version of it. Eg.
      * "mockito/shipkit" -> "mockitoShipkit"
      * "mockito/shipkit-example" -> "mockitoShipkitExample"
+     *
      * @param repositoryName GitHub repo name in format "org/repo", eg. "mockito/shipkit"
      */
     public static String repositoryNameToCamelCase(String repositoryName) {
@@ -37,7 +39,8 @@ public class RepositoryNameUtil {
     /**
      * Extracts only repo part of the GitHub repo URL, eg.
      * "https://github.com/mockito/shipkit" -> "mockito/shipkit"
-     * @param gitHubRepoUrl, full GitHub repo url, eg. "https://github.com/mockito/shipkit"
+     *
+     * @param gitHubRepoUrl full GitHub repo url, eg. "https://github.com/mockito/shipkit"
      */
     public static String extractRepoNameFromGitHubUrl(String gitHubRepoUrl) {
         String trimmed = gitHubRepoUrl.trim();


### PR DESCRIPTION
This PR will fix #290 

Most of the issues (beside of two ([wrong usage of @param](https://github.com/mockito/shipkit/blob/6af8b6812de506685deea755f1b1fcdb97e11d6e/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/release/tasks/GistsApi.java#L16)) and ([wrong param name (`,` was included)](https://github.com/mockito/shipkit/blob/6af8b6812de506685deea755f1b1fcdb97e11d6e/subprojects/shipkit/src/main/groovy/org/shipkit/internal/util/RepositoryNameUtil.java#L40))) was due the fact that we imported the `ShipkitConfiguration` instead of having a full package name in the `@link` javadoc.

I'm not a javadoc expert. But it seems that the issues appear because the documentation and the `ShipkitConfiguration` aren't in the same package.
`ShipkitConfiguration` lives in `org.shipkit.gradle.configuration`
while the "errors" lives in `org.shipkit.gradle.[other_but_not_configuration]`

I've added a test file in the `configuration` package like that
```java
/**
 * {@link ShipkitConfiguration.GitHub#getApiUrl()}
 */
public class Test {
}
```
and it doesn't show a warning... 🤷‍♂️ 

Whatever. Now we have no javadoc warnings anymore \o/
<img width="179" alt="bildschirmfoto 2017-10-03 um 08 02 06" src="https://user-images.githubusercontent.com/10229883/31111938-305c5382-a811-11e7-8ed6-7f8cef87f620.png">
