### PR TITLE
Fix #426 - Only cache jar, pom and xml files in .gradle/caches

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,13 +23,19 @@ script:
 
 # Remove often changing files to prevent cache re-upload on no changes in dependencies
 before_cache:
-  - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
-  - rm -fr $HOME/.gradle/caches/*/plugin-resolution/
-  - rm -fr $HOME/.gradle/caches/*/scripts/
-  - rm -fr $HOME/.gradle/caches/*/scripts-remapped/
-  - rm -fr $HOME/.gradle/caches/*/fileHashes/
-  - rm -fr $HOME/.gradle/caches/transforms-1/transforms-1.lock
+# pom, xml and jar files are known not to change
+# assume non-whitelisted extensions are changing
+# (this will include .lock, .bin, .metadata and potential future additions to gradle's caches folder)
+  - find $HOME/.gradle/caches -type f -not \( -iname \*.pom -o -iname \*.jar -o -iname \*.xml \) -delete
+# jar files which change
+  - rm -fr $HOME/.gradle/caches/*/workerMain/gradle-worker.jar
+# xml files which change
+  - find $HOME/.gradle/caches/modules-2 -name ivy.xml -delete
+# specific to shipkit build
   - rm -fr $HOME/.gradle/caches/jars-*/*/shipkit-*.jar
+  - find $HOME/.gradle/caches/modules-2 -name shipkit-\*.jar -delete
+# remove left over empty directories
+  - find $HOME/.gradle/caches -type d -empty -delete
 cache:
   directories:
     - $HOME/.gradle/caches/

--- a/subprojects/shipkit/src/main/resources/template.travis.yml
+++ b/subprojects/shipkit/src/main/resources/template.travis.yml
@@ -7,6 +7,19 @@ cache:
     - $HOME/.gradle/caches/
     - $HOME/.gradle/wrapper/
 
+# Remove often changing files to prevent cache re-upload on no changes in dependencies
+before_cache:
+# pom, xml and jar files are known not to change
+# assume non-whitelisted extensions are changing
+# (this will include .lock, .bin, .metadata and potential future additions to gradle's caches folder)
+  - find $HOME/.gradle/caches -type f -not \( -iname \*.pom -o -iname \*.jar -o -iname \*.xml \) -delete
+# jar files which change
+  - rm -fr $HOME/.gradle/caches/*/workerMain/gradle-worker.jar
+# xml files which change
+  - find $HOME/.gradle/caches/modules-2 -name ivy.xml -delete
+# remove left over empty directories
+  - find $HOME/.gradle/caches -type d -empty -delete
+
 language: java
 
 jdk:


### PR DESCRIPTION
Fixes #426.

Same change working for one of my projects - https://travis-ci.org/MinimallyCorrect/DefaultsPlugin/builds/295473198

Testing builds of this project by triggering PR build multiple times and checking that cache isn't changed.

----

[Test build 1 - cache changes due to removed .lock files, expected](https://travis-ci.org/mockito/shipkit/builds/295478474)  
[Test build 2 - has cache changes, should have no cache changes](https://travis-ci.org/mockito/shipkit/builds/295483481) ❌  
[Test build 3 - cache changes due to removing gradle-worker.jar and ivy.xml](https://travis-ci.org/mockito/shipkit/builds/295489863)  
[Test build 4 - has no cache changes, should have no cache changes](https://travis-ci.org/mockito/shipkit/builds/295493206) ✔️  
[Test build 5 - cache changes due to removing lots of shipkit-VERSION.jar from modules-2](https://travis-ci.org/mockito/shipkit/builds/295498115)  
[Test build 6 - has no cache changes, should have no cache changes](https://travis-ci.org/mockito/shipkit/builds/295501139)✔️  

