### PR TITLE
Shipkit version downgraded to the last working one and CloneGitRepositoryTask fixed

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         maven { url "https://plugins.gradle.org/m2/" }
     }
     dependencies {
-        classpath 'org.shipkit:shipkit:0.9.133'
+        classpath 'org.shipkit:shipkit:0.9.131'
         classpath 'ru.vyarus:gradle-animalsniffer-plugin:1.3.0'
     }
 }

--- a/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/git/tasks/CloneGitRepositoryTask.java
+++ b/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/git/tasks/CloneGitRepositoryTask.java
@@ -18,8 +18,11 @@ import java.util.List;
 import static java.lang.String.valueOf;
 
 /**
- * This task clone git project from repository to target dir.
- * It support clone from remote server and from local filesystem.
+ * This task clones git project from {@link #getRepositoryUrl()} to {@link #getTargetDir()}.
+ * It supports clone from remote server and from local filesystem.
+ * The task execution is skipped if {@link #getTargetDir()} exists and is not empty.
+ * If you want to always execute it, use clean task before calling this one.
+ * Note that it's a heavy operation and therefore multiple executions in the same build should be avoided.
  *
  * TODO ms - when you are ready, please move the new task types to the public packages,
  *   for example "org.shipkit.gradle.*". With 1.0 we need all task types to be public.

--- a/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/git/tasks/CloneGitRepositoryTask.java
+++ b/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/git/tasks/CloneGitRepositoryTask.java
@@ -37,7 +37,12 @@ public class CloneGitRepositoryTask extends DefaultTask {
 
     @TaskAction
     public void cloneRepository() {
+        if (!isTargetEmpty()) {
+            LOG.lifecycle("{} -  Target dir {} already exists and is not empty. Skipping execution of the task.");
+        }
+
         LOG.lifecycle("  Cloning repository {}\n    into {}", repositoryUrl, targetDir);
+
         getProject().getBuildDir().mkdirs();    // build dir can be not created yet
         ProcessRunner processRunner = Exec.getProcessRunner(getProject().getBuildDir());
         processRunner.run(getCloneCommand());
@@ -119,5 +124,9 @@ public class CloneGitRepositoryTask extends DefaultTask {
     @Input
     public void setDepth(int depth) {
         this.depth = depth;
+    }
+
+    private boolean isTargetEmpty() {
+        return !targetDir.exists() || targetDir.list().length == 0;
     }
 }


### PR DESCRIPTION
CloneGitRepositoryTask failed because we have two separate processes that use it (testDownstream and performRelease) in Travis script. I added a check if directory is empty, because it doesn't make sense to clone it again when running "upgradeDownstream". I also improved documentation of the task, so that it's clear how it behaves.