### PR TITLE
First step of fixing the problem with generating Gradle/Bintray URLs

### DIFF
--- a/subprojects/shipkit/src/main/groovy/org/shipkit/gradle/configuration/ShipkitConfiguration.java
+++ b/subprojects/shipkit/src/main/groovy/org/shipkit/gradle/configuration/ShipkitConfiguration.java
@@ -254,8 +254,8 @@ public class ShipkitConfiguration {
         }
 
         /**
-         * Set the Publication Repository where we look for your published binary.
-         * Version will be concatenated to it.
+         * Set the Publication Repository where we look for your published binary. Version will be concatenated to it.
+         * It is currently used to configure repository Badge URL when generating release notes.
          * E.g.
          * <pre>
          *   releaseNotes.publicationRepository = "https://plugins.gradle.org/plugin/org.shipkit.java/"

--- a/subprojects/shipkit/src/main/groovy/org/shipkit/gradle/configuration/ShipkitConfiguration.java
+++ b/subprojects/shipkit/src/main/groovy/org/shipkit/gradle/configuration/ShipkitConfiguration.java
@@ -255,10 +255,13 @@ public class ShipkitConfiguration {
 
         /**
          * Set the Publication Repository where we look for your published binary.
+         * Can contain placeholder {VERSION} which will be replaced with a currently built version.
          * E.g.
          * <pre>
-         *   releaseNotes.publicationRepository = "https://plugins.gradle.org/plugin/org.shipkit.java"
+         *   releaseNotes.publicationRepository = "https://plugins.gradle.org/plugin/org.shipkit.java/{VERSION}"
          * </pre>
+         * For version = "1.2.3" will result in:
+         * "https://plugins.gradle.org/plugin/org.shipkit.java/1.2.3"
          * This will be used for adding and linking the repository in the release notes.
          *
          * @see #getPublicationRepository()

--- a/subprojects/shipkit/src/main/groovy/org/shipkit/gradle/configuration/ShipkitConfiguration.java
+++ b/subprojects/shipkit/src/main/groovy/org/shipkit/gradle/configuration/ShipkitConfiguration.java
@@ -255,10 +255,10 @@ public class ShipkitConfiguration {
 
         /**
          * Set the Publication Repository where we look for your published binary.
-         * Can contain placeholder {VERSION} which will be replaced with a currently built version.
+         * Version will be concatenated to it.
          * E.g.
          * <pre>
-         *   releaseNotes.publicationRepository = "https://plugins.gradle.org/plugin/org.shipkit.java/{VERSION}"
+         *   releaseNotes.publicationRepository = "https://plugins.gradle.org/plugin/org.shipkit.java/"
          * </pre>
          * For version = "1.2.3" will result in:
          * "https://plugins.gradle.org/plugin/org.shipkit.java/1.2.3"

--- a/subprojects/shipkit/src/main/groovy/org/shipkit/internal/comparison/artifact/DefaultArtifactUrlResolverFactory.java
+++ b/subprojects/shipkit/src/main/groovy/org/shipkit/internal/comparison/artifact/DefaultArtifactUrlResolverFactory.java
@@ -6,6 +6,8 @@ import org.shipkit.internal.gradle.plugin.GradlePortalPublishPlugin;
 
 public class DefaultArtifactUrlResolverFactory {
 
+    private static final String VERSION_PLACEHOLDER = "{VERSION}";
+
     public DefaultArtifactUrlResolver getDefaultResolver(Project project, String artifactBaseName, String previousVersion) {
         if (project.getPlugins().hasPlugin(ShipkitBintrayPlugin.class)) {
             return new BintrayDefaultArtifactUrlResolver(project, artifactBaseName, previousVersion);
@@ -15,4 +17,11 @@ public class DefaultArtifactUrlResolverFactory {
         return null;
     }
 
+    public static String resolveUrlFromPublicationRepository(String publicationRepository, String version) {
+        if (publicationRepository.contains(VERSION_PLACEHOLDER)) {
+            return publicationRepository.replace(VERSION_PLACEHOLDER, version);
+        } else { // backwards compatibility with previous solution
+            return publicationRepository + "/" + version;
+        }
+    }
 }

--- a/subprojects/shipkit/src/main/groovy/org/shipkit/internal/comparison/artifact/DefaultArtifactUrlResolverFactory.java
+++ b/subprojects/shipkit/src/main/groovy/org/shipkit/internal/comparison/artifact/DefaultArtifactUrlResolverFactory.java
@@ -6,8 +6,6 @@ import org.shipkit.internal.gradle.plugin.GradlePortalPublishPlugin;
 
 public class DefaultArtifactUrlResolverFactory {
 
-    private static final String VERSION_PLACEHOLDER = "{VERSION}";
-
     public DefaultArtifactUrlResolver getDefaultResolver(Project project, String artifactBaseName, String previousVersion) {
         if (project.getPlugins().hasPlugin(ShipkitBintrayPlugin.class)) {
             return new BintrayDefaultArtifactUrlResolver(project, artifactBaseName, previousVersion);

--- a/subprojects/shipkit/src/main/groovy/org/shipkit/internal/comparison/artifact/DefaultArtifactUrlResolverFactory.java
+++ b/subprojects/shipkit/src/main/groovy/org/shipkit/internal/comparison/artifact/DefaultArtifactUrlResolverFactory.java
@@ -18,10 +18,6 @@ public class DefaultArtifactUrlResolverFactory {
     }
 
     public static String resolveUrlFromPublicationRepository(String publicationRepository, String version) {
-        if (publicationRepository.contains(VERSION_PLACEHOLDER)) {
-            return publicationRepository.replace(VERSION_PLACEHOLDER, version);
-        } else { // backwards compatibility with previous solution
-            return publicationRepository + "/" + version;
-        }
+        return publicationRepository + version;
     }
 }

--- a/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/java/tasks/DownloadPreviousPublications.java
+++ b/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/java/tasks/DownloadPreviousPublications.java
@@ -24,10 +24,11 @@ public class DownloadPreviousPublications {
         try {
             IOUtil.downloadToFile(remoteUrl, localFile);
         } catch (Exception e) {
-            LOG.lifecycle("  Unable to download, ignoring. Run with '-d' for stack trace. Url: {}", remoteUrl);
-            LOG.debug("Unable to download, ignoring." +
-                "If the download URL is incorrect you may need to configure the URL manually.\n" +
-                "See DownloadPreviousPublicationTask for details.\n", e);
+            LOG.lifecycle("  Unable to download, ignoring. Run with '-d' for stack trace.\n " +
+                "  If the download URL is incorrect you may need to configure the URL manually.\n" +
+                "  See DownloadPreviousPublicationTask for details.\n" +
+                "  Url: {}", remoteUrl);
+            LOG.debug("Unable to download, ignoring.", e);
         }
     }
 }

--- a/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/java/tasks/DownloadPreviousPublications.java
+++ b/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/java/tasks/DownloadPreviousPublications.java
@@ -25,7 +25,9 @@ public class DownloadPreviousPublications {
             IOUtil.downloadToFile(remoteUrl, localFile);
         } catch (Exception e) {
             LOG.lifecycle("  Unable to download, ignoring. Run with '-d' for stack trace. Url: {}", remoteUrl);
-            LOG.debug("Unable to download, ignoring", e);
+            LOG.debug("Unable to download, ignoring." +
+                "If the download URL is incorrect you may need to configure the URL manually.\n" +
+                "See DownloadPreviousPublicationTask for details.\n", e);
         }
     }
 }

--- a/subprojects/shipkit/src/main/groovy/org/shipkit/internal/notes/format/DetailedFormatter.java
+++ b/subprojects/shipkit/src/main/groovy/org/shipkit/internal/notes/format/DetailedFormatter.java
@@ -1,5 +1,6 @@
 package org.shipkit.internal.notes.format;
 
+import org.shipkit.internal.comparison.artifact.DefaultArtifactUrlResolverFactory;
 import org.shipkit.internal.gradle.util.StringUtil;
 import org.shipkit.internal.util.DateUtil;
 import org.shipkit.internal.util.MultiMap;
@@ -46,7 +47,7 @@ class DetailedFormatter implements MultiReleaseNotesFormatter {
         for (ReleaseNotesData d : data) {
             sb.append(header(d.getVersion(), d.getDate(), emphasizeVersion));
             String vcsCommitsLink = MessageFormat.format(vcsCommitsLinkTemplate, d.getPreviousVersionVcsTag(), d.getVcsTag());
-            sb.append(releaseSummary(d.getVersion(), d.getDate(), d.getContributions(), contributors, vcsCommitsLink, publicationRepository));
+            sb.append(releaseSummary(d.getVersion(), d.getContributions(), contributors, vcsCommitsLink, publicationRepository));
 
             if (!d.getContributions().getContributions().isEmpty()) {
                 //no point printing any improvements information if there are no code changes
@@ -68,7 +69,7 @@ class DetailedFormatter implements MultiReleaseNotesFormatter {
         return prefix + version + " (" + DateUtil.formatDate(date) + ")" + postfix + " - ";
     }
 
-    static String releaseSummary(String version, Date date, ContributionSet contributions, Map<String, Contributor> contributors,
+    static String releaseSummary(String version, ContributionSet contributions, Map<String, Contributor> contributors,
                                  String vcsCommitsLink, String publicationRepository) {
         return authorsSummary(contributions, contributors, vcsCommitsLink) +
                 " - published to " + getBintrayBadge(version, publicationRepository) + "\n" +
@@ -79,7 +80,7 @@ class DetailedFormatter implements MultiReleaseNotesFormatter {
         final String markdownPrefix = "[![Bintray](";
         final String shieldsIoBadgeLink = "https://img.shields.io/badge/Bintray-" + version + "-green.svg";
         final String markdownPostfix = ")]";
-        final String repositoryLinkWithVersion = publicationRepository + "/" + version;
+        final String repositoryLinkWithVersion = DefaultArtifactUrlResolverFactory.resolveUrlFromPublicationRepository(publicationRepository, version);
         return markdownPrefix + shieldsIoBadgeLink + markdownPostfix + "(" + repositoryLinkWithVersion + ")";
     }
 

--- a/subprojects/shipkit/src/test/groovy/org/shipkit/internal/comparison/artifact/DefaultArtifactUrlResolverFactoryTest.groovy
+++ b/subprojects/shipkit/src/test/groovy/org/shipkit/internal/comparison/artifact/DefaultArtifactUrlResolverFactoryTest.groovy
@@ -46,4 +46,22 @@ class DefaultArtifactUrlResolverFactoryTest extends Specification {
         then:
         EqualsBuilder.reflectionEquals(result, new GradlePluginArtifactUrlResolver("testGroup", "artifactName", "0.0.1"))
     }
+
+    def "resolves url from publicationRepository if it contains version placeholder"() {
+        when:
+        def result = DefaultArtifactUrlResolverFactory.resolveUrlFromPublicationRepository(
+            "https://bintray.com/a/b/c/v-{VERSION}", "1.7.4")
+
+        then:
+        result == "https://bintray.com/a/b/c/v-1.7.4"
+    }
+
+    def "adds version to url if publicationRepository does not contain version placeholder"() {
+        when:
+        def result = DefaultArtifactUrlResolverFactory.resolveUrlFromPublicationRepository(
+            "https://bintray.com/a/b/c", "1.7.4")
+
+        then:
+        result == "https://bintray.com/a/b/c/1.7.4"
+    }
 }

--- a/subprojects/shipkit/src/test/groovy/org/shipkit/internal/comparison/artifact/DefaultArtifactUrlResolverFactoryTest.groovy
+++ b/subprojects/shipkit/src/test/groovy/org/shipkit/internal/comparison/artifact/DefaultArtifactUrlResolverFactoryTest.groovy
@@ -47,21 +47,12 @@ class DefaultArtifactUrlResolverFactoryTest extends Specification {
         EqualsBuilder.reflectionEquals(result, new GradlePluginArtifactUrlResolver("testGroup", "artifactName", "0.0.1"))
     }
 
-    def "resolves url from publicationRepository if it contains version placeholder"() {
-        when:
-        def result = DefaultArtifactUrlResolverFactory.resolveUrlFromPublicationRepository(
-            "https://bintray.com/a/b/c/v-{VERSION}", "1.7.4")
-
-        then:
-        result == "https://bintray.com/a/b/c/v-1.7.4"
-    }
-
     def "adds version to url if publicationRepository does not contain version placeholder"() {
         when:
         def result = DefaultArtifactUrlResolverFactory.resolveUrlFromPublicationRepository(
-            "https://bintray.com/a/b/c", "1.7.4")
+            "https://bintray.com/a/b/c-", "1.7.4")
 
         then:
-        result == "https://bintray.com/a/b/c/1.7.4"
+        result == "https://bintray.com/a/b/c-1.7.4"
     }
 }

--- a/subprojects/shipkit/src/test/groovy/org/shipkit/internal/notes/format/DetailedFormatterTest.groovy
+++ b/subprojects/shipkit/src/test/groovy/org/shipkit/internal/notes/format/DetailedFormatterTest.groovy
@@ -154,7 +154,7 @@ Release notes:
                                     c("Tim van der Lippe", 10)]
         }
 
-        def summary = DetailedFormatter.releaseSummary("1.2.3", new Date(1483500000000), c, [:], "link",
+        def summary = DetailedFormatter.releaseSummary("1.2.3", c, [:], "link",
                 "https://bintray.com/shipkit")
 
         expect:

--- a/subprojects/shipkit/src/test/groovy/org/shipkit/internal/notes/format/DetailedFormatterTest.groovy
+++ b/subprojects/shipkit/src/test/groovy/org/shipkit/internal/notes/format/DetailedFormatterTest.groovy
@@ -11,7 +11,7 @@ import spock.lang.Specification
 class DetailedFormatterTest extends Specification {
 
     def f = new DetailedFormatter("Info about shipkit\n\n", "Release notes:\n\n", ["noteworthy": "Noteworthy", "bug": "Bugfixes"],
-            "http://commits/{0}...{1}", "Bintray", [:], false)
+            "http://commits/{0}...{1}", "Bintray/", [:], false)
 
     def "no releases"() {
         expect:
@@ -155,7 +155,7 @@ Release notes:
         }
 
         def summary = DetailedFormatter.releaseSummary("1.2.3", c, [:], "link",
-                "https://bintray.com/shipkit")
+                "https://bintray.com/shipkit/")
 
         expect:
         summary == """[100 commits](link) by 4 authors - published to [![Bintray](https://img.shields.io/badge/Bintray-1.2.3-green.svg)](https://bintray.com/shipkit/1.2.3)


### PR DESCRIPTION
First step of #478. It solves the problem for Powermock, so that they could use "powermock-{VERSION}" in the release notes. When it's merged I will raise a PR in powermock to fix this issue.