### PR TITLE
Fixed NPE issue when finding existing pull requests

### DIFF
--- a/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/git/domain/PullRequest.java
+++ b/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/git/domain/PullRequest.java
@@ -32,8 +32,9 @@ public class PullRequest {
     /**
      * See {@link #getRef()}
      */
-    public void setRef(String ref) {
+    public PullRequest setRef(String ref) {
         this.ref = ref;
+        return this;
     }
 
     /**

--- a/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/util/Optional.java
+++ b/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/util/Optional.java
@@ -1,0 +1,30 @@
+package org.shipkit.internal.gradle.util;
+
+import java.util.NoSuchElementException;
+
+/**
+ * We need to migrate to Java8 and remove this.
+ */
+public class Optional<T> {
+
+    private final T value;
+
+    public Optional(T value) {
+        this.value = value;
+    }
+
+    public T get() {
+        if (value == null) {
+            throw new NoSuchElementException("No value present");
+        }
+        return value;
+    }
+
+    public static <T> Optional<T> of(T object) {
+        return new Optional<T>(object);
+    }
+
+    public boolean isPresent() {
+        return value != null;
+    }
+}

--- a/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/util/Optional.java
+++ b/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/util/Optional.java
@@ -1,5 +1,7 @@
 package org.shipkit.internal.gradle.util;
 
+import org.shipkit.internal.util.ArgumentValidation;
+
 import java.util.NoSuchElementException;
 
 /**
@@ -9,7 +11,7 @@ public class Optional<T> {
 
     private final T value;
 
-    public Optional(T value) {
+    private Optional(T value) {
         this.value = value;
     }
 
@@ -21,7 +23,12 @@ public class Optional<T> {
     }
 
     public static <T> Optional<T> of(T object) {
+        ArgumentValidation.notNull();
         return new Optional<T>(object);
+    }
+
+    public static <T> Optional<T> ofNullable(T value) {
+        return new Optional<T>(value);
     }
 
     public boolean isPresent() {

--- a/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/util/Optional.java
+++ b/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/util/Optional.java
@@ -22,9 +22,9 @@ public class Optional<T> {
         return value;
     }
 
-    public static <T> Optional<T> of(T object) {
-        ArgumentValidation.notNull();
-        return new Optional<T>(object);
+    public static <T> Optional<T> of(T value) {
+        ArgumentValidation.notNull(value, "optional value");
+        return new Optional<T>(value);
     }
 
     public static <T> Optional<T> ofNullable(T value) {

--- a/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/versionupgrade/FindOpenPullRequestTask.java
+++ b/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/versionupgrade/FindOpenPullRequestTask.java
@@ -126,7 +126,7 @@ public class FindOpenPullRequestTask extends DefaultTask {
         dependant.dependsOn(this);
         this.doLast(new Action<Task>() {
             public void execute(Task task) {
-                action.execute(Optional.of(pullRequest));
+                action.execute(Optional.ofNullable(pullRequest));
             }
         });
     }

--- a/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/versionupgrade/FindOpenPullRequestTask.java
+++ b/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/versionupgrade/FindOpenPullRequestTask.java
@@ -7,6 +7,7 @@ import org.gradle.api.tasks.TaskAction;
 import org.json.simple.DeserializationException;
 import org.shipkit.gradle.configuration.ShipkitConfiguration;
 import org.shipkit.internal.gradle.git.domain.PullRequest;
+import org.shipkit.internal.gradle.util.Optional;
 
 import java.io.IOException;
 
@@ -121,11 +122,11 @@ public class FindOpenPullRequestTask extends DefaultTask {
      * - the task {@param #dependant} is executed after {@link FindOpenPullRequestTask}
      */
 
-    public void provideOpenPullRequest(Task dependant, final Action<PullRequest> action) {
+    public void provideOpenPullRequest(Task dependant, final Action<Optional<PullRequest>> action) {
         dependant.dependsOn(this);
         this.doLast(new Action<Task>() {
             public void execute(Task task) {
-                action.execute(pullRequest);
+                action.execute(Optional.of(pullRequest));
             }
         });
     }

--- a/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/versionupgrade/UpgradeDependencyPlugin.java
+++ b/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/versionupgrade/UpgradeDependencyPlugin.java
@@ -268,8 +268,10 @@ public class UpgradeDependencyPlugin implements Plugin<Project> {
                 findOpenPullRequestTask.provideOpenPullRequest(task, new Action<PullRequest>() {
                     @Override
                     public void execute(PullRequest openPullRequestBranch) {
+                        //TODO consider using Optional. This null check is duplicated
+                        String ref = openPullRequestBranch == null? null : openPullRequestBranch.getRef();
                         task.setVersionBranch(getCurrentVersionBranchName(upgradeDependencyExtension.getDependencyName(),
-                            upgradeDependencyExtension.getNewVersion(), openPullRequestBranch.getRef()));
+                            upgradeDependencyExtension.getNewVersion(), ref));
                     }
                 });
 

--- a/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/versionupgrade/UpgradeDependencyPlugin.java
+++ b/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/versionupgrade/UpgradeDependencyPlugin.java
@@ -305,9 +305,7 @@ public class UpgradeDependencyPlugin implements Plugin<Project> {
                 createPullRequestTask.provideCreatedPullRequest(task, new Action<PullRequest>() {
                     @Override
                     public void execute(PullRequest pullRequest) {
-                    if (pullRequest != null) {
-                        setPullRequestDataToTask(Optional.of(pullRequest), task);
-                    }
+                        setPullRequestDataToTask(Optional.ofNullable(pullRequest), task);
                     }
                 });
 

--- a/subprojects/shipkit/src/test/groovy/org/shipkit/internal/gradle/util/OptionalTest.groovy
+++ b/subprojects/shipkit/src/test/groovy/org/shipkit/internal/gradle/util/OptionalTest.groovy
@@ -1,0 +1,18 @@
+package org.shipkit.internal.gradle.util
+
+import spock.lang.Specification
+
+class OptionalTest extends Specification {
+
+    def "does not accept nulls"() {
+        when: Optional.of(null)
+        then: thrown(IllegalArgumentException)
+    }
+
+    def "wraps optional value"() {
+        def foo = Optional.of("foo")
+        expect:
+        foo.isPresent()
+        foo.get() == "foo"
+    }
+}

--- a/subprojects/shipkit/src/test/groovy/org/shipkit/internal/gradle/versionupgrade/UpgradeDependencyPluginTest.groovy
+++ b/subprojects/shipkit/src/test/groovy/org/shipkit/internal/gradle/versionupgrade/UpgradeDependencyPluginTest.groovy
@@ -3,9 +3,11 @@ package org.shipkit.internal.gradle.versionupgrade
 import org.shipkit.gradle.exec.ShipkitExecTask
 import org.shipkit.gradle.git.GitPushTask
 import org.shipkit.internal.gradle.git.GitOriginPlugin
+import org.shipkit.internal.gradle.git.domain.PullRequest
 import org.shipkit.internal.gradle.git.tasks.GitCheckOutTask
 import org.shipkit.internal.gradle.git.tasks.GitPullTask
 import org.shipkit.internal.gradle.git.tasks.IdentifyGitOriginRepoTask
+import org.shipkit.internal.gradle.util.Optional
 import testutil.PluginSpecification
 
 import static org.shipkit.internal.gradle.versionupgrade.UpgradeDependencyPlugin.CREATE_PULL_REQUEST
@@ -182,12 +184,14 @@ class UpgradeDependencyPluginTest extends PluginSpecification {
     }
 
     def "should return open pull request branch if it is not null"() {
+        def pr = Optional.of(new PullRequest().setRef("openPR"))
+
         expect:
-        "openPR" == UpgradeDependencyPlugin.getCurrentVersionBranchName(null, null, "openPR")
+        "openPR" == UpgradeDependencyPlugin.getCurrentVersionBranchName(null, null, pr)
     }
 
     def "should return new version branch if open pull request branch is null"() {
         expect:
-        "upgrade-shipkit-to-1.2.3" == UpgradeDependencyPlugin.getCurrentVersionBranchName("shipkit", "1.2.3", null)
+        "upgrade-shipkit-to-1.2.3" == UpgradeDependencyPlugin.getCurrentVersionBranchName("shipkit", "1.2.3", Optional.of(null))
     }
 }

--- a/subprojects/shipkit/src/test/groovy/org/shipkit/internal/gradle/versionupgrade/UpgradeDependencyPluginTest.groovy
+++ b/subprojects/shipkit/src/test/groovy/org/shipkit/internal/gradle/versionupgrade/UpgradeDependencyPluginTest.groovy
@@ -192,6 +192,6 @@ class UpgradeDependencyPluginTest extends PluginSpecification {
 
     def "should return new version branch if open pull request branch is null"() {
         expect:
-        "upgrade-shipkit-to-1.2.3" == UpgradeDependencyPlugin.getCurrentVersionBranchName("shipkit", "1.2.3", Optional.of(null))
+        "upgrade-shipkit-to-1.2.3" == UpgradeDependencyPlugin.getCurrentVersionBranchName("shipkit", "1.2.3", Optional.ofNullable(null))
     }
 }


### PR DESCRIPTION
Tested with mockito project - it eliminates the NPE.

I opened an issue to use Java8: #624 so that we can get rid of our current "Optional".

Here's my test with Mockito repo. It is convincing but I have not opened a real PR:

```
~/mockito/release/build/downstream/mockitoShipkit$ ./gradlew performVersionUpgrade -Pdependency=org.shipkit:shipkit:1.0.9 -s
  Building version '1.0.9' (value loaded from 'version.properties' file).
  [INCUBATING] upgrade-dependency plugin is incubating and may change in any version.
  [INCUBATING] downstream-testing plugin is incubating and may change in any version.
:checkoutBaseBranch
  Executing:
    git checkout master
:identifyGitOrigin
  Executing:
    git remote get-url origin
  Identified Git origin repository: mockito/shipkit
:pullUpstream
  'git pull' does not use GitHub write token because it was not specified
  Executing:
    git pull https://github.com/mockito/shipkit.git master
:findOpenPullRequest
  New pull request will be opened because we didn't find an existing PR to reuse.
:checkoutVersionBranch
  Executing:
    git checkout -b upgrade-shipkit-to-1.0.9
:replaceVersion
  Replacing version in '/Users/sfaber/mockito/release/build/downstream/mockitoShipkit/build.gradle' using pattern 'org.shipkit:shipkit:[0-9.]+' and version '1.0.9'.
:setGitUserEmail
  Setting git user email:
    git config --local user.email <shipkit.org@gmail.com>
  External process [config] completed.
:setGitUserName
  Setting git user name:
    git config --local user.name shipkit-org
  External process [config] completed.
:commitVersionUpgrade SKIPPED
:pushVersionUpgrade SKIPPED
:createPullRequest SKIPPED
:mergePullRequest SKIPPED
:performVersionUpgrade

BUILD SUCCESSFUL

Total time: 2.265 secs
```