### PR TITLE
fix broken 'published to' links if BintrayReleasePlugin is used

### DIFF
--- a/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/util/BintrayUtil.java
+++ b/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/util/BintrayUtil.java
@@ -21,6 +21,6 @@ public class BintrayUtil {
         if (org == null) {
             org = bintray.getUser();
         }
-        return MessageFormat.format("https://bintray.com/{0}/{1}/{2}", org, repo, pkg);
+        return MessageFormat.format("https://bintray.com/{0}/{1}/{2}/", org, repo, pkg);
     }
 }

--- a/subprojects/shipkit/src/test/groovy/org/shipkit/internal/gradle/bintray/BintrayReleasePluginTest.groovy
+++ b/subprojects/shipkit/src/test/groovy/org/shipkit/internal/gradle/bintray/BintrayReleasePluginTest.groovy
@@ -36,6 +36,6 @@ class BintrayReleasePluginTest extends PluginSpecification {
 
         then:
         UpdateReleaseNotesTask updateNotes = project.tasks.getByName(ReleaseNotesPlugin.UPDATE_NOTES_TASK)
-        updateNotes.publicationRepository == "https://bintray.com/some-org/some-repo/some-pkg"
+        updateNotes.publicationRepository == "https://bintray.com/some-org/some-repo/some-pkg/"
     }
 }

--- a/subprojects/shipkit/src/test/groovy/org/shipkit/internal/gradle/util/BintrayUtilTest.groovy
+++ b/subprojects/shipkit/src/test/groovy/org/shipkit/internal/gradle/util/BintrayUtilTest.groovy
@@ -17,7 +17,7 @@ class BintrayUtilTest extends Specification {
         b.pkg.userOrg = "mockito"
 
         expect:
-        getRepoLink(b) == "https://bintray.com/mockito/maven/mockito-core"
+        getRepoLink(b) == "https://bintray.com/mockito/maven/mockito-core/"
     }
 
     def "link without org"() {
@@ -27,7 +27,7 @@ class BintrayUtilTest extends Specification {
         b.user = "szczepiq"
 
         expect:
-        getRepoLink(b) == "https://bintray.com/szczepiq/maven/mockito-core"
+        getRepoLink(b) == "https://bintray.com/szczepiq/maven/mockito-core/"
     }
 
     def "link without unconfigured extension"() {


### PR DESCRIPTION
…  and shipkit.releaseNotes.publicationRepository is not set (2nd part of #584) .