### PR TITLE
update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ As much as useful the toolkit was to drive Mockito releases, we needed to make i
 - 2017, November - Shipkit mentioned at QCon '17 conference in San Francisco:
   - "CI/CD at scale: lessons from LinkedIn and Mockito" talk ([slide clip](https://www.slideshare.net/SzczepanFaber/clipboards/shipkit-clips), [video](https://www.infoq.com/presentations/ci-cd-linkedin-mockito))
 - 2017, December - 1.0 release! See the [release notes](docs/release-notes.md).
-- 2018, February - Shipkit 2.0, upgrade to Java8 and Gradle4 ([#624](https://github.com/mockito/shipkit/issues/624))
+- 2018, February - Shipkit 2.0, upgrade to Java8 and Gradle4. 2.0.0 is fully compatible with 1.0.12 feature-wise. ([#624](https://github.com/mockito/shipkit/issues/624))
 
 Want to include your event? Submit a pull request!
 

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Add Gradle plugin:
 ```groovy
 plugins {
   // TODO: Use latest version from https://plugins.gradle.org/plugin/org.shipkit.java
-  id "org.shipkit.java" version "1.0.12"
+  id "org.shipkit.java" version "2.0.0" // use 1.0.12 if you still need Java 6/7 and/or Gradle 2/3 support
 }
 ```
 
@@ -115,12 +115,12 @@ As much as useful the toolkit was to drive Mockito releases, we needed to make i
 - 2017, November - Shipkit mentioned at QCon '17 conference in San Francisco:
   - "CI/CD at scale: lessons from LinkedIn and Mockito" talk ([slide clip](https://www.slideshare.net/SzczepanFaber/clipboards/shipkit-clips), [video](https://www.infoq.com/presentations/ci-cd-linkedin-mockito))
 - 2017, December - 1.0 release! See the [release notes](docs/release-notes.md).
+- 2018, February - Shipkit 2.0, upgrade to Java8 and Gradle4 ([#624](https://github.com/mockito/shipkit/issues/624))
 
 Want to include your event? Submit a pull request!
 
 ### Plans
 
-- 2018, Q1 - Shipkit 2.0, upgrade to Java8 and Gradle4 ([#624](https://github.com/mockito/shipkit/issues/624))
 - 2018, Q2 - Make Shipkit the standard tool for Gradle plugin CI/CD ([#255](https://github.com/mockito/shipkit/issues/255))
 - 2018, Q1-Q4 - work on getting the community adopt Shipkit while adding CI/CD features
 - 2019, push OSS and enterprise code to CI/CD


### PR DESCRIPTION
 - use gradle 2.0.0 in getting started section
 - add a hint to use 1.0.12 if java6 and/or gradle 2/3 is needed
 - adjust history/plans