### PR TITLE
Add possibility to mock EnvVariables

### DIFF
--- a/subprojects/shipkit/src/main/groovy/org/shipkit/gradle/configuration/ShipkitConfiguration.java
+++ b/subprojects/shipkit/src/main/groovy/org/shipkit/gradle/configuration/ShipkitConfiguration.java
@@ -35,7 +35,7 @@ public class ShipkitConfiguration {
         this(new EnvVariables());
     }
 
-    public ShipkitConfiguration(EnvVariables envVariables) {
+    ShipkitConfiguration(EnvVariables envVariables) {
         this(new ShipkitConfigurationStore(envVariables));
 
         //Configure default values

--- a/subprojects/shipkit/src/main/groovy/org/shipkit/gradle/configuration/ShipkitConfiguration.java
+++ b/subprojects/shipkit/src/main/groovy/org/shipkit/gradle/configuration/ShipkitConfiguration.java
@@ -1,6 +1,7 @@
 package org.shipkit.gradle.configuration;
 
 import org.shipkit.internal.gradle.configuration.ShipkitConfigurationStore;
+import org.shipkit.internal.util.EnvVariables;
 
 import java.util.Collection;
 import java.util.Collections;
@@ -31,7 +32,11 @@ public class ShipkitConfiguration {
     private String previousReleaseVersion;
 
     public ShipkitConfiguration() {
-        this(new ShipkitConfigurationStore());
+        this(new EnvVariables());
+    }
+
+    public ShipkitConfiguration(EnvVariables envVariables) {
+        this(new ShipkitConfigurationStore(envVariables));
 
         //Configure default values
         git.setTagPrefix("v"); //so that tags are "v1.0", "v2.3.4"

--- a/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/configuration/ShipkitConfigurationStore.java
+++ b/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/configuration/ShipkitConfigurationStore.java
@@ -13,8 +13,8 @@ public class ShipkitConfigurationStore {
     private final EnvVariables envVariables;
     private final Map<String, Object> configuration;
 
-    public ShipkitConfigurationStore() {
-        this(new HashMap<String, Object>(), new EnvVariables(), false);
+    public ShipkitConfigurationStore(EnvVariables envVariables) {
+        this(new HashMap<String, Object>(), envVariables, false);
     }
 
     ShipkitConfigurationStore(Map<String, Object> configuration, EnvVariables envVariables, boolean lenient) {
@@ -76,6 +76,6 @@ public class ShipkitConfigurationStore {
     }
 
     public ShipkitConfigurationStore getLenient() {
-        return new ShipkitConfigurationStore(this.configuration, new EnvVariables(), true);
+        return new ShipkitConfigurationStore(this.configuration, envVariables, true);
     }
 }

--- a/subprojects/shipkit/src/test/groovy/org/shipkit/gradle/configuration/ShipkitConfigurationFactory.groovy
+++ b/subprojects/shipkit/src/test/groovy/org/shipkit/gradle/configuration/ShipkitConfigurationFactory.groovy
@@ -1,0 +1,10 @@
+package org.shipkit.gradle.configuration
+
+import org.shipkit.internal.util.EnvVariables
+
+class ShipkitConfigurationFactory {
+
+    static ShipkitConfiguration create(EnvVariables envVariables) {
+        return new ShipkitConfiguration(envVariables);
+    }
+}

--- a/subprojects/shipkit/src/test/groovy/org/shipkit/gradle/configuration/ShipkitConfigurationFactory.groovy
+++ b/subprojects/shipkit/src/test/groovy/org/shipkit/gradle/configuration/ShipkitConfigurationFactory.groovy
@@ -5,6 +5,6 @@ import org.shipkit.internal.util.EnvVariables
 class ShipkitConfigurationFactory {
 
     static ShipkitConfiguration create(EnvVariables envVariables) {
-        return new ShipkitConfiguration(envVariables);
+        return new ShipkitConfiguration(envVariables)
     }
 }

--- a/subprojects/shipkit/src/test/groovy/org/shipkit/internal/gradle/git/GitHubUrlBuilderTest.groovy
+++ b/subprojects/shipkit/src/test/groovy/org/shipkit/internal/gradle/git/GitHubUrlBuilderTest.groovy
@@ -1,6 +1,6 @@
 package org.shipkit.internal.gradle.git
 
-import org.shipkit.gradle.configuration.ShipkitConfiguration
+import org.shipkit.gradle.configuration.ShipkitConfigurationFactory
 import org.shipkit.internal.util.EnvVariables
 import spock.lang.Specification
 import spock.lang.Unroll
@@ -10,7 +10,7 @@ class GitHubUrlBuilderTest extends Specification {
     def envVariablesMock = Mock(EnvVariables) {
         getNonEmptyEnv("GH_WRITE_TOKEN") >> null
     }
-    def conf = new ShipkitConfiguration(envVariablesMock)
+    def conf = ShipkitConfigurationFactory.create(envVariablesMock)
 
     @Unroll
     def "should return GH url given gHurl '#ghUrl' repo '#repo' user '#user' token '#token'"() {

--- a/subprojects/shipkit/src/test/groovy/org/shipkit/internal/gradle/git/GitHubUrlBuilderTest.groovy
+++ b/subprojects/shipkit/src/test/groovy/org/shipkit/internal/gradle/git/GitHubUrlBuilderTest.groovy
@@ -1,16 +1,20 @@
 package org.shipkit.internal.gradle.git
 
 import org.shipkit.gradle.configuration.ShipkitConfiguration
+import org.shipkit.internal.util.EnvVariables
 import spock.lang.Specification
 import spock.lang.Unroll
 
 class GitHubUrlBuilderTest extends Specification {
 
-    def conf = new ShipkitConfiguration()
+    def envVariablesMock = Mock(EnvVariables) {
+        getNonEmptyEnv("GH_WRITE_TOKEN") >> null
+    }
+    def conf = new ShipkitConfiguration(envVariablesMock)
 
     @Unroll
     def "should return GH url given gHurl '#ghUrl' repo '#repo' user '#user' token '#token'"() {
-        when :
+        when:
         if (ghUrl) {
             conf.gitHub.url = ghUrl;
         }


### PR DESCRIPTION
currently, tests are failing on travis due to "GH_WRITE_TOKEN" env variable.
let's mock `getNonEmptyEnv("GH_WRITE_TOKEN")` in order to make the test more robust.