### PR TITLE
Added 'contributorTestRelease' task

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,13 +21,13 @@ Be pragmatic, all rules have exceptions given good reasons.
 1. Clone shipkit repo, make your changes, then run ```./gradlew fastInstall```
 This will install the artifacts in local maven repository for easy sharing.
 Notice the version you're building in the build output.
-2. Clone shipkit-example repo and ensure that 'shipkit-example/build.gradle' file uses the correct version of shipkit (declared at the top of build.gradle).
+2. Clone [shipkit-example](https://github.com/mockito/shipkit-example) repo
+and ensure that 'shipkit-example/build.gradle' file uses the correct version of shipkit (declared at the top of build.gradle).
 It should use the same version that was built in the previous step.
 3. Basic testing for contributors:
  - Smoke test (no tasks are run): ```./gradlew performRelease -m```
  - Test most things, without actually making any code pushes/publications:
- ```./gradlew releaseNeeded performRelease releaseCleanUp -x gitPush -x bintrayUpload -PdryRun```
- TODO: add "contributorTestRelease" task that wraps above similar to "testRelease" task.
+ ```./gradlew contributorTestRelease```
  - Release notes content: ```./gradlew updateReleaseNotes -Ppreview```
     To generate sizable release notes content, before running 'updateReleaseNotes' you can downgrade the 'previousVersion' in 'version.properties'.
     Release notes are generated from 'previousVersion' to current 'version' as declared in 'version.properties' file.
@@ -40,6 +40,11 @@ It should use the same version that was built in the previous step.
  For example, it will switch git user.
  Remember to switch it back when you finished.
  - Clone "mockito/mockito" repository and make testing with a proper project :)
+5. ```testRelease``` vs. ```contributorTestRelease``` - the latter excludes tasks that need secret keys
+and is useful for testing on a project where you don't have permissions to. Examples:
+If you are contributor out of the core team, use ```contributorTestRelease``` with shipkit-example.
+If you are core team member, use ```testRelease``` with shipkit-example.
+If you are contributor, you can use ```testRelease``` with your own project that you have permissions to.
 
 ### Troubleshooting releases
 

--- a/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/release/GradlePortalReleasePlugin.java
+++ b/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/release/GradlePortalReleasePlugin.java
@@ -28,6 +28,10 @@ import org.shipkit.internal.gradle.plugin.PluginValidationPlugin;
  *     <li>{@link GradlePortalPublishPlugin}</li>
  *     <li>{@link PluginDiscoveryPlugin}</li>
  *     <li>{@link PluginValidationPlugin}</li>
+ *     <li>Configures {@link ReleasePlugin#CONTRIBUTOR_TEST_RELEASE_TASK} task to exclude
+ *       {@link GradlePortalPublishPlugin#PUBLISH_PLUGINS_TASK} task from contributor test.
+ *       This way, contributors can test release logic without having secret keys.
+ *     </li></li>
  * </ul>
  *
  * Behavior:
@@ -39,7 +43,7 @@ public class GradlePortalReleasePlugin implements Plugin<Project> {
 
     @Override
     public void apply(final Project project) {
-        project.getPlugins().apply(ReleasePlugin.class);
+        ReleasePlugin releasePlugin = project.getPlugins().apply(ReleasePlugin.class);
         final ShipkitConfiguration conf = project.getPlugins().apply(ShipkitConfigurationPlugin.class).getConfiguration();
         final Task performRelease = project.getTasks().getByName(ReleasePlugin.PERFORM_RELEASE_TASK);
         final Task gitPush = project.getTasks().getByName(GitPlugin.GIT_PUSH_TASK);
@@ -63,6 +67,9 @@ public class GradlePortalReleasePlugin implements Plugin<Project> {
 
             UpdateReleaseNotesTask updateNotes = (UpdateReleaseNotesTask) project.getTasks().getByName(ReleaseNotesPlugin.UPDATE_NOTES_TASK);
             updateNotes.setPublicationRepository(conf.getReleaseNotes().getPublicationRepository());
+
+            //when contributors are testing, we need to avoid publish task because it requires secret keys
+            releasePlugin.excludeFromContributorTest(GradlePortalPublishPlugin.PUBLISH_PLUGINS_TASK);
         }));
     }
 }

--- a/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/release/ReleasePlugin.java
+++ b/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/release/ReleasePlugin.java
@@ -1,26 +1,22 @@
 package org.shipkit.internal.gradle.release;
 
-import org.gradle.api.Action;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
-import org.gradle.api.Task;
 import org.shipkit.gradle.exec.ShipkitExecTask;
 import org.shipkit.gradle.git.IdentifyGitBranchTask;
 import org.shipkit.gradle.notes.UpdateReleaseNotesTask;
 import org.shipkit.internal.gradle.git.GitBranchPlugin;
