### PR TITLE
Integration test for InitPlugin

### DIFF
--- a/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/init/InitPlugin.java
+++ b/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/init/InitPlugin.java
@@ -50,7 +50,6 @@ public class InitPlugin implements Plugin<Project> {
 
     @Override
     public void apply(final Project project) {
-        //TODO SF let's add an integration test
         project.getPlugins().apply(VersioningPlugin.class);
         project.getPlugins().apply(ShipkitConfigurationPlugin.class);
         final GitOriginPlugin gitOriginPlugin = project.getRootProject().getPlugins().apply(GitOriginPlugin.class);

--- a/subprojects/shipkit/src/test/groovy/org/shipkit/internal/gradle/init/InitPluginIntegTest.groovy
+++ b/subprojects/shipkit/src/test/groovy/org/shipkit/internal/gradle/init/InitPluginIntegTest.groovy
@@ -1,0 +1,30 @@
+package org.shipkit.internal.gradle.init
+
+import org.gradle.testkit.runner.BuildResult
+import testutil.GradleSpecification
+
+class InitPluginIntegTest extends GradleSpecification {
+
+        def "runs initShipkit task in a project without any Shipkit configuration"() {
+            given:
+            projectDir.newFolder("gradle")
+
+            buildFile << """
+            apply plugin: "org.shipkit.java"
+        """
+
+            expect:
+            BuildResult result = pass("initShipkit", "-s")
+
+            result.tasks.collect { it.path }.join("\n") == """:identifyGitOrigin
+:initShipkitFile
+:initTravis
+:initVersioning
+:initShipkit"""
+
+            // check if configuration files were generated
+            new File(projectDir.root, "gradle/shipkit.gradle").exists()
+            new File(projectDir.root, "version.properties").exists()
+            new File(projectDir.root, ".travis.yml").exists()
+        }
+}

--- a/subprojects/shipkit/src/test/groovy/org/shipkit/internal/gradle/init/InitPluginIntegTest.groovy
+++ b/subprojects/shipkit/src/test/groovy/org/shipkit/internal/gradle/init/InitPluginIntegTest.groovy
@@ -1,26 +1,17 @@
 package org.shipkit.internal.gradle.init
 
-import org.gradle.testkit.runner.BuildResult
 import testutil.GradleSpecification
 
 class InitPluginIntegTest extends GradleSpecification {
 
         def "runs initShipkit task in a project without any Shipkit configuration"() {
             given:
-            projectDir.newFolder("gradle")
-
             buildFile << """
             apply plugin: "org.shipkit.java"
         """
 
             expect:
-            BuildResult result = pass("initShipkit", "-s")
-
-            result.tasks.collect { it.path }.join("\n") == """:identifyGitOrigin
-:initShipkitFile
-:initTravis
-:initVersioning
-:initShipkit"""
+            pass("initShipkit", "-s")
 
             // check if configuration files were generated
             new File(projectDir.root, "gradle/shipkit.gradle").exists()


### PR DESCRIPTION
I went through TODOs in code on a plane today and I figured this test is important, it assures that you can apply Shipkit plugin in empty project and run initShipkit on it. 