### PR TITLE
Avoid fetching contributors for normal builds

### DIFF
--- a/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/java/PomContributorsPlugin.java
+++ b/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/java/PomContributorsPlugin.java
@@ -30,22 +30,12 @@ public class PomContributorsPlugin implements Plugin<Project> {
     @Override
     public void apply(final Project project) {
         project.getPlugins().apply(GitHubContributorsPlugin.class);
-        project.allprojects(new Action<Project>() {
-            public void execute(final Project subproject) {
-                subproject.getPlugins().withType(JavaPublishPlugin.class, new Action<Plugin>() {
-                    @Override
-                    public void execute(Plugin plugin) {
-                        final Task fetcher = project.getTasks().getByName(GitHubContributorsPlugin.FETCH_CONTRIBUTORS);
-                        //Because maven-publish plugin uses new configuration model, we cannot get the task directly
-                        //So we use 'matching' technique
-                        subproject.getTasks().matching(withName(POM_TASK)).all(new Action<Task>() {
-                            public void execute(Task t) {
-                                t.dependsOn(fetcher);
-                            }
-                        });
-                    }
-                });
-            }
-        });
+        project.allprojects(subproject ->
+            subproject.getPlugins().withType(JavaPublishPlugin.class, (Action<Plugin>) plugin -> {
+                final Task fetcher = project.getTasks().getByName(GitHubContributorsPlugin.FETCH_CONTRIBUTORS);
+                //Because maven-publish plugin uses new configuration model, we cannot get the task directly
+                //So we use 'matching' technique
+                subproject.getTasks().matching(withName(POM_TASK)).all(t -> t.dependsOn(fetcher));
+            }));
     }
 }

--- a/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/java/PomContributorsPlugin.java
+++ b/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/java/PomContributorsPlugin.java
@@ -1,9 +1,9 @@
 package org.shipkit.internal.gradle.java;
 
-import org.gradle.api.Action;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.Task;
+import org.shipkit.internal.gradle.bintray.ShipkitBintrayPlugin;
 import org.shipkit.internal.gradle.contributors.github.GitHubContributorsPlugin;
 
 import static org.shipkit.internal.gradle.java.JavaPublishPlugin.POM_TASK;
@@ -19,9 +19,13 @@ import static org.shipkit.internal.gradle.util.Specs.withName;
  * </ul>
  * Other features:
  * <ul>
- *     <li>Injects configuration to all projects that have {@link JavaPublishPlugin} plugin.
- *     Makes sure that the task that generates pom file has dependency on task that fetches all contributors.
+ *     <li>Injects configuration to all projects that have {@link JavaBintrayPlugin} plugin.
+ *     Makes sure that the task that generates pom file will have the contributors data generated first.
  *     All contributors are listed in the pom file.
+ *     </li>
+ *     <li>
+ *     Fetching contributors only occurs if we're publishing to Bintray. For normal builds like './gradlew build',
+ *     we don't fetch contributors. This way the builds are faster and can run offline.
  *     </li>
  * </ul>
  */
@@ -30,12 +34,18 @@ public class PomContributorsPlugin implements Plugin<Project> {
     @Override
     public void apply(final Project project) {
         project.getPlugins().apply(GitHubContributorsPlugin.class);
+        final Task fetcher = project.getTasks().getByName(GitHubContributorsPlugin.FETCH_CONTRIBUTORS);
+
         project.allprojects(subproject ->
-            subproject.getPlugins().withType(JavaPublishPlugin.class, (Action<Plugin>) plugin -> {
-                final Task fetcher = project.getTasks().getByName(GitHubContributorsPlugin.FETCH_CONTRIBUTORS);
+            subproject.getPlugins().withType(JavaBintrayPlugin.class, plugin -> {
                 //Because maven-publish plugin uses new configuration model, we cannot get the task directly
-                //So we use 'matching' technique
-                subproject.getTasks().matching(withName(POM_TASK)).all(t -> t.dependsOn(fetcher));
+                //So we use 'matching' technique.
+                subproject.getTasks().matching(withName(POM_TASK)).all(t -> t.mustRunAfter(fetcher));
+
+                //Pom task needs data from fetcher hence 'mustRunAfter' above.
+                //We don't use 'dependsOn' because we want the fetcher to be included only when we are publishing to Bintray
+                Task upload = subproject.getTasks().getByName(ShipkitBintrayPlugin.BINTRAY_UPLOAD_TASK);
+                upload.dependsOn(fetcher);
             }));
     }
 }

--- a/subprojects/shipkit/src/test/groovy/org/shipkit/internal/gradle/java/PomContributorsPluginTest.groovy
+++ b/subprojects/shipkit/src/test/groovy/org/shipkit/internal/gradle/java/PomContributorsPluginTest.groovy
@@ -1,0 +1,15 @@
+package org.shipkit.internal.gradle.java
+
+import org.gradle.testfixtures.ProjectBuilder
+import spock.lang.Specification
+
+class PomContributorsPluginTest extends Specification {
+
+    def project = new ProjectBuilder().build()
+
+    def "applies"() {
+        expect:
+        project.plugins.apply(PomContributorsPlugin)
+        project.plugins.apply(JavaBintrayPlugin)
+    }
+}


### PR DESCRIPTION
Avoid fetching contributors for normal builds, keep them for release builds

Fixes #345

Tested on example project - fetching contributors only happens when 'bintrayUpload' task is included