### PR TITLE
Fixed problem with the release (again)

### DIFF
--- a/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/git/GitSetupPlugin.java
+++ b/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/git/GitSetupPlugin.java
@@ -63,7 +63,7 @@ public class GitSetupPlugin implements Plugin<Project> {
                 //Travis default clone is shallow which will prevent correct release notes generation for repos with lots of commits
                 t.setDescription("Ensures good chunk of recent commits is available for release notes automation.");
                 t.execCommand(ExecCommandFactory.execCommand("Getting more commits",
-                    asList("git", "fetch", "--unshallow", "tags"), new Action<ExecResult>() {
+                    asList("git", "fetch", "--unshallow", "--tags"), new Action<ExecResult>() {
                         @Override
                         public void execute(ExecResult result) {
                             if (result.getExitValue() != 0) {


### PR DESCRIPTION
Our git unshallow task also needs to specify '--tags'. Otherwise we don't fetch the latest tag needed for release generation. See #512 

Tested by simulating Travis CI shallow clone, followed by running ./gradlew gitUnshallow.

Please ship it because it fixes the build!