### PR TITLE
update checkstyle to 8.8

### DIFF
--- a/subprojects/shipkit/shipkit.gradle
+++ b/subprojects/shipkit/shipkit.gradle
@@ -11,6 +11,7 @@ apply from: "$rootDir/gradle/upgrade-downstream.gradle"
 apply plugin: 'org.shipkit.compare-publications'
 
 checkstyle {
+    toolVersion = '8.8'
     configFile = file("${rootDir}/config/checkstyle/checkstyle.xml")
 }
 

--- a/subprojects/shipkit/src/main/groovy/org/shipkit/internal/exec/ProcessRunner.java
+++ b/subprojects/shipkit/src/main/groovy/org/shipkit/internal/exec/ProcessRunner.java
@@ -13,7 +13,7 @@ public interface ProcessRunner {
      * @param commandLine to execute
      * @return combined error and standard output.
      */
-    String run(String ... commandLine);
+    String run(String... commandLine);
 
     /**
      * Executes given command line and returns result.

--- a/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/exec/ExecCommandFactory.java
+++ b/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/exec/ExecCommandFactory.java
@@ -74,14 +74,14 @@ public class ExecCommandFactory {
     /**
      * See {@link #execCommand(String, List)}
      */
-    public static ExecCommand execCommand(String description, String ... commandLine) {
+    public static ExecCommand execCommand(String description, String... commandLine) {
         return execCommand(description, asList(commandLine));
     }
 
     /**
      * See {@link #execCommand(String, List)}
      */
-    public static ExecCommand execCommand(String description, File workingDir, String ... commandLine) {
+    public static ExecCommand execCommand(String description, File workingDir, String... commandLine) {
         List<String> cmd = asList(commandLine);
         String prefix = defaultPrefix(cmd);
         return new ExecCommand(prefix, description, cmd, ignoreResult(workingDir), ensureSucceeded(prefix));

--- a/subprojects/shipkit/src/main/groovy/org/shipkit/internal/util/ArgumentValidation.java
+++ b/subprojects/shipkit/src/main/groovy/org/shipkit/internal/util/ArgumentValidation.java
@@ -9,7 +9,7 @@ public abstract class ArgumentValidation {
      * None of the input targets can not be null otherwise IllegalArgumentException is thrown.
      * Every second argument must a String describing the previous element.
      */
-    public static void notNull(Object ... targets) {
+    public static void notNull(Object... targets) {
         if (targets.length % 2 != 0) {
             throw new IllegalArgumentException("notNull method requires pairs of argument + message");
         }


### PR DESCRIPTION
let's use latest version of checkstyle. we can do so now since we are using java8 now.

What about using `[ci skip-release]` while merging this one?
It is just a minor change and doesn't have to trigger a release.
