### PR TITLE
Reducing number of version upgrade pull requests 

### DIFF
--- a/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/versionupgrade/FindOpenPullRequest.java
+++ b/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/versionupgrade/FindOpenPullRequest.java
@@ -1,0 +1,40 @@
+package org.shipkit.internal.gradle.versionupgrade;
+
+import org.gradle.api.logging.Logger;
+import org.gradle.api.logging.Logging;
+import org.json.simple.DeserializationException;
+import org.json.simple.JsonArray;
+import org.json.simple.JsonObject;
+import org.json.simple.Jsoner;
+import org.shipkit.internal.util.GitHubApi;
+
+import java.io.IOException;
+
+class FindOpenPullRequest {
+
+    private static final Logger LOG = Logging.getLogger(FindOpenPullRequest.class);
+
+    public String findOpenPullRequest(FindOpenPullRequestTask task) throws IOException, DeserializationException {
+        return findOpenPullRequest(task, new GitHubApi(task.getGitHubApiUrl(), task.getAuthToken()));
+    }
+
+    public String findOpenPullRequest(FindOpenPullRequestTask task, GitHubApi gitHubApi) throws IOException, DeserializationException {
+        String response = gitHubApi.get("/repos/" + task.getUpstreamRepositoryName() + "/pulls?state=open");
+
+        JsonArray pullRequests = Jsoner.deserialize(response, new JsonArray());
+
+        for (Object pullRequest : pullRequests) {
+            JsonObject head = (JsonObject) ((JsonObject) pullRequest).get("head");
+            String branchName = head.getString("ref");
+            if (branchName.matches(task.getVersionBranchRegex())) {
+                LOG.lifecycle("  Found an open pull request with version upgrade on branch {}", branchName);
+                return head.getString("ref");
+            }
+        }
+
+        LOG.lifecycle("  No open pull request with version upgrade found.");
+
+        return null;
+    }
+
+}

