### PR TITLE
remove --daemon from travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,4 +19,4 @@ install:
  - true
 
 script:
-  - ./gradlew build testDownstream -PcheckJava8Compatibility --daemon -s && ./gradlew ciPerformRelease -s
+  - ./gradlew build testDownstream -PcheckJava8Compatibility -s && ./gradlew ciPerformRelease -s


### PR DESCRIPTION
let's remove --daemon from travis.yml. We added it back then because travis did default to very high xmx values and adding the --daemon did solve our memory problems previously.
this pr is related to #675 although it might need another pr to do some more tuning.