### PR TITLE
refactor GitHubStatusCheck

### DIFF
--- a/subprojects/shipkit/src/main/groovy/org/shipkit/internal/util/GitHubStatusCheck.java
+++ b/subprojects/shipkit/src/main/groovy/org/shipkit/internal/util/GitHubStatusCheck.java
@@ -9,6 +9,7 @@ import org.shipkit.internal.gradle.versionupgrade.MergePullRequestTask;
 
 import java.io.IOException;
 import java.util.Collection;
+import java.util.concurrent.TimeUnit;
 
 public class GitHubStatusCheck {
 
@@ -17,8 +18,6 @@ public class GitHubStatusCheck {
     private MergePullRequestTask task;
     private GitHubApi gitHubApi;
     private final int amountOfRetries;
-
-
 
     public GitHubStatusCheck(MergePullRequestTask task, GitHubApi gitHubApi, int amountOfRetries) {
         this.task = task;
@@ -43,10 +42,10 @@ public class GitHubStatusCheck {
             if (allStatusesPassed(status)) {
                 return PullRequestStatus.SUCCESS;
             } else {
-                int waitTime = 10000 * timeouts;
-                Thread.sleep(waitTime);
                 timeouts++;
-                LOG.lifecycle("Pull Request checks still in pending state. Waiting %d seconds...", waitTime / 1000);
+                long waitTimeInMillis = TimeUnit.SECONDS.toMillis(10) * timeouts;
+                LOG.lifecycle("Pull Request checks still in pending state. Waiting {} seconds...", TimeUnit.MILLISECONDS.toSeconds(waitTimeInMillis));
+                Thread.sleep(waitTimeInMillis);
             }
         }
         return PullRequestStatus.TIMEOUT;

--- a/subprojects/shipkit/src/main/groovy/org/shipkit/internal/util/GitHubStatusCheck.java
+++ b/subprojects/shipkit/src/main/groovy/org/shipkit/internal/util/GitHubStatusCheck.java
@@ -38,6 +38,8 @@ public class GitHubStatusCheck {
         int timeouts = 0;
         while (timeouts < amountOfRetries) {
             JsonObject status = getStatusCheck(task, gitHubApi);
+            // it might be the case that we are too fast and statuses are not available yet -> let's do at least
+            // one retry in this case.
             if (timeouts > 0 && isNullOrEmpty(status, "statuses")) {
                 return PullRequestStatus.NO_CHECK_DEFINED;
             } else if (!isNullOrEmpty(status, "statuses") && allStatusesPassed(status)) {


### PR DESCRIPTION
this one is related to #634

there are two possibilities why the automatic merge now does not work

- the first check is too fast and 'statuses' are not set yet:
   I have added a retry in order to perform the check for a 2nd time. I'm not entirely happy with this solution but it looks like we need something like that.

 - the pullrequest sha is not the one we are supposed to use:
  I have added a log message to be able to check whether we are using the correct sha