### PR TITLE
gradle build scans and stop building with '-i'

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ install:
  - true
 
 script:
-  - ./gradlew build testDownstream -PcheckJava6Compatibility --daemon -s -i && ./gradlew ciPerformRelease -s
+  - ./gradlew build testDownstream -PcheckJava6Compatibility --daemon -s && ./gradlew ciPerformRelease -s
 
 # Remove often changing files to prevent cache re-upload on no changes in dependencies
 before_cache:

--- a/build.gradle
+++ b/build.gradle
@@ -14,9 +14,7 @@ buildscript {
 apply plugin: 'com.gradle.build-scan'
 
 buildScan {
-    if (System.getenv('CI')) {
-        publishAlways()
-    }
+    publishAlways()
     licenseAgreementUrl = 'https://gradle.com/terms-of-service'
     licenseAgree = 'yes'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -6,8 +6,19 @@ buildscript {
     }
     dependencies {
         classpath 'org.shipkit:shipkit:1.0.7'
+        classpath 'com.gradle:build-scan-plugin:1.11'
         classpath 'ru.vyarus:gradle-animalsniffer-plugin:1.3.0'
     }
+}
+
+apply plugin: 'com.gradle.build-scan'
+
+buildScan {
+    if (System.getenv('CI')) {
+        publishAlways()
+    }
+    licenseAgreementUrl = 'https://gradle.com/terms-of-service'
+    licenseAgree = 'yes'
 }
 
 apply from: "$rootDir/gradle/java6-compatibility.gradle"


### PR DESCRIPTION
fixes #622 

I thought it might be a good idea to use `publishAlways()` only if we are in CI. One can trigger a build scan from non CI environments manually if needed.
Furthermore, we can switch back to `publishOnFailure()` later on, but for now let's have a look at some build scans.