### PR TITLE
add gradle version to test name

### DIFF
--- a/subprojects/shipkit/src/test/groovy/org/shipkit/gradle/ShipkitGradlePluginIntegTest.groovy
+++ b/subprojects/shipkit/src/test/groovy/org/shipkit/gradle/ShipkitGradlePluginIntegTest.groovy
@@ -5,7 +5,7 @@ import testutil.GradleSpecification
 
 class ShipkitGradlePluginIntegTest extends GradleSpecification {
 
-    def "all tasks in dry run"() {
+    def "all tasks in dry run (using gradle version #gradleVersionToTest)"() {
         given:
         gradleVersion = gradleVersionToTest
 

--- a/subprojects/shipkit/src/test/groovy/org/shipkit/internal/gradle/init/InitPluginIntegTest.groovy
+++ b/subprojects/shipkit/src/test/groovy/org/shipkit/internal/gradle/init/InitPluginIntegTest.groovy
@@ -4,18 +4,24 @@ import testutil.GradleSpecification
 
 class InitPluginIntegTest extends GradleSpecification {
 
-        def "runs initShipkit task in a project without any Shipkit configuration"() {
-            given:
-            buildFile << """
+    def "runs initShipkit task in a project without any Shipkit configuration (using gradle version #gradleVersionToTest)"() {
+        given:
+        gradleVersion = gradleVersionToTest
+
+        and:
+        buildFile << """
             apply plugin: "org.shipkit.java"
         """
 
-            expect:
-            pass("initShipkit", "-s")
+        expect:
+        pass("initShipkit", "-s")
 
-            // check if configuration files were generated
-            new File(projectDir.root, "gradle/shipkit.gradle").exists()
-            new File(projectDir.root, "version.properties").exists()
-            new File(projectDir.root, ".travis.yml").exists()
-        }
+        // check if configuration files were generated
+        new File(projectDir.root, "gradle/shipkit.gradle").exists()
+        new File(projectDir.root, "version.properties").exists()
+        new File(projectDir.root, ".travis.yml").exists()
+
+        where:
+        gradleVersionToTest << determineGradleVersionsToTest()
+    }
 }

--- a/subprojects/shipkit/src/test/groovy/org/shipkit/internal/gradle/versionupgrade/CiUpgradeDownstreamPluginIntegTest.groovy
+++ b/subprojects/shipkit/src/test/groovy/org/shipkit/internal/gradle/versionupgrade/CiUpgradeDownstreamPluginIntegTest.groovy
@@ -5,7 +5,7 @@ import testutil.GradleSpecification
 
 class CiUpgradeDownstreamPluginIntegTest extends GradleSpecification {
 
-    def "all tasks in dry run"() {
+    def "all tasks in dry run (using gradle version #gradleVersionToTest)"() {
         given:
         gradleVersion = gradleVersionToTest
 
@@ -22,7 +22,7 @@ class CiUpgradeDownstreamPluginIntegTest extends GradleSpecification {
         buildFile << """
             apply plugin: "org.shipkit.ci-upgrade-downstream"
 
-            upgradeDownstream{
+            upgradeDownstream {
                 repositories = ['wwilk/mockito']
             }
         """

--- a/subprojects/shipkit/src/test/groovy/org/shipkit/internal/gradle/versionupgrade/UpgradeDependencyPluginIntegTest.groovy
+++ b/subprojects/shipkit/src/test/groovy/org/shipkit/internal/gradle/versionupgrade/UpgradeDependencyPluginIntegTest.groovy
@@ -5,7 +5,7 @@ import testutil.GradleSpecification
 
 class UpgradeDependencyPluginIntegTest extends GradleSpecification {
 
-    def "all tasks in dry run"() {
+    def "all tasks in dry run (using gradle version #gradleVersionToTest)"() {
         given:
         gradleVersion = gradleVersionToTest
 

--- a/subprojects/shipkit/src/test/groovy/org/shipkit/internal/gradle/versionupgrade/UpgradeDownstreamPluginIntegTest.groovy
+++ b/subprojects/shipkit/src/test/groovy/org/shipkit/internal/gradle/versionupgrade/UpgradeDownstreamPluginIntegTest.groovy
@@ -5,7 +5,7 @@ import testutil.GradleSpecification
 
 class UpgradeDownstreamPluginIntegTest extends GradleSpecification {
 
-    def "all tasks in dry run"() {
+    def "all tasks in dry run (using gradle version #gradleVersionToTest)"() {
         given:
         gradleVersion = gradleVersionToTest
 
@@ -20,7 +20,7 @@ class UpgradeDownstreamPluginIntegTest extends GradleSpecification {
         buildFile << """
             apply plugin: "org.shipkit.upgrade-downstream"
 
-            upgradeDownstream{
+            upgradeDownstream {
                 repositories = ['wwilk/mockito']
             }
         """


### PR DESCRIPTION
in order to make it easier to analyze integration test problems (e.g. one test is just failing while using a certain gradle version).

test names will look like 

> all tasks in dry run (using gradle version 4.0.2)
> all tasks in dry run (using gradle version 4.2.1)

instead of

> all tasks in dry run[0]
> all tasks in dry run[1]