--- a/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/versionupgrade/FindOpenPullRequest.java
+++ b/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/versionupgrade/FindOpenPullRequest.java
@@ -15,24 +15,25 @@ class FindOpenPullRequest {
     private static final Logger LOG = Logging.getLogger(FindOpenPullRequest.class);
 
     public String findOpenPullRequest(FindOpenPullRequestTask task) throws IOException, DeserializationException {
-        return findOpenPullRequest(task, new GitHubApi(task.getGitHubApiUrl(), task.getAuthToken()));
+        return findOpenPullRequest(task.getUpstreamRepositoryName(), task.getVersionBranchRegex(),
+            new GitHubApi(task.getGitHubApiUrl(), task.getAuthToken()));
     }
 
-    public String findOpenPullRequest(FindOpenPullRequestTask task, GitHubApi gitHubApi) throws IOException, DeserializationException {
-        String response = gitHubApi.get("/repos/" + task.getUpstreamRepositoryName() + "/pulls?state=open");
+    public String findOpenPullRequest(String upstreamRepositoryName, String versionBranchRegex, GitHubApi gitHubApi) throws IOException, DeserializationException {
+        String response = gitHubApi.get("/repos/" + upstreamRepositoryName + "/pulls?state=open");
 
         JsonArray pullRequests = Jsoner.deserialize(response, new JsonArray());
 
         for (Object pullRequest : pullRequests) {
             JsonObject head = (JsonObject) ((JsonObject) pullRequest).get("head");
             String branchName = head.getString("ref");
-            if (branchName.matches(task.getVersionBranchRegex())) {
+            if (branchName.matches(versionBranchRegex)) {
                 LOG.lifecycle("  Found an open pull request with version upgrade on branch {}", branchName);
                 return head.getString("ref");
             }
         }
 
-        LOG.lifecycle("  No open pull request with version upgrade found.");
+        LOG.lifecycle("  New pull request will be opened because we didn't find an existing PR to reuse.");
 
         return null;
     }

--- a/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/versionupgrade/FindOpenPullRequestTask.java
+++ b/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/versionupgrade/FindOpenPullRequestTask.java
@@ -1,0 +1,108 @@
+package org.shipkit.internal.gradle.versionupgrade;
+
+import org.gradle.api.Action;
+import org.gradle.api.DefaultTask;
+import org.gradle.api.Task;
+import org.gradle.api.tasks.TaskAction;
+import org.json.simple.DeserializationException;
+import org.shipkit.gradle.configuration.ShipkitConfiguration;
+
+import java.io.IOException;
+
+/**
+ * Looks for an open pull request with a version upgrade by:
+ * - querying GitHubAPI of {@link #upstreamRepositoryName} for all open pull requests
+ * - checks if any HEAD branch of resulting pull requests matches {@link #versionBranchRegex}
+ */
+public class FindOpenPullRequestTask extends DefaultTask {
+
+    private String upstreamRepositoryName;
+    private String gitHubApiUrl;
+    private String authToken;
+    private String versionBranchRegex;
+
+    private String openPullRequestBranch;
+
+    @TaskAction
+    public void findOpenPullRequest() throws IOException, DeserializationException {
+        openPullRequestBranch = new FindOpenPullRequest().findOpenPullRequest(this);
+    }
+
+    /**
+     * See {@link ShipkitConfiguration.GitHub#getReadOnlyAuthToken()}
+     */
+    public String getAuthToken() {
+        return authToken;
+    }
+
+    /**
+     * See {@link ShipkitConfiguration.GitHub#getReadOnlyAuthToken()}
+     */
+    public void setAuthToken(String authToken) {
+        this.authToken = authToken;
+    }
+
+    /**
+     * See {@link ShipkitConfiguration.GitHub#getApiUrl()}
+     */
+    public String getGitHubApiUrl() {
+        return gitHubApiUrl;
+    }
+
+    /**
+     * See {@link ShipkitConfiguration.GitHub#getApiUrl()}
+     */
+    public void setGitHubApiUrl(String gitHubApiUrl) {
+        this.gitHubApiUrl = gitHubApiUrl;
+    }
+
+    /**
+     * See {@link ShipkitConfiguration.GitHub#getRepository()}
+     */
+    public String getUpstreamRepositoryName() {
+        return upstreamRepositoryName;
+    }
+
+    /**
+     * See {@link ShipkitConfiguration.GitHub#getRepository()}
+     */
+    public void setUpstreamRepositoryName(String upstreamRepositoryName) {
+        this.upstreamRepositoryName = upstreamRepositoryName;
+    }
+
+    /**
+     * Regex matching version upgrade branch for any version.
+     * It's a combination of:
+     * - {@link UpgradeDependencyPlugin#getVersionBranchName}
+     * - {@link ReplaceVersionTask#VERSION_REGEX}
+     */
+    public String getVersionBranchRegex() {
+        return versionBranchRegex;
+    }
+
+    /**
+     * See {@link #getVersionBranchRegex()}
+     */
+    public void setVersionBranchRegex(String versionBranchRegex) {
+        this.versionBranchRegex = versionBranchRegex;
+    }
+
+    /**
+     * Returns branch of the current open pull request with version upgrade or null if it doesn't exist.
+     */
+    public String getOpenPullRequestBranch() {
+        return openPullRequestBranch;
+    }
+
+    /**
+     * Call if you want {@param #openPullRequestBranchCallback} to be executed after this task is finished.
+     */
+    public void provideOpenPullRequestBranch(Task t, final Action<String> openPullRequestBranchCallback) {
+        t.dependsOn(this);
+        this.doLast(new Action<Task>() {
+            public void execute(Task task) {
+                openPullRequestBranchCallback.execute(openPullRequestBranch);
+            }
+        });
+    }
+}

--- a/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/versionupgrade/UpgradeDependencyPlugin.java
+++ b/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/versionupgrade/UpgradeDependencyPlugin.java
@@ -152,7 +152,7 @@ public class UpgradeDependencyPlugin implements Plugin<Project> {
                 task.setDescription("Creates a new version branch and checks it out.");
                 task.mustRunAfter(FIND_OPEN_PULL_REQUEST);
 
-                findOpenPullRequestTask.provideOpenPullRequestBranch(task, new Action<String>() {
+                findOpenPullRequestTask.provideBranchTo(task, new Action<String>() {
                     @Override
                     public void execute(String openPullRequestBranch) {
                         task.setRev(getCurrentVersionBranchName(upgradeDependencyExtension.getDependencyName(),
@@ -209,7 +209,7 @@ public class UpgradeDependencyPlugin implements Plugin<Project> {
                     }
                 });
 
-                findOpenPullRequestTask.provideOpenPullRequestBranch(task, new Action<String>() {
+                findOpenPullRequestTask.provideBranchTo(task, new Action<String>() {
                     @Override
                     public void execute(String openPullRequestBranch) {
                         task.getTargets().add(getCurrentVersionBranchName(upgradeDependencyExtension.getDependencyName(),
@@ -241,7 +241,7 @@ public class UpgradeDependencyPlugin implements Plugin<Project> {
                     }
                 });
 
-                findOpenPullRequestTask.provideOpenPullRequestBranch(task, new Action<String>() {
+                findOpenPullRequestTask.provideBranchTo(task, new Action<String>() {
                     @Override
                     public void execute(String openPullRequestBranch) {
                         task.setVersionBranch(getCurrentVersionBranchName(upgradeDependencyExtension.getDependencyName(),

--- a/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/versionupgrade/UpgradeDependencyPlugin.java
+++ b/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/versionupgrade/UpgradeDependencyPlugin.java
@@ -254,6 +254,7 @@ public class UpgradeDependencyPlugin implements Plugin<Project> {
             }
         });
 
+        //TODO: WW add validation for the case when 'dependency' property is not provided
         TaskMaker.task(project, PERFORM_VERSION_UPGRADE, new Action<Task>() {
             @Override
             public void execute(Task task) {

--- a/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/versionupgrade/UpgradeDependencyPlugin.java
+++ b/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/versionupgrade/UpgradeDependencyPlugin.java
@@ -1,9 +1,6 @@
 package org.shipkit.internal.gradle.versionupgrade;
 
-import org.gradle.api.Action;
-import org.gradle.api.Plugin;
-import org.gradle.api.Project;
-import org.gradle.api.Task;
+import org.gradle.api.*;
 import org.gradle.api.specs.Spec;
 import org.shipkit.gradle.configuration.ShipkitConfiguration;
 import org.shipkit.gradle.exec.ShipkitExecTask;
@@ -36,11 +33,12 @@ import static org.shipkit.internal.gradle.exec.ExecCommandFactory.execCommand;
  * <ul>
  *     <li>checkoutBaseBranch - checkouts base branch - the branch to which version upgrade should be applied through pull request</li>
  *     <li>pullUpstream - syncs the fork on which we perform version upgrade with the upstream repo</li>
- *     <li>checkoutVersionBranch - checkouts version branch - a new branch where version will be upgraded</li>
+ *     <li>findOpenPullRequest - finds an open pull request with version upgrade if it exists</li>
+ *     <li>checkoutVersionBranch - checkouts version branch where version will be upgraded. A new branch or the head branch for open pull request</li>
  *     <li>replaceVersion - replaces version in build file, using dependency pattern</li>
  *     <li>commitVersionUpgrade - commits replaced version</li>
  *     <li>pushVersionUpgrade - pushes the commit to the version branch</li>
- *     <li>createPullRequest - creates a pull request between base and version branches</li>
+ *     <li>createPullRequest - creates a pull request between base and version branches if there is no open pull request for this dependency already</li>
  *     <li>performVersionUpgrade - task aggregating all of the above</li>
  * </ul>
  *
@@ -66,6 +64,7 @@ public class UpgradeDependencyPlugin implements Plugin<Project> {
 
     public static final String CHECKOUT_BASE_BRANCH = "checkoutBaseBranch";
     public static final String PULL_UPSTREAM = "pullUpstream";
+    public static final String FIND_OPEN_PULL_REQUEST = "findOpenPullRequest";
     public static final String CHECKOUT_VERSION_BRANCH = "checkoutVersionBranch";
     public static final String REPLACE_VERSION = "replaceVersion";
     public static final String COMMIT_VERSION_UPGRADE = "commitVersionUpgrade";
@@ -132,12 +131,36 @@ public class UpgradeDependencyPlugin implements Plugin<Project> {
             }
         });
 
+        final FindOpenPullRequestTask findOpenPullRequestTask = TaskMaker.task(project,
+            FIND_OPEN_PULL_REQUEST, FindOpenPullRequestTask.class, new Action<FindOpenPullRequestTask>() {
+
+            @Override
+            public void execute(final FindOpenPullRequestTask task) {
+                task.setDescription("Find an open pull request with version upgrade, if such exists.");
+                task.mustRunAfter(PULL_UPSTREAM);
+
+                task.setGitHubApiUrl(conf.getGitHub().getApiUrl());
+                task.setAuthToken(conf.getLenient().getGitHub().getReadOnlyAuthToken());
+                task.setUpstreamRepositoryName(conf.getGitHub().getRepository());
+                task.setVersionBranchRegex(getVersionBranchName(
+                    upgradeDependencyExtension.getDependencyName(), ReplaceVersionTask.VERSION_REGEX));
+            }
+        });
+
         TaskMaker.task(project, CHECKOUT_VERSION_BRANCH, GitCheckOutTask.class, new Action<GitCheckOutTask>() {
             public void execute(final GitCheckOutTask task) {
                 task.setDescription("Creates a new version branch and checks it out.");
-                task.mustRunAfter(PULL_UPSTREAM);
-                task.setRev(getVersionBranchName(upgradeDependencyExtension));
-                task.setNewBranch(true);
+                task.mustRunAfter(FIND_OPEN_PULL_REQUEST);
+
+                findOpenPullRequestTask.provideOpenPullRequestBranch(task, new Action<String>() {
+                    @Override
+                    public void execute(String openPullRequestBranch) {
+                        task.setRev(getCurrentVersionBranchName(upgradeDependencyExtension.getDependencyName(),
+                            upgradeDependencyExtension.getNewVersion(), openPullRequestBranch));
+                        // don't create a new branch if there is already a branch with open pull request with version upgrade
+                        task.setNewBranch(openPullRequestBranch == null);
+                    }
+                });
             }
         });
 
@@ -177,13 +200,20 @@ public class UpgradeDependencyPlugin implements Plugin<Project> {
                 task.mustRunAfter(COMMIT_VERSION_UPGRADE);
 
                 task.setDryRun(conf.isDryRun());
-                task.getTargets().add(getVersionBranchName(upgradeDependencyExtension));
 
                 gitOriginPlugin.provideOriginRepo(task, new Action<String>() {
                     public void execute(String originRepo) {
                         GitUrlInfo info = new GitUrlInfo(conf);
                         task.setUrl(info.getGitUrl());
                         task.setSecretValue(info.getWriteToken());
+                    }
+                });
+
+                findOpenPullRequestTask.provideOpenPullRequestBranch(task, new Action<String>() {
+                    @Override
+                    public void execute(String openPullRequestBranch) {
+                        task.getTargets().add(getCurrentVersionBranchName(upgradeDependencyExtension.getDependencyName(),
+                            upgradeDependencyExtension.getNewVersion(), openPullRequestBranch));
                     }
                 });
 
@@ -199,7 +229,6 @@ public class UpgradeDependencyPlugin implements Plugin<Project> {
                 task.setGitHubApiUrl(conf.getGitHub().getApiUrl());
                 task.setDryRun(conf.isDryRun());
                 task.setAuthToken(conf.getLenient().getGitHub().getWriteAuthToken());
-                task.setVersionBranch(getVersionBranchName(upgradeDependencyExtension));
                 task.setVersionUpgrade(upgradeDependencyExtension);
                 task.setPullRequestTitle(getPullRequestTitle(task));
                 task.setPullRequestDescription(getPullRequestDescription(task));
@@ -212,6 +241,15 @@ public class UpgradeDependencyPlugin implements Plugin<Project> {
                     }
                 });
 
+                findOpenPullRequestTask.provideOpenPullRequestBranch(task, new Action<String>() {
+                    @Override
+                    public void execute(String openPullRequestBranch) {
+                        task.setVersionBranch(getCurrentVersionBranchName(upgradeDependencyExtension.getDependencyName(),
+                            upgradeDependencyExtension.getNewVersion(), openPullRequestBranch));
+                    }
+                });
+
+                task.onlyIf(wasOpenPullRequestNotFound(findOpenPullRequestTask));
                 task.onlyIf(wasBuildFileUpdatedSpec(replaceVersionTask));
             }
         });
@@ -221,6 +259,7 @@ public class UpgradeDependencyPlugin implements Plugin<Project> {
             public void execute(Task task) {
                 task.setDescription("Checkouts new version branch, updates Shipkit dependency in config file, commits and pushes.");
                 task.dependsOn(CHECKOUT_BASE_BRANCH);
+                task.dependsOn(FIND_OPEN_PULL_REQUEST);
                 task.dependsOn(PULL_UPSTREAM);
                 task.dependsOn(CHECKOUT_VERSION_BRANCH);
                 task.dependsOn(REPLACE_VERSION);
@@ -229,6 +268,13 @@ public class UpgradeDependencyPlugin implements Plugin<Project> {
                 task.dependsOn(CREATE_PULL_REQUEST);
             }
         });
+    }
+
+    static String getCurrentVersionBranchName(String dependencyName, String version, String openPullRequestBranch) {
+        if (openPullRequestBranch != null) {
+            return openPullRequestBranch;
+        }
+        return getVersionBranchName(dependencyName, version);
     }
 
     private String getPullRequestDescription(CreatePullRequestTask task) {
@@ -252,8 +298,17 @@ public class UpgradeDependencyPlugin implements Plugin<Project> {
         };
     }
 
-    private String getVersionBranchName(UpgradeDependencyExtension versionUpgrade) {
-        return "upgrade-" + versionUpgrade.getDependencyName() + "-to-" + versionUpgrade.getNewVersion();
+    private Spec<Task> wasOpenPullRequestNotFound(final FindOpenPullRequestTask findOpenPullRequestTask) {
+        return new Spec<Task>() {
+            @Override
+            public boolean isSatisfiedBy(Task task) {
+                return findOpenPullRequestTask.getOpenPullRequestBranch() == null;
+            }
+        };
+    }
+
+    private static String getVersionBranchName(String dependencyName, String newVersion) {
+        return "upgrade-" + dependencyName + "-to-" + newVersion;
     }
 
     public UpgradeDependencyExtension getUpgradeDependencyExtension() {

--- a/subprojects/shipkit/src/main/groovy/org/shipkit/internal/util/GitHubApi.java
+++ b/subprojects/shipkit/src/main/groovy/org/shipkit/internal/util/GitHubApi.java
@@ -50,6 +50,24 @@ public class GitHubApi {
         }
     }
 
+    public String get(String relativeUrl) throws IOException {
+        URL url = new URL(gitHubApiUrl + relativeUrl + "?access_token=" + authToken);
+
+        HttpsURLConnection conn = (HttpsURLConnection) url.openConnection();
+        conn.setRequestMethod("GET");
+        conn.setDoOutput(true);
+        conn.setRequestProperty("Content-Type", "application/json");
+
+        if (conn.getResponseCode() < HttpURLConnection.HTTP_BAD_REQUEST) {
+            return IOUtil.readFully(conn.getInputStream());
+        } else {
+            String errorMessage =
+                String.format("GET %s failed, response code = %s, response body:\n%s",
+                    maskUrl(url), conn.getResponseCode(), IOUtil.readFully(conn.getErrorStream()));
+            throw new IOException(errorMessage);
+        }
+    }
+
     private String maskUrl(URL url) {
         return url.toExternalForm().replace(authToken, "[SECRET]");
     }

--- a/subprojects/shipkit/src/test/groovy/org/shipkit/internal/gradle/versionupgrade/FindOpenPullRequestTest.groovy
+++ b/subprojects/shipkit/src/test/groovy/org/shipkit/internal/gradle/versionupgrade/FindOpenPullRequestTest.groovy
@@ -10,41 +10,27 @@ class FindOpenPullRequestTest extends Specification {
     def "should return null if response is empty"() {
         given:
         def gitHubApi = Mock(GitHubApi)
-        def findOpenPullRequestTask = Mock(FindOpenPullRequestTask)
-
-        findOpenPullRequestTask.getUpstreamRepositoryName() >> "repo"
-        def url = "/repos/repo/pulls?state=open"
-        gitHubApi.get(url) >> "[ ]"
+        gitHubApi.get("/repos/repo/pulls?state=open") >> "[ ]"
 
         expect:
-        null == findOpenPullRequest.findOpenPullRequest(findOpenPullRequestTask, gitHubApi)
+        null == findOpenPullRequest.findOpenPullRequest("repo", null, gitHubApi)
     }
 
     def "should return null if head->ref does not match versionBranchRegex"() {
         given:
         def gitHubApi = Mock(GitHubApi)
-        def findOpenPullRequestTask = Mock(FindOpenPullRequestTask)
-
-        findOpenPullRequestTask.getUpstreamRepositoryName() >> "repo"
-        findOpenPullRequestTask.getVersionBranchRegex() >> "shipkit-[0-9]*"
-        def url = "/repos/repo/pulls?state=open"
-        gitHubApi.get(url) >> "[{\"head\" : {\"ref\" : \"shipkit-1.2\"}} ]"
+        gitHubApi.get("/repos/repo/pulls?state=open") >> "[{\"head\" : {\"ref\" : \"shipkit-1.2\"}} ]"
 
         expect:
-        null == findOpenPullRequest.findOpenPullRequest(findOpenPullRequestTask, gitHubApi)
+        null == findOpenPullRequest.findOpenPullRequest("repo", "shipkit-[0-9]*", gitHubApi)
     }
 
     def "should return head->ref if it matches versionBranchRegex"() {
         given:
         def gitHubApi = Mock(GitHubApi)
-        def findOpenPullRequestTask = Mock(FindOpenPullRequestTask)
-
-        findOpenPullRequestTask.getUpstreamRepositoryName() >> "repo"
-        findOpenPullRequestTask.getVersionBranchRegex() >> "shipkit-[0-9]*"
-        def url = "/repos/repo/pulls?state=open"
-        gitHubApi.get(url) >> "[{\"head\" : {\"ref\" : \"shipkit-1\"}} ]"
+        gitHubApi.get("/repos/repo/pulls?state=open") >> "[{\"head\" : {\"ref\" : \"shipkit-1\"}} ]"
 
         expect:
-        "shipkit-1" == findOpenPullRequest.findOpenPullRequest(findOpenPullRequestTask, gitHubApi)
+        "shipkit-1" == findOpenPullRequest.findOpenPullRequest("repo", "shipkit-[0-9]*", gitHubApi)
     }
 }

--- a/subprojects/shipkit/src/test/groovy/org/shipkit/internal/gradle/versionupgrade/UpgradeDependencyPluginIntegTest.groovy
+++ b/subprojects/shipkit/src/test/groovy/org/shipkit/internal/gradle/versionupgrade/UpgradeDependencyPluginIntegTest.groovy
@@ -29,6 +29,7 @@ class UpgradeDependencyPluginIntegTest extends GradleSpecification {
         skippedTaskPathsGradleBugWorkaround(result.output).join("\n") == """:checkoutBaseBranch
 :identifyGitOrigin
 :pullUpstream
+:findOpenPullRequest
 :checkoutVersionBranch
 :replaceVersion
 :setGitUserEmail

--- a/subprojects/shipkit/src/test/groovy/org/shipkit/internal/util/GitHubApiTest.groovy
+++ b/subprojects/shipkit/src/test/groovy/org/shipkit/internal/util/GitHubApiTest.groovy
@@ -4,7 +4,7 @@ import spock.lang.Specification
 
 class GitHubApiTest extends Specification {
 
-    def "should mask access token"() {
+    def "should mask access token for post request"() {
         given:
         def api = new GitHubApi("https://api.github.com", "accessToken")
 
@@ -15,5 +15,18 @@ class GitHubApiTest extends Specification {
         def ex = thrown(Exception)
         ex.message.startsWith(
             "POST https://api.github.com/repos/shipkit-example/pulls?access_token=[SECRET] failed")
+    }
+
+    def "should mask access token for get request"() {
+        given:
+        def api = new GitHubApi("https://api.github.com", "accessToken")
+
+        when:
+        api.get("/repos/shipkit-example/pulls")
+
+        then:
+        def ex = thrown(Exception)
+        ex.message.startsWith(
+            "GET https://api.github.com/repos/shipkit-example/pulls?access_token=[SECRET] failed")
     }
 }


### PR DESCRIPTION
… by updating the open pull request instead of creating a new one #460 

I tested it by running "performVersionUpgrade" on shipkit-example:
- first with one open pull request -> pull request updated with new commit changing the version
- no open pull request -> new pull request created