### PR TITLE
Improved test failure logging

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,5 +32,13 @@ allprojects {
         jcenter()
         maven { url "https://plugins.gradle.org/m2/" }
     }
+
+    tasks.withType(Test) {
+        testLogging {
+            //This way Spock/Groovy power asserts will be visible in the build log
+            //Very useful - you don't have to look at the test results to debug a test failure
+            exceptionFormat "full"
+        }
+    }
 }
 


### PR DESCRIPTION
Fixes #666. 

Now it is possible to debug a test failure without looking at the test log. This change does not affect the build log during "happy" execution (all tests green).