+import org.shipkit.internal.gradle.git.GitPlugin;
 import org.shipkit.internal.gradle.notes.ReleaseNotesPlugin;
 import org.shipkit.internal.gradle.notes.tasks.UpdateReleaseNotes;
-import org.shipkit.internal.gradle.version.VersioningPlugin;
-import org.shipkit.internal.gradle.git.GitPlugin;
 import org.shipkit.internal.gradle.util.TaskMaker;
 import org.shipkit.internal.gradle.util.TaskSuccessfulMessage;
-
-import java.util.function.Supplier;
+import org.shipkit.internal.gradle.version.VersioningPlugin;
 
 import static java.util.Arrays.asList;
+import static org.shipkit.internal.gradle.exec.ExecCommandFactory.execCommand;
 import static org.shipkit.internal.gradle.git.GitBranchPlugin.IDENTIFY_GIT_BRANCH;
 import static org.shipkit.internal.gradle.notes.ReleaseNotesPlugin.UPDATE_NOTES_TASK;
-import static org.shipkit.internal.gradle.exec.ExecCommandFactory.execCommand;
 import static org.shipkit.internal.gradle.release.ReleaseNeededPlugin.RELEASE_NEEDED;
 
 /**
@@ -55,49 +51,38 @@ public class ReleasePlugin implements Plugin<Project> {
         project.getPlugins().apply(ReleaseNeededPlugin.class);
         project.getPlugins().apply(GitBranchPlugin.class);
 
-        TaskMaker.task(project, PERFORM_RELEASE_TASK, new Action<Task>() {
-            public void execute(final Task t) {
-                t.setDescription("Performs release. " +
-                        "For testing, use: './gradlew testRelease'");
+        TaskMaker.task(project, PERFORM_RELEASE_TASK, t -> {
+            t.setDescription("Performs release. " +
+                    "For testing, use: './gradlew testRelease'");
 
-                t.dependsOn(VersioningPlugin.BUMP_VERSION_FILE_TASK, UPDATE_NOTES_TASK);
-                t.dependsOn(GitPlugin.PERFORM_GIT_PUSH_TASK);
-                t.dependsOn(IDENTIFY_GIT_BRANCH);
+            t.dependsOn(VersioningPlugin.BUMP_VERSION_FILE_TASK, UPDATE_NOTES_TASK);
+            t.dependsOn(GitPlugin.PERFORM_GIT_PUSH_TASK);
+            t.dependsOn(IDENTIFY_GIT_BRANCH);
 
-                final UpdateReleaseNotesTask updateReleaseNotesTask = (UpdateReleaseNotesTask) project.getTasks().getByName(UPDATE_NOTES_TASK);
-                final IdentifyGitBranchTask identifyGitBranchTask = (IdentifyGitBranchTask) project.getTasks().getByName(IDENTIFY_GIT_BRANCH);
+            final UpdateReleaseNotesTask updateReleaseNotesTask = (UpdateReleaseNotesTask) project.getTasks().getByName(UPDATE_NOTES_TASK);
+            final IdentifyGitBranchTask identifyGitBranchTask = (IdentifyGitBranchTask) project.getTasks().getByName(IDENTIFY_GIT_BRANCH);
 
-                TaskSuccessfulMessage.logOnSuccess(t, new Supplier<String>() {
-                    @Override
-                    public String get() {
-                        return "\n" +
-                            "Release shipped!\n" +
-                            "    - Publication repository: " + updateReleaseNotesTask.getPublicationRepository() + "\n" +
-                            "    - Release notes:          " + new UpdateReleaseNotes().getReleaseNotesUrl(updateReleaseNotesTask, identifyGitBranchTask.getBranch());
-                    }
-                });
-            }
+            TaskSuccessfulMessage.logOnSuccess(t, () -> "\n" +
+                "Release shipped!\n" +
+                "    - Publication repository: " + updateReleaseNotesTask.getPublicationRepository() + "\n" +
+                "    - Release notes:          " + new UpdateReleaseNotes().getReleaseNotesUrl(updateReleaseNotesTask, identifyGitBranchTask.getBranch()));
         });
 
-        TaskMaker.task(project, TEST_RELEASE_TASK, ShipkitExecTask.class, new Action<ShipkitExecTask>() {
-            public void execute(ShipkitExecTask t) {
-                t.setDescription("Tests the release procedure and cleans up. Safe to be invoked multiple times.");
-                //releaseCleanUp is already set up to run all his "subtasks" after performRelease is performed
-                //releaseNeeded is used here only to execute the code paths in the release needed task (extra testing)
-                t.getExecCommands().add(execCommand("Performing release in dry run, with cleanup",
-                    asList("./gradlew", RELEASE_NEEDED, PERFORM_RELEASE_TASK, RELEASE_CLEAN_UP_TASK, "-PdryRun")));
-                TaskSuccessfulMessage.logOnSuccess(t, "  The release test was successful. Ship it!");
-            }
+        TaskMaker.task(project, TEST_RELEASE_TASK, ShipkitExecTask.class, t -> {
+            t.setDescription("Tests the release procedure and cleans up. Safe to be invoked multiple times.");
+            //releaseCleanUp is already set up to run all his "subtasks" after performRelease is performed
+            //releaseNeeded is used here only to execute the code paths in the release needed task (extra testing)
+            t.getExecCommands().add(execCommand("Performing release in dry run, with cleanup",
+                asList("./gradlew", RELEASE_NEEDED, PERFORM_RELEASE_TASK, RELEASE_CLEAN_UP_TASK, "-PdryRun")));
+            TaskSuccessfulMessage.logOnSuccess(t, "  The release test was successful. Ship it!");
         });
 
-        TaskMaker.task(project, RELEASE_CLEAN_UP_TASK, new Action<Task>() {
-            public void execute(final Task t) {
-                t.setDescription("Cleans up the working copy, useful after dry running the release");
+        TaskMaker.task(project, RELEASE_CLEAN_UP_TASK, t -> {
+            t.setDescription("Cleans up the working copy, useful after dry running the release");
 
-                //using finalizedBy so that all clean up tasks run, even if one of them fails
-                t.finalizedBy(GitPlugin.PERFORM_GIT_COMMIT_CLEANUP_TASK);
-                t.finalizedBy(GitPlugin.TAG_CLEANUP_TASK);
-            }
+            //using finalizedBy so that all clean up tasks run, even if one of them fails
+            t.finalizedBy(GitPlugin.PERFORM_GIT_COMMIT_CLEANUP_TASK);
+            t.finalizedBy(GitPlugin.TAG_CLEANUP_TASK);
         });
     }
 }

--- a/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/release/ReleasePlugin.java
+++ b/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/release/ReleasePlugin.java
@@ -114,6 +114,10 @@ public class ReleasePlugin implements Plugin<Project> {
         return execCommand("Performing release in dry run, with cleanup", commandLine);
     }
 
+    /**
+     * Overwrites the contributorTestRelease task to exclude additional task.
+     * Needed so that contributors can test release logic without running tasks that require secret keys.
+     */
     public void excludeFromContributorTest(String taskName) {
         contributorTestRelease.setExecCommands(asList(contributorTestCommand("-x", taskName)));
     }

