### PR TITLE
Inform the user if no files are uploaded to bintray

### DIFF
--- a/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/bintray/ShipkitBintrayPlugin.java
+++ b/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/bintray/ShipkitBintrayPlugin.java
@@ -56,7 +56,7 @@ public class ShipkitBintrayPlugin implements Plugin<Project> {
         });
 
         bintrayUpload.doLast(task -> {
-                BintrayUploadTask bintrayUploadTask = (BintrayUploadTask)task;
+                BintrayUploadTask bintrayUploadTask = (BintrayUploadTask) task;
                 if ((bintrayUploadTask.getFileUploads() == null || bintrayUploadTask.getFileUploads().length == 0) &&
                     (bintrayUploadTask.getConfigurationUploads() == null || bintrayUploadTask.getConfigurationUploads().length == 0) &&
                     (bintrayUploadTask.getPublicationUploads() == null || bintrayUploadTask.getPublicationUploads().length == 0)) {
@@ -64,7 +64,6 @@ public class ShipkitBintrayPlugin implements Plugin<Project> {
                 }
             }
         );
-
 
         final BintrayExtension.PackageConfig pkg = bintray.getPkg();
         pkg.setPublicDownloadNumbers(true);

--- a/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/bintray/ShipkitBintrayPlugin.java
+++ b/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/bintray/ShipkitBintrayPlugin.java
@@ -55,6 +55,17 @@ public class ShipkitBintrayPlugin implements Plugin<Project> {
             LOG.lifecycle(welcomeMessage);
         });
 
+        bintrayUpload.doLast(task -> {
+                BintrayUploadTask bintrayUploadTask = (BintrayUploadTask)task;
+                if ((bintrayUploadTask.getFileUploads() == null || bintrayUploadTask.getFileUploads().length == 0) &&
+                    (bintrayUploadTask.getConfigurationUploads() == null || bintrayUploadTask.getConfigurationUploads().length == 0) &&
+                    (bintrayUploadTask.getPublicationUploads() == null || bintrayUploadTask.getPublicationUploads().length == 0)) {
+                    LOG.lifecycle("No artifacts have been published to bintray!");
+                }
+            }
+        );
+
+
         final BintrayExtension.PackageConfig pkg = bintray.getPkg();
         pkg.setPublicDownloadNumbers(true);
         pkg.getVersion().getGpg().setSign(true);


### PR DESCRIPTION
fixes #686 

if no artifacts are uploaded the log now looks like:
```
  Building version '1.5.23'.
:bintrayUpload - publishing to Bintray
  - dry run: false, version: 1.0.0, Maven Central sync: false
  - user/org: shipkit-bot/shipkit.org, repository/package: shipkit/shipkit-example
No artifacts have been published to bintray!
```