### PR TITLE
fix auto merging

### DIFF
--- a/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/versionupgrade/CreatePullRequestTask.java
+++ b/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/versionupgrade/CreatePullRequestTask.java
@@ -34,7 +34,7 @@ public class CreatePullRequestTask extends DefaultTask {
 
     @TaskAction
     public void createPullRequest() throws IOException {
-        new CreatePullRequest().createPullRequest(this);
+        pullRequest = new CreatePullRequest().createPullRequest(this);
     }
 
     /**


### PR DESCRIPTION
this one should allow us to merge pr's automatically again (see #629).
It looks like we somehow lost this assignment. Without it `task.setVersionBranch` is never called.