### PR TITLE
Prevent noise from test tasks in info level build

### DIFF
--- a/subprojects/shipkit/shipkit.gradle
+++ b/subprojects/shipkit/shipkit.gradle
@@ -39,6 +39,14 @@ test {
     testLogging {
         info.events = ["failed", "skipped"]
     }
+    afterSuite { desc, result ->
+        if (!desc.parent)
+            logger.info("Test summary: " +
+                "${result.testCount} tests " +
+                "(${result.successfulTestCount} succeeded, " +
+                "${result.failedTestCount} failed, " +
+                "${result.skippedTestCount} skipped)")
+    }
 }
 
 pluginBundle {

--- a/subprojects/shipkit/shipkit.gradle
+++ b/subprojects/shipkit/shipkit.gradle
@@ -35,6 +35,12 @@ dependencies {
     testCompile gradleTestKit()
 }
 
+test {
+    testLogging {
+        info.events = ["failed", "skipped"]
+    }
+}
+
 pluginBundle {
     website = 'http://shipkit.org/'
     vcsUrl = 'https://github.com/mockito/shipkit'


### PR DESCRIPTION
fixes #380 

build log of test task using info level now looks like: 

> :shipkit:test (Thread[Daemon worker,5,main]) started.
> :shipkit:test
> Executing task ':shipkit:test' (up-to-date check took 0.058 secs) due to:
>   No history is available.
> Starting process 'Gradle Test Executor 2'. Working directory: /home/travis/build/mockito/shipkit/subprojects/shipkit Command: /usr/lib/jvm/java-8-oracle/bin/java -Djava.security.manager=worker.org.gradle.process.internal.worker.child.BootstrapSecurityManager -Dfile.encoding=UTF-8 -Duser.country=US -Duser.language=en -Duser.variant -ea -cp /home/travis/.gradle/caches/2.14.1/workerMain/gradle-worker.jar worker.org.gradle.process.internal.worker.GradleWorkerMain 'Gradle Test Executor 2'
> Successfully started process 'Gradle Test Executor 2'
> Picked up _JAVA_OPTIONS: -Xmx2048m -Xms512m
> Gradle Test Executor 2 started executing tests.
> org.shipkit.internal.notes.generator.DefaultReleaseNotesGeneratorTest > gets release notes data SKIPPED
> Gradle Test Executor 2 finished executing tests.
> Finished generating test XML results (0.113 secs) into: /home/travis/build/mockito/shipkit/subprojects/shipkit/build/test-results
> Generating HTML test report...
> Finished generating test html results (0.139 secs) into: /home/travis/build/mockito/shipkit/subprojects/shipkit/build/reports/tests
> :shipkit:test (Thread[Daemon worker,5,main]) completed. Took 59.816 secs.