### PR TITLE
Setting contributors should not break "updateReleaseNotes" task

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,6 +13,7 @@ buildscript {
 apply from: "$rootDir/gradle/java6-compatibility.gradle"
 apply from: "$rootDir/gradle/precommit.gradle"
 
+apply plugin: 'base'
 apply plugin: 'org.shipkit.gradle-plugin'
 
 allprojects {

--- a/subprojects/shipkit/src/main/groovy/org/shipkit/gradle/notes/UpdateReleaseNotesTask.java
+++ b/subprojects/shipkit/src/main/groovy/org/shipkit/gradle/notes/UpdateReleaseNotesTask.java
@@ -33,7 +33,7 @@ public class UpdateReleaseNotesTask extends DefaultTask {
     @InputFile private File releaseNotesData;
     @Input private Collection<String> developers = new LinkedList<String>();
     @Input private Collection<String> contributors = new LinkedList<String>();
-    @InputFile private File contributorsDataFile;
+    @InputFile @Optional private File contributorsDataFile;
 
     @Input private boolean emphasizeVersion;
     @Input private String version;
@@ -235,7 +235,7 @@ public class UpdateReleaseNotesTask extends DefaultTask {
     }
 
     /**
-     * File name from reads contributors from GitHub
+     * File containing contributors fetched from GitHub
      */
     public File getContributorsDataFile() {
         return contributorsDataFile;

--- a/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/notes/ReleaseNotesPlugin.java
+++ b/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/notes/ReleaseNotesPlugin.java
@@ -98,13 +98,17 @@ public class ReleaseNotesPlugin implements Plugin<Project> {
 
         task.setGitHubRepository(conf.getGitHub().getRepository());
         task.setDevelopers(conf.getTeam().getDevelopers());
+
         task.setContributors(conf.getTeam().getContributors());
+        if (conf.getTeam().getContributors().isEmpty()) {
+            task.setContributorsDataFile(contributorsFetcher.getOutputs().getFiles().getSingleFile());
+        }
+
         task.setGitHubLabelMapping(conf.getReleaseNotes().getLabelMapping());
         task.setReleaseNotesFile(project.file(conf.getReleaseNotes().getFile()));
         task.setGitHubUrl(conf.getGitHub().getUrl());
         task.setPreviousVersion(project.getExtensions().getByType(VersionInfo.class).getPreviousVersion());
 
         task.setReleaseNotesData(releaseNotesFetcher.getOutputFile());
-        task.setContributorsDataFile(contributorsFetcher.getOutputs().getFiles().getSingleFile());
     }
 }


### PR DESCRIPTION
The problem was caused by the fact that if "shipkit.team.contributors" property is set, fetchContributors task is skipped so "all-contributors.json" is not created. In this case this file is not needed so can be made @Optional but unfortunately Gradle will still throw an exception that it doesn't exist (see https://github.com/gradle/gradle/issues/2919). Therefore I'm setting it to null in this case to be ignored by Gradle validation.

Additionally I applied "base" plugin in Shipkit root project, because there is no clean for it currently, and some files (like 'all-contributors.json') are created in root project's build dir.

Fixes #516