### PR TITLE
Use put instead of post for merge pr rest request

### DIFF
--- a/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/versionupgrade/MergePullRequest.java
+++ b/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/versionupgrade/MergePullRequest.java
@@ -50,7 +50,7 @@ class MergePullRequest {
             }
 
             LOG.lifecycle("All checks passed! Merging pull request in repository '{}' between base = '{}' and head = '{}'.", task.getUpstreamRepositoryName(), task.getBaseBranch(), headBranch);
-            gitHubApi.post("/repos/" + task.getUpstreamRepositoryName() + "/pulls/" + task.getPullRequestNumber() + "/merge", body);
+            gitHubApi.put("/repos/" + task.getUpstreamRepositoryName() + "/pulls/" + task.getPullRequestNumber() + "/merge", body);
         } catch (Exception e) {
             throw new GradleException(String.format("Exception happen while trying to merge pull request. Merge aborted. Original issue: %s", e.getMessage()), e);
         }

--- a/subprojects/shipkit/src/test/groovy/org/shipkit/internal/gradle/versionupgrade/MergePullRequestTest.groovy
+++ b/subprojects/shipkit/src/test/groovy/org/shipkit/internal/gradle/versionupgrade/MergePullRequestTest.groovy
@@ -43,7 +43,7 @@ class MergePullRequestTest extends Specification {
 
         then:
         1 * githubStatusCheck.checkStatusWithRetries() >> PullRequestStatus.SUCCESS
-        1 * gitHubApi.post("/repos/mockito/shipkit-example/pulls/123/merge", '{  "merge_method": "merge",  "base": "master"}')
+        1 * gitHubApi.put("/repos/mockito/shipkit-example/pulls/123/merge", '{  "merge_method": "merge",  "base": "master"}')
     }
 
     def "should return in case of no status checks defined"() {


### PR DESCRIPTION
It looks like I somehow forgot to change the request method while migrating to the new pr merge rest api.
We have to use put instead of post, see https://developer.github.com/v3/pulls/#merge-a-pull-request-merge-button for details.

Let's use put instead of post now.