### PR TITLE
Fixed empty dependency info files if 'java-library' plugin is used

### DIFF
--- a/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/java/ComparePublicationsPlugin.java
+++ b/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/java/ComparePublicationsPlugin.java
@@ -68,7 +68,7 @@ public class ComparePublicationsPlugin implements Plugin<Project> {
             public void execute(final CreateDependencyInfoFileTask task) {
                 task.setDescription("Creates a file with all declared runtime dependencies.");
                 task.setOutputFile(new File(project.getBuildDir(), DEPENDENCY_INFO_FILENAME));
-                task.setConfiguration(project.getConfigurations().getByName("runtime"));
+                task.setConfiguration(project.getConfigurations().getByName("runtimeClasspath"));
                 task.setProjectVersion(project.getVersion().toString());
 
                 DeferredConfiguration.deferredConfiguration(project, new Runnable() {

--- a/subprojects/shipkit/src/test/groovy/org/shipkit/internal/gradle/java/ComparePublicationsPluginTest.groovy
+++ b/subprojects/shipkit/src/test/groovy/org/shipkit/internal/gradle/java/ComparePublicationsPluginTest.groovy
@@ -116,7 +116,7 @@ class ComparePublicationsPluginTest extends PluginSpecification {
 
         then:
         CreateDependencyInfoFileTask task = project.tasks.createDependencyInfoFile
-        task.configuration == project.configurations.getByName("runtime")
+        task.configuration == project.configurations.getByName("runtimeClasspath")
         task.outputFile == new File(project.buildDir, "dependency-info.md")
         task.projectGroup == "projectGroup"
         task.projectVersion == "1.2.3"

--- a/subprojects/shipkit/src/test/groovy/org/shipkit/internal/gradle/java/ComparePublicationsPluginTest.groovy
+++ b/subprojects/shipkit/src/test/groovy/org/shipkit/internal/gradle/java/ComparePublicationsPluginTest.groovy
@@ -121,4 +121,36 @@ class ComparePublicationsPluginTest extends PluginSpecification {
         task.projectGroup == "projectGroup"
         task.projectVersion == "1.2.3"
     }
+
+    def "verify content of dependency-info.md file (using '#plugin' plugin and #libraries)"() {
+        given:
+        project.group = "projectGroup"
+        project.version = "1.2.3"
+        project.plugins.apply(plugin)
+        project.repositories.add(project.repositories.jcenter())
+        libraries.each { config, lib ->
+            project.dependencies.add(config, lib)
+        }
+
+        when:
+        project.plugins.apply(ComparePublicationsPlugin)
+        project.evaluate()
+        project.tasks["createDependencyInfoFile"].execute()
+
+        then:
+        CreateDependencyInfoFileTask task = project.tasks.createDependencyInfoFile
+        def dependencyInfoFile = task.outputFile
+
+        dependencyInfoFile.exists()
+        dependencyInfoFile.text
+        libraries.each { config, lib ->
+            assert dependencyInfoFile.text.contains(lib)
+        }
+
+        where:
+        plugin          | libraries
+        'java'          | ['compile': 'org.mockito:mockito-core:2.15.0']
+        'java-library'  | ['api': 'org.mockito:mockito-core:2.13.0']
+        'java-library'  | ['api': 'org.mockito:mockito-core:2.13.0', 'implementation': 'com.google.guava:guava:21.0' ]
+    }
 }

--- a/subprojects/shipkit/src/test/groovy/org/shipkit/internal/gradle/java/ComparePublicationsPluginTest.groovy
+++ b/subprojects/shipkit/src/test/groovy/org/shipkit/internal/gradle/java/ComparePublicationsPluginTest.groovy
@@ -151,6 +151,6 @@ class ComparePublicationsPluginTest extends PluginSpecification {
         plugin          | libraries
         'java'          | ['compile': 'org.mockito:mockito-core:2.15.0']
         'java-library'  | ['api': 'org.mockito:mockito-core:2.13.0']
-        'java-library'  | ['api': 'org.mockito:mockito-core:2.13.0', 'implementation': 'com.google.guava:guava:21.0' ]
+        'java-library'  | ['api': 'org.mockito:mockito-core:2.13.0', 'implementation': 'org.opentest4j:opentest4j:1.0.0' ]
     }
 }


### PR DESCRIPTION
fixes #619 

previously, the dependency info file did not contain any dependencies if the 'java-library' plugin was used.
Now we are also adding dependency info if  'java-library' plugin is used.

I added a test in order to reproduce problem described in the ticket, see [travis log](https://travis-ci.org/mockito/shipkit/builds/348725531#L550-L554) for details.
