### PR TITLE
Use publicationRepositoy in shipkit

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         maven { url "https://plugins.gradle.org/m2/" }
     }
     dependencies {
-        classpath 'org.shipkit:shipkit:0.9.94'
+        classpath 'org.shipkit:shipkit:0.9.97'
         classpath 'ru.vyarus:gradle-animalsniffer-plugin:1.3.0'
     }
 }

--- a/gradle/shipkit.gradle
+++ b/gradle/shipkit.gradle
@@ -5,13 +5,7 @@ shipkit {
     team.developers = ['szczepiq:Szczepan Faber', 'mstachniuk:Marcin Stachniuk',
                        'wwilk:Wojtek Wilk', 'epeee:Erhard Pointl', 'NagRock:Maciej Kuster']
 
-    // Comment in after the next version of shipkit is released
-    //releaseNotes.publicationRepository = "https://plugins.gradle.org/plugin/org.shipkit.java"
-}
-
-// Remove me after the next version of shipkit is released
-afterEvaluate {
-    project.rootProject.tasks.updateReleaseNotes.publicationRepository = "https://plugins.gradle.org/plugin/org.shipkit.java"
+    releaseNotes.publicationRepository = "https://plugins.gradle.org/plugin/org.shipkit.java"
 }
 
 apply plugin: 'org.shipkit.upgrade-dependency'


### PR DESCRIPTION
This will fix #473 

Hopefully 🤞 

~To be honest. I don't know why... Can you maybe explain it why there was that issue?~

Ok. Got it.
I don't of its ok for you guys to update the shipkit version manually?!
But otherwise we should add a workaround so that it works. Which isn't really better...
The problem is the following:
On older shipkit versions everythings works fine.
On newer shipkit versions the `project.rootProject.tasks.updateReleaseNotes.publicationRepository` has no effect anymore.
Because we should define the `shipkit.releaseNotes.publicationRepository`. Otherwise it can't build.
I can't just configure the `shipkit.releaseNotes.publicationRepository` in older versions. Because it will don't build because there is no property called `publicationRepository` :(

Or is there another solution I currently don't see? 🤔 