### PR TITLE
emit nice summary at the end of the release (release notes)

### DIFF
--- a/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/util/TaskSuccessfulMessage.java
+++ b/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/util/TaskSuccessfulMessage.java
@@ -4,6 +4,7 @@ import org.gradle.api.Action;
 import org.gradle.api.Task;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
+import org.shipkit.internal.notes.util.Supplier;
 
 public class TaskSuccessfulMessage {
 
@@ -18,6 +19,15 @@ public class TaskSuccessfulMessage {
             @Override
             public void execute(Task task) {
                 LOG.lifecycle(message);
+            }
+        });
+    }
+
+    public static void logOnSuccess(Task task, final Supplier<String> supplier) {
+        task.doLast(new Action<Task>() {
+            @Override
+            public void execute(Task task) {
+                LOG.lifecycle(supplier.get());
             }
         });
     }

--- a/subprojects/shipkit/src/main/groovy/org/shipkit/internal/notes/util/Supplier.java
+++ b/subprojects/shipkit/src/main/groovy/org/shipkit/internal/notes/util/Supplier.java
@@ -1,0 +1,6 @@
+package org.shipkit.internal.notes.util;
+
+public interface Supplier<T> {
+
+    T get();
+}


### PR DESCRIPTION
 - very first version which includes a link to the release notes

first part of #450 

Did some testing locally:

```
:performRelease

Release shipped!
    - Release notes:      https://github.com/mockito/shipkit/blob/ep2/docs/release-notes.md
```