### PR TITLE
Enable gradle build cache

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,2 @@
 org.gradle.daemon=true
+org.gradle.caching=true


### PR DESCRIPTION
since we recently migrated to gradle 4, let's also enable the gradle build cache now.