### PR TITLE
Improved authentication for GH API requests

### DIFF
--- a/subprojects/shipkit/src/main/groovy/org/shipkit/internal/util/GitHubApi.java
+++ b/subprojects/shipkit/src/main/groovy/org/shipkit/internal/util/GitHubApi.java
@@ -1,5 +1,7 @@
 package org.shipkit.internal.util;
 
+import org.gradle.api.logging.Logger;
+import org.gradle.api.logging.Logging;
 import org.shipkit.internal.notes.util.IOUtil;
 
 import javax.net.ssl.HttpsURLConnection;
@@ -13,6 +15,8 @@ import java.net.URL;
  */
 public class GitHubApi {
 
+    private static final Logger LOG = Logging.getLogger(GitHubApi.class);
+
     private final String gitHubApiUrl;
     private final String authToken;
 
@@ -22,12 +26,13 @@ public class GitHubApi {
     }
 
     public String post(String relativeUrl, String body) throws IOException {
-        URL url = new URL(gitHubApiUrl + relativeUrl + "?access_token=" + authToken);
+        URL url = new URL(gitHubApiUrl + relativeUrl);
 
         HttpsURLConnection conn = (HttpsURLConnection) url.openConnection();
         conn.setRequestMethod("POST");
         conn.setDoOutput(true);
         conn.setRequestProperty("Content-Type", "application/json");
+        conn.setRequestProperty("Authorization", "token " + authToken);
 
         DataOutputStream wr = null;
         try {
@@ -40,35 +45,31 @@ public class GitHubApi {
             }
         }
 
-        if (conn.getResponseCode() < HttpURLConnection.HTTP_BAD_REQUEST) {
-            return IOUtil.readFully(conn.getInputStream());
-        } else {
-            String errorMessage =
-                String.format("POST %s failed, response code = %s, response body:\n%s",
-                maskUrl(url), conn.getResponseCode(), IOUtil.readFully(conn.getErrorStream()));
-            throw new IOException(errorMessage);
-        }
+        return call("POST", conn);
     }
 
     public String get(String relativeUrl) throws IOException {
-        URL url = new URL(gitHubApiUrl + relativeUrl + "?access_token=" + authToken);
+        URL url = new URL(gitHubApiUrl + relativeUrl);
 
         HttpsURLConnection conn = (HttpsURLConnection) url.openConnection();
         conn.setRequestMethod("GET");
         conn.setDoOutput(true);
         conn.setRequestProperty("Content-Type", "application/json");
+        conn.setRequestProperty("Authorization", "token " + authToken);
+
+        return call("GET", conn);
+    }
+
+    private String call(String method, HttpsURLConnection conn) throws IOException {
+        LOG.info("  Calling {} {}. Turn on debug logging to see response headers.", method, conn.getURL());
 
         if (conn.getResponseCode() < HttpURLConnection.HTTP_BAD_REQUEST) {
             return IOUtil.readFully(conn.getInputStream());
         } else {
             String errorMessage =
-                String.format("GET %s failed, response code = %s, response body:\n%s",
-                    maskUrl(url), conn.getResponseCode(), IOUtil.readFully(conn.getErrorStream()));
+                String.format("%s %s failed, response code = %s, response body:\n%s",
+                    method, conn.getURL(), conn.getResponseCode(), IOUtil.readFully(conn.getErrorStream()));
             throw new IOException(errorMessage);
         }
-    }
-
-    private String maskUrl(URL url) {
-        return url.toExternalForm().replace(authToken, "[SECRET]");
     }
 }

--- a/subprojects/shipkit/src/test/groovy/org/shipkit/internal/util/GitHubApiTest.groovy
+++ b/subprojects/shipkit/src/test/groovy/org/shipkit/internal/util/GitHubApiTest.groovy
@@ -4,7 +4,7 @@ import spock.lang.Specification
 
 class GitHubApiTest extends Specification {
 
-    def "should mask access token for post request"() {
+    def "should not show accessToken in error message for post request"() {
         given:
         def api = new GitHubApi("https://api.github.com", "accessToken")
 
@@ -16,7 +16,7 @@ class GitHubApiTest extends Specification {
         !ex.message.contains("accessToken");
     }
 
-    def "should mask access token for get request"() {
+    def "should not show accessToken in error message for get request"() {
         given:
         def api = new GitHubApi("https://api.github.com", "accessToken")
 

--- a/subprojects/shipkit/src/test/groovy/org/shipkit/internal/util/GitHubApiTest.groovy
+++ b/subprojects/shipkit/src/test/groovy/org/shipkit/internal/util/GitHubApiTest.groovy
@@ -13,8 +13,7 @@ class GitHubApiTest extends Specification {
 
         then:
         def ex = thrown(Exception)
-        ex.message.startsWith(
-            "POST https://api.github.com/repos/shipkit-example/pulls?access_token=[SECRET] failed")
+        !ex.message.contains("accessToken");
     }
 
     def "should mask access token for get request"() {
@@ -26,7 +25,6 @@ class GitHubApiTest extends Specification {
 
         then:
         def ex = thrown(Exception)
-        ex.message.startsWith(
-            "GET https://api.github.com/repos/shipkit-example/pulls?access_token=[SECRET] failed")
+        !ex.message.contains("accessToken");
     }
 }


### PR DESCRIPTION
CI Build fails due to:

Execution failed for task ':findOpenPullRequest'.
[upgradeDownstream] [performVersionUpgrade] > java.io.IOException: GET https://api.github.com/repos/mockito/shipkit/pulls?state=open?access_token=[SECRET] failed, response code = 403, response body:
[upgradeDownstream] [performVersionUpgrade]   {"message":"API rate limit exceeded for 52.54.31.11. (But here's the good news: Authenticated requests get a higher rate limit. Check out the documentation for more details.)","documentation_url":"https://developer.github.com/v3/#rate-limiting"}

As you can notice we use 
pulls?state=open?access_token=[SECRET],
 so we concatenate strings in a wrong way, and because of that authentication is not picked up by GitHub. I used Authorization header instead.

Tested it by running ./gradlew findOpenPullRequest and checking if in response headers I get correct limits, see https://developer.github.com/v3/#rate-limiting for details. 