### PR TITLE
Fix memory problems in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,4 +22,4 @@ before_script:
   - _JAVA_OPTIONS=
 
 script:
-  - ./gradlew build testDownstream -PcheckJava8Compatibility -s && ./gradlew ciPerformRelease -s
+  - ./gradlew build testDownstream -PcheckJava8Compatibility -Xmx1024m -Xms128m -s && ./gradlew ciPerformRelease -s

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,6 @@ install:
 
 before_script:
   - _JAVA_OPTIONS=
-  - GRADLE_OPTS="-Xmx1024m -Xms128m"
 
 script:
   - ./gradlew build testDownstream -PcheckJava8Compatibility -s && ./gradlew ciPerformRelease -s

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,5 +18,8 @@ branches:
 install:
  - true
 
+before_script:
+  - _JAVA_OPTIONS="-Xmx1024m -Xms128m"
+
 script:
   - ./gradlew build testDownstream -PcheckJava8Compatibility -s && ./gradlew ciPerformRelease -s

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ install:
  - true
 
 before_script:
-  - _JAVA_OPTIONS="-Xmx1024m -Xms128m"
+  - _JAVA_OPTIONS=
 
 script:
   - ./gradlew build testDownstream -PcheckJava8Compatibility -s && ./gradlew ciPerformRelease -s

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ install:
 
 before_script:
   - _JAVA_OPTIONS=
+  - GRADLE_OPTS="-Xmx1024m -Xms128m"
 
 script:
-  - ./gradlew build testDownstream -PcheckJava8Compatibility -Xmx1024m -Xms128m -s && ./gradlew ciPerformRelease -s
+  - ./gradlew build testDownstream -PcheckJava8Compatibility -s && ./gradlew ciPerformRelease -s

--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,7 @@ allprojects {
 
     tasks.withType(Test) {
         minHeapSize = '128m'
+        maxHeapSize = '1024m'
         testLogging {
             //This way Spock/Groovy power asserts will be visible in the build log
             //Very useful - you don't have to look at the test results to debug a test failure

--- a/build.gradle
+++ b/build.gradle
@@ -35,7 +35,7 @@ allprojects {
 
     tasks.withType(Test) {
         minHeapSize = '128m'
-        maxHeapSize = '1024m'
+        maxHeapSize = '512m'
         testLogging {
             //This way Spock/Groovy power asserts will be visible in the build log
             //Very useful - you don't have to look at the test results to debug a test failure

--- a/build.gradle
+++ b/build.gradle
@@ -34,6 +34,7 @@ allprojects {
     }
 
     tasks.withType(Test) {
+        minHeapSize = '128m'
         testLogging {
             //This way Spock/Groovy power asserts will be visible in the build log
             //Very useful - you don't have to look at the test results to debug a test failure

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,3 @@
 org.gradle.daemon=true
 org.gradle.caching=true
+org.gradle.jvmargs=-Xmx1g -Xms256m


### PR DESCRIPTION
Issue: #675

Travis is using `_JAVA_OPTIONS="-Xmx2048m -Xms512m"` by default. 
Let's adjust this values to our needs.

The build is failing now because mockito project recently updated to Gradle 4.6 and we are heading into something similar to https://github.com/mockito/shipkit/pull/649 now (see [gist](https://gist.github.com/shipkit-org/1a4425d5698b990ca6978256d14d5778) for details).
Let's have a look at this one in a separate ticket. 