### PR TITLE
org.shipkit.gradle-plugin automatically avoids releases when publications are identical

### DIFF
--- a/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/release/GradlePortalReleasePlugin.java
+++ b/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/release/GradlePortalReleasePlugin.java
@@ -8,6 +8,7 @@ import org.shipkit.gradle.configuration.ShipkitConfiguration;
 import org.shipkit.gradle.notes.UpdateReleaseNotesTask;
 import org.shipkit.internal.gradle.configuration.ShipkitConfigurationPlugin;
 import org.shipkit.internal.gradle.git.GitPlugin;
+import org.shipkit.internal.gradle.java.ComparePublicationsPlugin;
 import org.shipkit.internal.gradle.notes.ReleaseNotesPlugin;
 import org.shipkit.internal.gradle.plugin.GradlePortalPublishPlugin;
 import org.shipkit.internal.gradle.plugin.PluginDiscoveryPlugin;
@@ -53,6 +54,7 @@ public class GradlePortalReleasePlugin implements Plugin<Project> {
                         subproject.getPlugins().apply(PluginDiscoveryPlugin.class);
                         subproject.getPlugins().apply(PluginValidationPlugin.class);
                         subproject.getPlugins().apply(GradlePortalPublishPlugin.class);
+                        subproject.getPlugins().apply(ComparePublicationsPlugin.class);
 
                         Task publishPlugins = subproject.getTasks().getByName(GradlePortalPublishPlugin.PUBLISH_PLUGINS_TASK);
 

--- a/subprojects/shipkit/src/test/groovy/org/shipkit/gradle/ShipkitGradlePluginIntegTest.groovy
+++ b/subprojects/shipkit/src/test/groovy/org/shipkit/gradle/ShipkitGradlePluginIntegTest.groovy
@@ -40,9 +40,10 @@ class ShipkitGradlePluginIntegTest extends GradleSpecification {
 :processResources
 :classes
 :jar
-:publishPluginJar
 :javadoc
-:publishPluginJavaDocsJar
+:javadocJar
+:createDependencyInfoFile
+:sourcesJar
 :buildArchives
 :gitTag
 :gitPush


### PR DESCRIPTION
... and also make compare-publications plugin a default for ShipkitGradlePlugin users.

fixes #487

