### PR TITLE
Add publication repository to release summary

### DIFF
--- a/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/release/ReleasePlugin.java
+++ b/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/release/ReleasePlugin.java
@@ -71,7 +71,7 @@ public class ReleasePlugin implements Plugin<Project> {
                     public String get() {
                         return "\n" +
                             "Release shipped!\n" +
-                            "    - Publication repository: " + updateReleaseNotesTask.getPublicationRepository() +
+                            "    - Publication repository: " + updateReleaseNotesTask.getPublicationRepository() + "\n" +
                             "    - Release notes:          " + new UpdateReleaseNotes().getReleaseNotesUrl(updateReleaseNotesTask, identifyGitBranchTask.getBranch());
                     }
                 });

--- a/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/release/ReleasePlugin.java
+++ b/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/release/ReleasePlugin.java
@@ -71,7 +71,8 @@ public class ReleasePlugin implements Plugin<Project> {
                     public String get() {
                         return "\n" +
                             "Release shipped!\n" +
-                            "    - Release notes:      " + new UpdateReleaseNotes().getReleaseNotesUrl(updateReleaseNotesTask, identifyGitBranchTask.getBranch());
+                            "    - Publication repository: " + updateReleaseNotesTask.getPublicationRepository() +
+                            "    - Release notes:          " + new UpdateReleaseNotes().getReleaseNotesUrl(updateReleaseNotesTask, identifyGitBranchTask.getBranch());
                     }
                 });
             }


### PR DESCRIPTION
another part of #450: let's also add the publication repository to the release summary.
E.g. for mockito it will look like this: 

```
Release shipped!
    - Publication repository: https://bintray.com/mockito/maven/mockito-development/
    - Release notes:          https://github.com/mockito/mockito/blob/release/2.x/doc/release-notes/official.md
```