### PR TITLE
Added validation of missing 'dependency' project property

### DIFF
--- a/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/versionupgrade/UpgradeDependencyPlugin.java
+++ b/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/versionupgrade/UpgradeDependencyPlugin.java
@@ -401,12 +401,12 @@ public class UpgradeDependencyPlugin implements Plugin<Project> {
 
     private void addLazyDependencyValidation(final String dependency, Task... tasks) {
         if (dependency == null) {
-            for (Task task : tasks) {
+            for (final Task task : tasks) {
                 LazyConfiguration.lazyConfiguration(task, new Runnable() {
                     @Override
                     public void run() {
-                        throw new GradleException("Dependency property not set. You need to add 'dependency' parameter in" +
-                            " order to run this task. E.g.: -Pdependency=\"org.shipkit:shipkit:1.2.3\"");
+                        throw new GradleException("Dependency project property not set. It is required for task '" + task.getPath() + "'.\n" +
+                            "You can pass project property via command line: -Pdependency=\"org.shipkit:shipkit:1.2.3\"");
                     }
                 });
             }

--- a/subprojects/shipkit/src/test/groovy/org/shipkit/internal/gradle/versionupgrade/UpgradeDependencyPluginTest.groovy
+++ b/subprojects/shipkit/src/test/groovy/org/shipkit/internal/gradle/versionupgrade/UpgradeDependencyPluginTest.groovy
@@ -1,7 +1,6 @@
 package org.shipkit.internal.gradle.versionupgrade
 
 import org.gradle.api.GradleException
-import org.gradle.api.Task
 import org.shipkit.gradle.exec.ShipkitExecTask
 import org.shipkit.gradle.git.GitPushTask
 import org.shipkit.internal.gradle.configuration.LazyConfiguration
@@ -215,68 +214,13 @@ class UpgradeDependencyPluginTest extends PluginSpecification {
         task << ['commitVersionUpgrade', 'findOpenPullRequest', 'replaceVersion', 'pushVersionUpgrade', 'createPullRequest']
     }
 
-    def "should not register commitVersionUpgrade task in lazy configuration when dependency set"() {
-        given:
-        project.extensions.dependency = "org.shipkit:shipkit:1.2.30"
-
+    def "dependency project property is not needed during Gradle's configuration"() {
         when:
         project.plugins.apply(UpgradeDependencyPlugin)
-        Task task = project.tasks.commitVersionUpgrade
-        LazyConfiguration.forceConfiguration(task)
 
         then:
-        thrown NullPointerException
-    }
-
-    def "should not register findOpenPullRequest task in lazy configuration when dependency set"() {
-        given:
-        project.extensions.dependency = "org.shipkit:shipkit:1.2.30"
-
-        when:
-        project.plugins.apply(UpgradeDependencyPlugin)
-        Task task = project.tasks.findOpenPullRequest
-        LazyConfiguration.forceConfiguration(task)
-
-        then:
-        thrown NullPointerException
-    }
-
-    def "should not register replaceVersion task in lazy configuration when dependency set"() {
-        given:
-        project.extensions.dependency = "org.shipkit:shipkit:1.2.30"
-
-        when:
-        project.plugins.apply(UpgradeDependencyPlugin)
-        Task task = project.tasks.replaceVersion
-        LazyConfiguration.forceConfiguration(task)
-
-        then:
-        thrown NullPointerException
-    }
-
-    def "should not register pushVersionUpgrade task in lazy configuration when dependency set"() {
-        given:
-        project.extensions.dependency = "org.shipkit:shipkit:1.2.30"
-
-        when:
-        project.plugins.apply(UpgradeDependencyPlugin)
-        Task task = project.tasks.pushVersionUpgrade
-        LazyConfiguration.forceConfiguration(task)
-
-        then:
-        thrown NullPointerException
-    }
-
-    def "should not register createPullRequest task in lazy configuration when dependency set"() {
-        given:
-        project.extensions.dependency = "org.shipkit:shipkit:1.2.30"
-
-        when:
-        project.plugins.apply(UpgradeDependencyPlugin)
-        Task task = project.tasks.createPullRequest
-        LazyConfiguration.forceConfiguration(task)
-
-        then:
-        thrown NullPointerException
+        //safe to evaluate despite there is no 'dependency' project property
+        //we only want to validate when user runs task that needs the 'dependency' project property
+        project.evaluate()
     }
 }


### PR DESCRIPTION
This PR is based of #620, I recreated new PR because we had problems merging the initial contribution by @micd.

Copied from #620:

As described and discussed within #614. I have added lazy configuration to the tasks that depends on ``dependency`` parameter, which will validate if dependency exists.

**Tests**
After running:
- ``gradlew createPullRequest``
- ``gradlew pushVersionUpgrade``
- ``gradlew replaceVersion``
- ``gradlew findOpenPullRequest``
- ``gradlew commitVersionUpgrade``
- ``gradlew performVersionUpgrad``

you should get ``GradleException`` with ``"Dependency property not set. You need to add 'dependency' parameter in order to run this task. E.g.: -Pdependency="org.shipkit:shipkit:1.2.3"``message.

When ``-Pdependency`` parameter set there should not be such exception message.