### PR TITLE
fix UpgradeDependencyPlugin for gradle 4.5.1

### DIFF
--- a/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/versionupgrade/UpgradeDependencyPlugin.java
+++ b/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/versionupgrade/UpgradeDependencyPlugin.java
@@ -93,8 +93,8 @@ public class UpgradeDependencyPlugin implements Plugin<Project> {
     @Override
     public void apply(final Project project) {
         IncubatingWarning.warn("upgrade-dependency plugin");
-        final GitOriginPlugin gitOriginPlugin = project.getRootProject().getPlugins().apply(GitOriginPlugin.class);
         final ShipkitConfiguration conf = project.getPlugins().apply(ShipkitConfigurationPlugin.class).getConfiguration();
+        final GitOriginPlugin gitOriginPlugin = project.getRootProject().getPlugins().apply(GitOriginPlugin.class);
         project.getPlugins().apply(GitConfigPlugin.class);
 
         upgradeDependencyExtension = project.getExtensions().create("upgradeDependency", UpgradeDependencyExtension.class);

--- a/subprojects/shipkit/src/test/groovy/testutil/GradleVersionsDeterminer.groovy
+++ b/subprojects/shipkit/src/test/groovy/testutil/GradleVersionsDeterminer.groovy
@@ -24,7 +24,7 @@ trait GradleVersionsDeterminer {
             case null:
                 return [currentGradleVersion()]
             case QUICK_GRADLE_VERSIONS_VALUE:
-                return [currentGradleVersion(), "4.2.1", "4.0.2"].unique()
+                return [currentGradleVersion(), "4.5.1", "4.2.1", "4.0.2"].unique()
             default:
                 log.warn("Unsupported $REGRESSION_TESTS_ENV_NAME value '$regressionTestsLevel' (expected '$CURRENT_GRADLE_VERSION_ONLY_VALUE' or " +
                     "'$QUICK_GRADLE_VERSIONS_VALUE'). Assuming '$CURRENT_GRADLE_VERSION_ONLY_VALUE'.")


### PR DESCRIPTION
fixes #641 
and add gradle 4.5.1 to set of gradle versions used for integration testing.