### PR TITLE
Gradle build script cleanup

### DIFF
--- a/subprojects/shipkit/shipkit.gradle
+++ b/subprojects/shipkit/shipkit.gradle
@@ -8,8 +8,6 @@ apply plugin: 'com.gradle.plugin-publish'
 
 apply from: "$rootDir/gradle/upgrade-downstream.gradle"
 
-apply plugin: 'org.shipkit.compare-publications'
-
 checkstyle {
     toolVersion = '8.8'
     configFile = file("${rootDir}/config/checkstyle/checkstyle.xml")


### PR DESCRIPTION
No longer apply 'compare-publications' plugin in gradle file because it is now applied by default via 'org.shipkit.gradle-plugin'.