### PR TITLE
cleanup buildscript

### DIFF
--- a/subprojects/shipkit/shipkit.gradle
+++ b/subprojects/shipkit/shipkit.gradle
@@ -85,6 +85,3 @@ task fastInstall { Task t ->
     }
     t.doLast { println "  Shipkit $version installed to local maven repo" }
 }
-
-//TODO delete below when PR is merged
-tasks.check.dependsOn validatePlugins


### PR DESCRIPTION
we can get rid of this configuration now since it is default starting from [shipkit 2.0.19](https://github.com/mockito/shipkit/blob/master/docs/release-notes.md#2019).