### PR TITLE
update release needed doc

### DIFF
--- a/docs/gradle-plugins/release-needed-plugin.md
+++ b/docs/gradle-plugins/release-needed-plugin.md
@@ -32,6 +32,7 @@ Release is considered not needed when:
  * 'SKIP_RELEASE' environment variable is present
  * commit message contains '[ci skip-release]'
  * we are building a "pull request", see [Travis Documentation](https://docs.travis-ci.com/user/environment-variables/) for more information
+
 Release is needed when all above is false and:
  * we are building on a branch that matches releaseBranchRegex (e.g. 'master'), see **releaseBranchRegex** in [Configuration section](#configuration)
  * and one of the following criteria is true:

--- a/docs/gradle-plugins/release-needed-plugin.md
+++ b/docs/gradle-plugins/release-needed-plugin.md
@@ -35,9 +35,9 @@ Release is considered not needed when:
 Release is needed when all above is false and:
  * we are building on a branch that matches releaseBranchRegex (e.g. 'master'), see **releaseBranchRegex** in [Configuration section](#configuration)
  * and one of the following criteria is true:
- ⋅⋅* there are changes in the binaries when compared to previous version
- ⋅⋅* commit message contains '[ci skip-compare-publications]'
- ⋅⋅* 'skipComparePublications' property on task releaseNeeded is true
+   * there are changes in the binaries when compared to previous version
+   * commit message contains '[ci skip-compare-publications]'
+   * 'skipComparePublications' property on task releaseNeeded is true
 
 #### Usage
 

--- a/docs/gradle-plugins/release-needed-plugin.md
+++ b/docs/gradle-plugins/release-needed-plugin.md
@@ -28,12 +28,16 @@ Also set automatically by Shipkit CI plugins.
 
 #### Reasons why release may not be needed
 
-There is a couple of them:
-- Environment variable **SKIP_RELEASE** is set to any value (eg. 'true')
-- Commit message contains "[ci skip-release]"
-- The build is a pull request, see [Travis Documentation](https://docs.travis-ci.com/user/environment-variables/) for more information
-- Branch is a releasable one, see **releaseBranchRegex** in [Configuration section](#configuration)
-- One of the publications changed, see [section below](#comparing-publications)
+Release is considered not needed when:
+ * 'SKIP_RELEASE' environment variable is present
+ * commit message contains '[ci skip-release]'
+ * we are building a "pull request", see [Travis Documentation](https://docs.travis-ci.com/user/environment-variables/) for more information
+Release is needed when all above is false and:
+ * we are building on a branch that matches releaseBranchRegex (e.g. 'master'), see **releaseBranchRegex** in [Configuration section](#configuration)
+ * and one of the following criteria is true:
+ ⋅⋅* there are changes in the binaries when compared to previous version
+ ⋅⋅* commit message contains '[ci skip-compare-publications]'
+ ⋅⋅* 'skipComparePublications' property on task releaseNeeded is true
 
 #### Usage
 

--- a/subprojects/shipkit/src/main/groovy/org/shipkit/gradle/release/ReleaseNeededTask.java
+++ b/subprojects/shipkit/src/main/groovy/org/shipkit/gradle/release/ReleaseNeededTask.java
@@ -12,12 +12,8 @@ import java.util.List;
  * Decides if the release is needed.
  * It is necessary to avoid making releases in certain scenarios like when we are building pull requests.
  * <p>
- * The release is <strong>not needed</strong> when any of below is true:
- *  - the env variable 'SKIP_RELEASE' is present
- *  - the commit message, loaded from 'TRAVIS_COMMIT_MESSAGE' env variable contains '[ci skip-release]' keyword
- *  - the env variable 'TRAVIS_PULL_REQUEST' is not empty, not an empty String and and not 'false'
- *  - the current Git branch does not match release-eligibility regex ({@link #getReleasableBranchRegex()}.
- *  - binaries have not changes since the previous release
+ * See {@link org.shipkit.internal.gradle.release.ReleaseNeededPlugin} to get more details about how we are checking
+ * if a release is needed.
  */
 public class ReleaseNeededTask extends DefaultTask {
 


### PR DESCRIPTION
The javadoc in release-needed-plugin.md did not contain the latest changes.
Furthermore, I thought it might be a good idea to get rid of duplication in javadoc and create a link instead of duplicating the doc to multiple java files. 