### PR TITLE
use codenarc v1.0

### DIFF
--- a/subprojects/shipkit/shipkit.gradle
+++ b/subprojects/shipkit/shipkit.gradle
@@ -49,6 +49,10 @@ test {
     }
 }
 
+codenarc {
+    toolVersion = '1.0'
+}
+
 pluginBundle {
     website = 'http://shipkit.org/'
     vcsUrl = 'https://github.com/mockito/shipkit'


### PR DESCRIPTION
while having a look at a travis build log I realized that we do get quite some messages like

> Error from [org.codenarc.rule.imports.UnusedImportRule] processing source file [/home/travis/build/mockito/shipkit/subprojects/shipkit/src/test/groovy/org/shipkit/gradle/UpdateReleaseNotesTaskTest.groovy]
> Error processing filePath: 'org/shipkit/gradle/UpdateReleaseNotesTaskTest.groovy'
> Error from [org.codenarc.rule.imports.UnusedImportRule] processing source file [/home/travis/build/mockito/shipkit/subprojects/shipkit/src/test/groovy/org/shipkit/gradle/configuration/ShipkitConfigurationFactory.groovy]

Using codenarc v1.0 seems to solve the problem.