### PR TITLE
fix 'published to' links in shipkit release notes

### DIFF
--- a/gradle/shipkit.gradle
+++ b/gradle/shipkit.gradle
@@ -5,7 +5,7 @@ shipkit {
     team.developers = ['mockitoguy:Szczepan Faber', 'mstachniuk:Marcin Stachniuk',
                        'wwilk:Wojtek Wilk', 'epeee:Erhard Pointl', 'NagRock:Maciej Kuster']
 
-    releaseNotes.publicationRepository = "https://plugins.gradle.org/plugin/org.shipkit.java"
+    releaseNotes.publicationRepository = "https://plugins.gradle.org/plugin/org.shipkit.java/"
 }
 
 apply plugin: 'org.shipkit.upgrade-dependency'


### PR DESCRIPTION
addresses #584 for shipkit project by applying the config described in javadoc:

https://github.com/mockito/shipkit/blob/ac02a3ad51e3d9defcfd480090ec24c3b61161c4/subprojects/shipkit/src/main/groovy/org/shipkit/gradle/configuration/ShipkitConfiguration.java#L256-L268