--- a/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/release/ReleasePlugin.java
+++ b/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/release/ReleasePlugin.java
@@ -65,7 +65,7 @@ public class ReleasePlugin implements Plugin<Project> {
 
         TaskMaker.task(project, PERFORM_RELEASE_TASK, t -> {
             t.setDescription("Performs release. " +
-                    "For testing, use: './gradlew testRelease'");
+                "For testing, use: './gradlew testRelease'");
 
             t.dependsOn(VersioningPlugin.BUMP_VERSION_FILE_TASK, UPDATE_NOTES_TASK);
             t.dependsOn(GitPlugin.PERFORM_GIT_PUSH_TASK);
@@ -107,7 +107,7 @@ public class ReleasePlugin implements Plugin<Project> {
         });
     }
 
-    private static ExecCommand contributorTestCommand(String ... additionalArguments) {
+    private static ExecCommand contributorTestCommand(String... additionalArguments) {
         List<String> commandLine = new LinkedList<>(asList(
             "./gradlew", RELEASE_NEEDED, PERFORM_RELEASE_TASK, RELEASE_CLEAN_UP_TASK, "-PdryRun", "-x", GitPlugin.GIT_PUSH_TASK));
         commandLine.addAll(asList(additionalArguments));

--- a/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/release/ReleasePlugin.java
+++ b/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/release/ReleasePlugin.java
@@ -38,11 +38,14 @@ import static org.shipkit.internal.gradle.release.ReleaseNeededPlugin.RELEASE_NE
  * Adds tasks:
  *
  * <ul>
- *     <li>performRelease</li>
- *     <li>testRelease</li>
- *     <li>releaseCleanUp</li>
+ *     <li>performRelease - ships new release: builds artifacts, generates release notes,
+ *       makes version bump commit, creates tag, pushes code, uploads to bintray. Ship it!</li>
+ *     <li>testRelease - performs release test in 'dryRun' mode. Useful to test the release logic
+ *       without actually performing externally visible commands like 'gitPush' or 'bintrayUpload'.</li>
+ *     <li>releaseCleanUp - cleans up after the release (removes version bump commit, removes the tag).
+ *       Useful in conjuction with 'testRelease' task.</li>
  *     <li>contributorTestRelease - runs a test of release logic excluding tasks that need secret keys
- *     (git push, bintray upload, etc). See also 'testRelease' task.</li>
+ *       (git push, bintray upload, etc). See also 'testRelease' task.</li>
  * </ul>
  */
 public class ReleasePlugin implements Plugin<Project> {

--- a/subprojects/shipkit/src/test/groovy/org/shipkit/internal/gradle/bintray/BintrayReleasePluginTest.groovy
+++ b/subprojects/shipkit/src/test/groovy/org/shipkit/internal/gradle/bintray/BintrayReleasePluginTest.groovy
@@ -1,8 +1,10 @@
 package org.shipkit.internal.gradle.bintray
 
+import org.shipkit.gradle.exec.ShipkitExecTask
 import org.shipkit.gradle.notes.UpdateReleaseNotesTask
 import org.shipkit.internal.gradle.java.JavaBintrayPlugin
 import org.shipkit.internal.gradle.notes.ReleaseNotesPlugin
+import org.shipkit.internal.gradle.release.ReleasePlugin
 import testutil.PluginSpecification
 
 class BintrayReleasePluginTest extends PluginSpecification {
@@ -37,5 +39,15 @@ class BintrayReleasePluginTest extends PluginSpecification {
         then:
         UpdateReleaseNotesTask updateNotes = project.tasks.getByName(ReleaseNotesPlugin.UPDATE_NOTES_TASK)
         updateNotes.publicationRepository == "https://bintray.com/some-org/some-repo/some-pkg/"
+    }
+
+    def "configures contributor test"() {
+        when:
+        project.plugins.apply(BintrayReleasePlugin)
+        project.plugins.apply(ShipkitBintrayPlugin)
+
+        then:
+        ShipkitExecTask contrib = project.tasks.getByName(ReleasePlugin.CONTRIBUTOR_TEST_RELEASE_TASK)
+        contrib.execCommands*.commandLine.toString() == "[[./gradlew, releaseNeeded, performRelease, releaseCleanUp, -PdryRun, -x, gitPush, -x, bintrayUpload]]"
     }
 }

--- a/subprojects/shipkit/src/test/groovy/org/shipkit/internal/gradle/release/GradlePortalReleasePluginTest.groovy
+++ b/subprojects/shipkit/src/test/groovy/org/shipkit/internal/gradle/release/GradlePortalReleasePluginTest.groovy
@@ -1,5 +1,6 @@
 package org.shipkit.internal.gradle.release
 
+import org.shipkit.gradle.exec.ShipkitExecTask
 import org.shipkit.gradle.notes.UpdateReleaseNotesTask
 import org.shipkit.internal.gradle.notes.ReleaseNotesPlugin
 import testutil.PluginSpecification
@@ -18,5 +19,8 @@ class GradlePortalReleasePluginTest extends PluginSpecification {
         then:
         UpdateReleaseNotesTask updateNotes = project.tasks.getByName(ReleaseNotesPlugin.UPDATE_NOTES_TASK)
         updateNotes.publicationRepository == "publicRepo"
+
+        ShipkitExecTask contrib = project.tasks.getByName(ReleasePlugin.CONTRIBUTOR_TEST_RELEASE_TASK)
+        contrib.execCommands*.commandLine.toString() == "[[./gradlew, releaseNeeded, performRelease, releaseCleanUp, -PdryRun, -x, gitPush, -x, publishPlugins]]"
     }
 }

--- a/subprojects/shipkit/src/test/groovy/org/shipkit/internal/gradle/release/ReleasePluginTest.groovy
+++ b/subprojects/shipkit/src/test/groovy/org/shipkit/internal/gradle/release/ReleasePluginTest.groovy
@@ -1,14 +1,19 @@
 package org.shipkit.internal.gradle.release
 
 import org.gradle.testfixtures.ProjectBuilder
+import org.shipkit.gradle.exec.ShipkitExecTask
 import spock.lang.Specification
 
 class ReleasePluginTest extends Specification {
 
     def project = new ProjectBuilder().build()
 
-    def "applies"() {
-        expect:
+    def "configures tasks"() {
+        when:
         project.plugins.apply(ReleasePlugin.class)
+
+        then:
+        ShipkitExecTask contrib = project.tasks.getByName(ReleasePlugin.CONTRIBUTOR_TEST_RELEASE_TASK)
+        contrib.execCommands*.commandLine.toString() == "[[./gradlew, releaseNeeded, performRelease, releaseCleanUp, -PdryRun, -x, gitPush]]"
     }
 }


### PR DESCRIPTION
New task streamlines testing of Shipkit for contributors.

Addresses most of #437

Tested with 'shipkit-example' - build log: https://gist.github.com/mockitoguy/4d602ab652527d9d8af5088a5fce7d00

I suggest to review commit-by-commit!

Also tested with 'shipkit' project itself - build log: https://gist.github.com/mockitoguy/ff823427f836d33ceb468feb5ecb2702