### PR TITLE
Ignore test of default behaviour if env variable exists

### DIFF
--- a/subprojects/shipkit/src/main/groovy/org/shipkit/gradle/configuration/ShipkitConfiguration.java
+++ b/subprojects/shipkit/src/main/groovy/org/shipkit/gradle/configuration/ShipkitConfiguration.java
@@ -108,6 +108,8 @@ public class ShipkitConfiguration {
 
     public class GitHub {
 
+        public static final String GH_WRITE_TOKEN = "GH_WRITE_TOKEN";
+
         /**
          * GitHub URL address, for example: https://github.com.
          * Useful when you are using on-premises GitHub Enterprise
@@ -192,8 +194,8 @@ public class ShipkitConfiguration {
          * if this value is not specified.
          */
         public String getWriteAuthToken() {
-            return (String) store.getValue("gitHub.writeAuthToken", "GH_WRITE_TOKEN", "Please export 'GH_WRITE_TOKEN' variable first!\n" +
-                "It is highly recommended to keep write token secure and store env variable 'GH_WRITE_TOKEN' with your CI configuration." +
+            return (String) store.getValue("gitHub.writeAuthToken", GH_WRITE_TOKEN, "Please export '" + GH_WRITE_TOKEN + "' variable first!\n" +
+                "It is highly recommended to keep write token secure and store env variable '" + GH_WRITE_TOKEN + "' with your CI configuration." +
                 "Alternatively, you can configure GitHub write auth token explicitly (don't check this in to Git!):\n" +
                 "  shipkit.gitHub.writeAuthToken = 'secret'");
         }

--- a/subprojects/shipkit/src/test/groovy/org/shipkit/internal/gradle/git/GitHubUrlBuilderTest.groovy
+++ b/subprojects/shipkit/src/test/groovy/org/shipkit/internal/gradle/git/GitHubUrlBuilderTest.groovy
@@ -11,22 +11,22 @@ class GitHubUrlBuilderTest extends Specification {
     def conf = new ShipkitConfiguration()
 
     @Unroll
-    def "should return authorized GH url given gHurl '#ghUrl' repo '#repo' user '#user' token '#token'"() {
+    def "should return authorized GH url given gHurl '#ghUrl'"() {
         when :
         if (ghUrl) {
             conf.gitHub.url = ghUrl
         }
 
-            conf.gitHub.writeAuthUser = user
-            conf.gitHub.writeAuthToken = token
+        conf.gitHub.writeAuthUser = "user"
+        conf.gitHub.writeAuthToken = "token"
 
         then:
         GitHubUrlBuilder.getGitHubUrl("org/repo", conf) == expected
 
         where:
-        repo        | token   | user    | ghUrl                     | expected
-        "org/repo"  | "token" | "user"  | null                      | "https://user:token@github.com/org/repo.git"
-        "org/repo"  | "token" | "user"  | "https://gh.ent.com:8080" | "https://user:token@gh.ent.com:8080/org/repo.git"
+        ghUrl                     | expected
+        null                      | "https://user:token@github.com/org/repo.git"
+        "https://gh.ent.com:8080" | "https://user:token@gh.ent.com:8080/org/repo.git"
     }
 
     /**
@@ -35,7 +35,7 @@ class GitHubUrlBuilderTest extends Specification {
      */
     @Unroll
     @IgnoreIf({System.getenv(GitHub.GH_WRITE_TOKEN)})
-    def "should return unauthorized GH url given gHurl '#ghUrl' repo '#repo' user '#user' token '#token'"() {
+    def "should return unauthorized GH url given gHurl '#ghUrl'"() {
         when :
         if (ghUrl) {
             conf.gitHub.url = ghUrl
@@ -45,8 +45,8 @@ class GitHubUrlBuilderTest extends Specification {
         GitHubUrlBuilder.getGitHubUrl("org/repo", conf) == expected
 
         where:
-        repo        | token   | user    | ghUrl                     | expected
-        "org/repo"  | null    | null    | null                      | "https://github.com/org/repo.git"
-        "org/repo"  | null    | null    | "https://gh.ent.com:8080" | "https://gh.ent.com:8080/org/repo.git"
+        ghUrl                     | expected
+        null                      | "https://github.com/org/repo.git"
+        "https://gh.ent.com:8080" | "https://gh.ent.com:8080/org/repo.git"
     }
 }

--- a/subprojects/shipkit/src/test/groovy/org/shipkit/internal/gradle/git/GitHubUrlBuilderTest.groovy
+++ b/subprojects/shipkit/src/test/groovy/org/shipkit/internal/gradle/git/GitHubUrlBuilderTest.groovy
@@ -1,24 +1,44 @@
 package org.shipkit.internal.gradle.git
 
 import org.shipkit.gradle.configuration.ShipkitConfiguration
+import spock.lang.IgnoreIf
 import spock.lang.Specification
 import spock.lang.Unroll
+import org.shipkit.gradle.configuration.ShipkitConfiguration.GitHub
 
 class GitHubUrlBuilderTest extends Specification {
 
     def conf = new ShipkitConfiguration()
 
     @Unroll
-    def "should return GH url given gHurl '#ghUrl' repo '#repo' user '#user' token '#token'"() {
+    def "should return authorized GH url given gHurl '#ghUrl' repo '#repo' user '#user' token '#token'"() {
         when :
         if (ghUrl) {
-            conf.gitHub.url = ghUrl;
+            conf.gitHub.url = ghUrl
         }
-        if (user) {
+
             conf.gitHub.writeAuthUser = user
-        }
-        if (token) {
             conf.gitHub.writeAuthToken = token
+
+        then:
+        GitHubUrlBuilder.getGitHubUrl("org/repo", conf) == expected
+
+        where:
+        repo        | token   | user    | ghUrl                     | expected
+        "org/repo"  | "token" | "user"  | null                      | "https://user:token@github.com/org/repo.git"
+        "org/repo"  | "token" | "user"  | "https://gh.ent.com:8080" | "https://user:token@gh.ent.com:8080/org/repo.git"
+    }
+
+    /**
+    If GH_WRITE_TOKEN exists then the value of that is used over null inside the ShipkitConfiguration class
+    see {@link org.shipkit.internal.gradle.configuration.ShipkitConfigurationStore#getValue}
+     */
+    @Unroll
+    @IgnoreIf({System.getenv(GitHub.GH_WRITE_TOKEN)})
+    def "should return unauthorized GH url given gHurl '#ghUrl' repo '#repo' user '#user' token '#token'"() {
+        when :
+        if (ghUrl) {
+            conf.gitHub.url = ghUrl
         }
 
         then:
@@ -27,8 +47,6 @@ class GitHubUrlBuilderTest extends Specification {
         where:
         repo        | token   | user    | ghUrl                     | expected
         "org/repo"  | null    | null    | null                      | "https://github.com/org/repo.git"
-        "org/repo"  | "token" | "user"  | null                      | "https://user:token@github.com/org/repo.git"
         "org/repo"  | null    | null    | "https://gh.ent.com:8080" | "https://gh.ent.com:8080/org/repo.git"
-        "org/repo"  | "token" | "user"  | "https://gh.ent.com:8080" | "https://user:token@gh.ent.com:8080/org/repo.git"
     }
 }


### PR DESCRIPTION
How about this solution to the problem with #594 @wwilk ?

Its not perfect to ignore test but as far as my abilities go right now its to much work to refactor so I can mock the `EnvVariables` class, which is the best way to go I believe. 

About the existence of `GH_WRITE_TOKEN` is that present on all branches or just master or some such? 
