### PR TITLE
Support for building "-SNAPSHOT" artifacts

### DIFF
--- a/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/java/JavaPublishPlugin.java
+++ b/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/java/JavaPublishPlugin.java
@@ -24,12 +24,15 @@ import org.shipkit.internal.gradle.util.StringUtil;
  * <ul>
  *     <li>{@link JavaLibraryPlugin}</li>
  *     <li>maven-publish</li>
+ *     <li>{@link LocalSnapshotPlugin}</li>
  * </ul>
  *
  * Other features:
  * <ul>
  *     <li>Configures Gradle's publications to publish java library</li>
- *     <li>Adds build.dependsOn "publishToMavenLocal" to flesh out publication issues during the build</li>
+ *     <li>Configures 'build' taks to depend on 'publishJavaLibraryToMavenLocal'
+ *          to flesh out publication issues during the build</li>
+ *     <li>Configures 'snapshot' task to depend on 'publishJavaLibraryToMavenLocal'</li>
  * </ul>
  */
 public class JavaPublishPlugin implements Plugin<Project> {

--- a/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/java/JavaPublishPlugin.java
+++ b/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/java/JavaPublishPlugin.java
@@ -3,6 +3,7 @@ package org.shipkit.internal.gradle.java;
 import org.gradle.api.Action;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
+import org.gradle.api.Task;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
 import org.gradle.api.publish.PublicationContainer;
@@ -10,6 +11,7 @@ import org.gradle.api.publish.maven.MavenPublication;
 import org.gradle.api.tasks.bundling.Jar;
 import org.shipkit.gradle.configuration.ShipkitConfiguration;
 import org.shipkit.internal.gradle.configuration.ShipkitConfigurationPlugin;
+import org.shipkit.internal.gradle.snapshot.LocalSnapshotPlugin;
 import org.shipkit.internal.gradle.util.GradleDSLHelper;
 import org.shipkit.internal.gradle.util.PomCustomizer;
 import org.shipkit.internal.gradle.util.StringUtil;
@@ -41,6 +43,10 @@ public class JavaPublishPlugin implements Plugin<Project> {
     public void apply(final Project project) {
         final ShipkitConfiguration conf = project.getPlugins().apply(ShipkitConfigurationPlugin.class).getConfiguration();
 
+        project.getPlugins().apply(LocalSnapshotPlugin.class);
+        Task snapshotTask = project.getTasks().getByName(LocalSnapshotPlugin.SNAPSHOT_TASK);
+        snapshotTask.dependsOn(MAVEN_LOCAL_TASK);
+
         project.getPlugins().apply(JavaLibraryPlugin.class);
         project.getPlugins().apply("maven-publish");
 
@@ -63,6 +69,6 @@ public class JavaPublishPlugin implements Plugin<Project> {
         });
 
         //so that we flesh out problems with maven publication during the build process
-        project.getTasks().getByName("build").dependsOn("publishToMavenLocal");
+        project.getTasks().getByName("build").dependsOn(MAVEN_LOCAL_TASK);
     }
 }

--- a/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/plugin/GradlePortalPublishPlugin.java
+++ b/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/plugin/GradlePortalPublishPlugin.java
@@ -10,6 +10,7 @@ import org.shipkit.gradle.configuration.ShipkitConfiguration;
 import org.shipkit.internal.gradle.configuration.BasicValidator;
 import org.shipkit.internal.gradle.configuration.LazyConfiguration;
 import org.shipkit.internal.gradle.configuration.ShipkitConfigurationPlugin;
+import org.shipkit.internal.gradle.snapshot.LocalMavenSnapshotPlugin;
 import org.shipkit.internal.util.EnvVariables;
 
 import javax.inject.Inject;
@@ -59,6 +60,7 @@ public class GradlePortalPublishPlugin implements Plugin<Project> {
     @Override
     public void apply(final Project project) {
         final ShipkitConfiguration conf = project.getPlugins().apply(ShipkitConfigurationPlugin.class).getConfiguration();
+        project.getPlugins().apply(LocalMavenSnapshotPlugin.class);
 
         project.getPlugins().apply("com.gradle.plugin-publish");
         //Above also applies 'java' plugin

--- a/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/plugin/GradlePortalPublishPlugin.java
+++ b/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/plugin/GradlePortalPublishPlugin.java
@@ -26,6 +26,7 @@ import static org.shipkit.internal.gradle.util.StringUtil.isEmpty;
  * <ul>
  *     <li>{@link ShipkitConfigurationPlugin}</li>
  *     <li>com.gradle.plugin-publish</li>
+ *     <li>{@link LocalMavenSnapshotPlugin}</li>
  * </ul>
  *
  * <ul>

--- a/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/plugin/GradlePortalPublishPlugin.java
+++ b/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/plugin/GradlePortalPublishPlugin.java
@@ -5,7 +5,6 @@ import org.gradle.api.Project;
 import org.gradle.api.Task;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
-import org.gradle.api.specs.Spec;
 import org.shipkit.gradle.configuration.ShipkitConfiguration;
 import org.shipkit.internal.gradle.configuration.BasicValidator;
 import org.shipkit.internal.gradle.configuration.LazyConfiguration;
@@ -67,22 +66,16 @@ public class GradlePortalPublishPlugin implements Plugin<Project> {
 
         final Task publishPlugins = project.getTasks().getByName(PUBLISH_PLUGINS_TASK);
 
-        LazyConfiguration.lazyConfiguration(publishPlugins, new Runnable() {
-            @Override
-            public void run() {
-                authenticate(PUBLISH_KEY_PROPERTY, project, PUBLISH_KEY_ENV, envVariables);
-                authenticate(PUBLISH_SECRET_PROPERTY, project, PUBLISH_SECRET_ENV, envVariables);
-            }
+        LazyConfiguration.lazyConfiguration(publishPlugins, () -> {
+            authenticate(PUBLISH_KEY_PROPERTY, project, PUBLISH_KEY_ENV, envVariables);
+            authenticate(PUBLISH_SECRET_PROPERTY, project, PUBLISH_SECRET_ENV, envVariables);
         });
 
-        publishPlugins.onlyIf(new Spec<Task>() {
-            @Override
-            public boolean isSatisfiedBy(Task t) {
-                if (conf.isDryRun()) {
-                    LOG.info("dryRun is enabled, skipping '{}' using 'onlyIf'", t.getName());
-                }
-                return !conf.isDryRun();
+        publishPlugins.onlyIf(t -> {
+            if (conf.isDryRun()) {
+                LOG.info("dryRun is enabled, skipping '{}' using 'onlyIf'", t.getName());
             }
+            return !conf.isDryRun();
         });
     }
 

--- a/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/snapshot/LocalMavenSnapshotPlugin.java
+++ b/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/snapshot/LocalMavenSnapshotPlugin.java
@@ -1,0 +1,17 @@
+package org.shipkit.internal.gradle.snapshot;
+
+import org.gradle.api.Plugin;
+import org.gradle.api.Project;
+import org.gradle.api.Task;
+
+public class LocalMavenSnapshotPlugin implements Plugin<Project> {
+
+    @Override
+    public void apply(Project project) {
+        project.getPlugins().apply(LocalSnapshotPlugin.class);
+        project.getPlugins().apply("maven");
+
+        Task snapshotTask = project.getTasks().getByName(LocalSnapshotPlugin.SNAPSHOT_TASK);
+        snapshotTask.dependsOn("install");
+    }
+}

--- a/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/snapshot/LocalMavenSnapshotPlugin.java
+++ b/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/snapshot/LocalMavenSnapshotPlugin.java
@@ -4,6 +4,14 @@ import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.Task;
 
+/**
+ * <ul>
+ *     <li>Applies {@link LocalSnapshotPlugin} for 'snapshot' task</li>
+ *     <li>Applies Gradle's built-in 'maven' plugin for 'install' task</li>
+ *     <li>Makes 'snapshot' task depend on 'install' so that
+ *          you can run 'snapshot' to create locally installed snapshot</li>
+ * </ul>
+ */
 public class LocalMavenSnapshotPlugin implements Plugin<Project> {
 
     @Override

--- a/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/snapshot/LocalSnapshotPlugin.java
+++ b/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/snapshot/LocalSnapshotPlugin.java
@@ -12,12 +12,11 @@ public class LocalSnapshotPlugin implements Plugin<Project> {
 
     public static final String SNAPSHOT_TASK = "snapshot";
     private final static Logger LOG = Logging.getLogger(LocalSnapshotPlugin.class);
-    private SnapshotInfo info;
+    private boolean isSnapshot;
 
     @Override
     public void apply(Project project) {
-        boolean isSnapshot = project.getGradle().getStartParameter().getTaskNames().contains(SNAPSHOT_TASK);
-        info = new SnapshotInfo(isSnapshot);
+        this.isSnapshot = project.getGradle().getStartParameter().getTaskNames().contains(SNAPSHOT_TASK);
 
         TaskMaker.task(project, SNAPSHOT_TASK, t -> {
             t.setDescription("Depends on specific tasks that create local snapshot files.");
@@ -31,20 +30,7 @@ public class LocalSnapshotPlugin implements Plugin<Project> {
         });
     }
 
-    public SnapshotInfo getSnapshotInfo() {
-        return info;
-    }
-
-    public static class SnapshotInfo {
-
-        private final boolean isSnapshot;
-
-        SnapshotInfo(boolean isSnapshot) {
-            this.isSnapshot = isSnapshot;
-        }
-
-        public boolean isSnapshot() {
-            return isSnapshot;
-        }
+    public boolean isSnapshot() {
+        return isSnapshot;
     }
 }

--- a/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/snapshot/LocalSnapshotPlugin.java
+++ b/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/snapshot/LocalSnapshotPlugin.java
@@ -2,16 +2,49 @@ package org.shipkit.internal.gradle.snapshot;
 
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
+import org.gradle.api.logging.Logger;
+import org.gradle.api.logging.Logging;
 import org.shipkit.internal.gradle.util.TaskMaker;
+
+import static org.shipkit.internal.gradle.util.Specs.withName;
 
 public class LocalSnapshotPlugin implements Plugin<Project> {
 
     public static final String SNAPSHOT_TASK = "snapshot";
+    private final static Logger LOG = Logging.getLogger(LocalSnapshotPlugin.class);
+    private SnapshotInfo info;
 
     @Override
     public void apply(Project project) {
+        boolean isSnapshot = project.getGradle().getStartParameter().getTaskNames().contains(SNAPSHOT_TASK);
+        info = new SnapshotInfo(isSnapshot);
+
         TaskMaker.task(project, SNAPSHOT_TASK, t -> {
             t.setDescription("Depends on specific tasks that create local snapshot files.");
+
+            if (isSnapshot) {
+                project.getTasks().matching(withName("javadoc", "groovydoc")).all(doc -> {
+                    LOG.info("{} - disabled to speed up the 'snapshot' build", t.getPath());
+                    doc.setEnabled(false);
+                });
+            }
         });
+    }
+
+    public SnapshotInfo getSnapshotInfo() {
+        return info;
+    }
+
+    public static class SnapshotInfo {
+
+        private final boolean isSnapshot;
+
+        SnapshotInfo(boolean isSnapshot) {
+            this.isSnapshot = isSnapshot;
+        }
+
+        public boolean isSnapshot() {
+            return isSnapshot;
+        }
     }
 }

--- a/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/snapshot/LocalSnapshotPlugin.java
+++ b/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/snapshot/LocalSnapshotPlugin.java
@@ -1,5 +1,6 @@
 package org.shipkit.internal.gradle.snapshot;
 
+import org.gradle.StartParameter;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.logging.Logger;
@@ -8,6 +9,17 @@ import org.shipkit.internal.gradle.util.TaskMaker;
 
 import static org.shipkit.internal.gradle.util.Specs.withName;
 
+/**
+ * <ul>
+ *     <li>Adds 'snapshot' task with no behavior.
+ *          The task will depend on specific tasks that create and install local snapshot</li>
+ *     <li>Checks if 'snapshot' task is requested from command line
+ *          by inspecting {@link StartParameter#getTaskNames()}.
+ *          If requested then tasks with name 'javadoc' and 'groovydoc' are automatically disabled.
+ *          This way, we make building snapshots fast - we don't need docs for local testing of snapshot.
+ *          </li>
+ * </ul>
+ */
 public class LocalSnapshotPlugin implements Plugin<Project> {
 
     public static final String SNAPSHOT_TASK = "snapshot";

--- a/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/snapshot/LocalSnapshotPlugin.java
+++ b/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/snapshot/LocalSnapshotPlugin.java
@@ -1,0 +1,17 @@
+package org.shipkit.internal.gradle.snapshot;
+
+import org.gradle.api.Plugin;
+import org.gradle.api.Project;
+import org.shipkit.internal.gradle.util.TaskMaker;
+
+public class LocalSnapshotPlugin implements Plugin<Project> {
+
+    public static final String SNAPSHOT_TASK = "snapshot";
+
+    @Override
+    public void apply(Project project) {
+        TaskMaker.task(project, SNAPSHOT_TASK, t -> {
+            t.setDescription("Depends on specific tasks that create local snapshot files.");
+        });
+    }
+}

--- a/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/snapshot/LocalSnapshotPlugin.java
+++ b/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/snapshot/LocalSnapshotPlugin.java
@@ -27,6 +27,8 @@ public class LocalSnapshotPlugin implements Plugin<Project> {
 
     public static final String SNAPSHOT_TASK = "snapshot";
     private final static Logger LOG = Logging.getLogger(LocalSnapshotPlugin.class);
+
+    //Boolean wrapper for early failure if the isSnapshot getter is accessed before "apply()" method
     private Boolean isSnapshot;
 
     @Override

--- a/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/snapshot/LocalSnapshotPlugin.java
+++ b/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/snapshot/LocalSnapshotPlugin.java
@@ -3,9 +3,12 @@ package org.shipkit.internal.gradle.snapshot;
 import org.gradle.StartParameter;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
+import org.gradle.api.Task;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
 import org.shipkit.internal.gradle.util.TaskMaker;
+
+import java.util.List;
 
 import static org.shipkit.internal.gradle.util.Specs.withName;
 
@@ -24,22 +27,26 @@ public class LocalSnapshotPlugin implements Plugin<Project> {
 
     public static final String SNAPSHOT_TASK = "snapshot";
     private final static Logger LOG = Logging.getLogger(LocalSnapshotPlugin.class);
-    private boolean isSnapshot;
+    private Boolean isSnapshot;
 
     @Override
     public void apply(Project project) {
-        this.isSnapshot = project.getGradle().getStartParameter().getTaskNames().contains(SNAPSHOT_TASK);
-
-        TaskMaker.task(project, SNAPSHOT_TASK, t -> {
+        Task snapshotTask = TaskMaker.task(project, SNAPSHOT_TASK, t -> {
             t.setDescription("Depends on specific tasks that create local snapshot files.");
-
-            if (isSnapshot) {
-                project.getTasks().matching(withName("javadoc", "groovydoc")).all(doc -> {
-                    LOG.info("{} - disabled to speed up the 'snapshot' build", t.getPath());
-                    doc.setEnabled(false);
-                });
-            }
         });
+
+        this.isSnapshot = configureTask(snapshotTask, project.getGradle().getStartParameter().getTaskNames());
+    }
+
+    static boolean configureTask(Task snapshotTask, List<String> taskNames) {
+        boolean isSnapshot = taskNames.contains(SNAPSHOT_TASK);
+        if (isSnapshot) {
+            snapshotTask.getProject().getTasks().matching(withName("javadoc", "groovydoc")).all(doc -> {
+                LOG.info("{} - disabled to speed up the 'snapshot' build", snapshotTask.getPath());
+                doc.setEnabled(false);
+            });
+        }
+        return isSnapshot;
     }
 
     public boolean isSnapshot() {

--- a/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/util/Specs.java
+++ b/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/util/Specs.java
@@ -18,11 +18,6 @@ public class Specs {
      */
     public static Spec<Task> withName(final String ... names) {
         Set<String> namesSet = new HashSet<>(asList(names));
-        return new Spec<Task>() {
-            @Override
-            public boolean isSatisfiedBy(Task t) {
-                return namesSet.contains(t.getName());
-            }
-        };
+        return t -> namesSet.contains(t.getName());
     }
 }

--- a/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/util/Specs.java
+++ b/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/util/Specs.java
@@ -6,7 +6,7 @@ import org.gradle.api.specs.Spec;
 import java.util.HashSet;
 import java.util.Set;
 
-import static edu.emory.mathcs.backport.java.util.Arrays.asList;
+import static java.util.Arrays.asList;
 
 /**
  * Helper methods for Gradle Spec objects

--- a/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/util/Specs.java
+++ b/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/util/Specs.java
@@ -4,6 +4,10 @@ import org.gradle.api.Task;
 import org.gradle.api.specs.Spec;
 
 import java.io.File;
+import java.util.HashSet;
+import java.util.Set;
+
+import static edu.emory.mathcs.backport.java.util.Arrays.asList;
 
 /**
  * Helper methods for Gradle Spec objects
@@ -11,13 +15,14 @@ import java.io.File;
 public class Specs {
 
     /**
-     * Spec satisfied by task that matches provided name
+     * Task that matches any of the provided names
      */
-    public static Spec<Task> withName(final String name) {
+    public static Spec<Task> withName(final String ... names) {
+        Set<String> namesSet = new HashSet<>(asList(names));
         return new Spec<Task>() {
             @Override
             public boolean isSatisfiedBy(Task t) {
-                return t.getName().equals(name);
+                return namesSet.contains(t.getName());
             }
         };
     }

--- a/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/util/Specs.java
+++ b/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/util/Specs.java
@@ -3,7 +3,6 @@ package org.shipkit.internal.gradle.util;
 import org.gradle.api.Task;
 import org.gradle.api.specs.Spec;
 
-import java.io.File;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -23,18 +22,6 @@ public class Specs {
             @Override
             public boolean isSatisfiedBy(Task t) {
                 return namesSet.contains(t.getName());
-            }
-        };
-    }
-
-    /**
-     * Spec that checks if file exists using {@link File#isFile()} method.
-     */
-    public static Spec<Task> fileExists(final File file) {
-        return new Spec<Task>() {
-            @Override
-            public boolean isSatisfiedBy(Task task) {
-                return file.isFile();
             }
         };
     }

--- a/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/util/Specs.java
+++ b/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/util/Specs.java
@@ -16,7 +16,7 @@ public class Specs {
     /**
      * Task that matches any of the provided names
      */
-    public static Spec<Task> withName(final String ... names) {
+    public static Spec<Task> withName(final String... names) {
         Set<String> namesSet = new HashSet<>(asList(names));
         return t -> namesSet.contains(t.getName());
     }

--- a/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/version/VersionInfoFactory.java
+++ b/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/version/VersionInfoFactory.java
@@ -6,7 +6,6 @@ import org.shipkit.internal.version.Version;
 import org.shipkit.version.VersionInfo;
 
 import java.io.File;
-import java.util.List;
 
 class VersionInfoFactory {
 
@@ -15,8 +14,7 @@ class VersionInfoFactory {
     /**
      * Creates version info and logs the version we will be building
      */
-    VersionInfo createVersionInfo(File versionFile, Object version, List<String> taskNames) {
-        boolean isSnapshot = taskNames.contains("snapshot");
+    VersionInfo createVersionInfo(File versionFile, Object version, boolean isSnapshot) {
         VersionInfo info;
         if (versionFile.isFile()) {
             info = Version.versionInfo(versionFile, isSnapshot);

--- a/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/version/VersionInfoFactory.java
+++ b/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/version/VersionInfoFactory.java
@@ -1,0 +1,30 @@
+package org.shipkit.internal.gradle.version;
+
+import org.gradle.api.logging.Logger;
+import org.gradle.api.logging.Logging;
+import org.shipkit.internal.version.Version;
+import org.shipkit.version.VersionInfo;
+
+import java.io.File;
+import java.util.List;
+
+class VersionInfoFactory {
+
+    private final static Logger LOG = Logging.getLogger(VersionInfoFactory.class);
+
+    /**
+     * Creates version info and logs the version we will be building
+     */
+    VersionInfo createVersionInfo(File versionFile, Object version, List<String> taskNames) {
+        boolean isSnapshot = taskNames.contains("snapshot");
+        VersionInfo info;
+        if (versionFile.isFile()) {
+            info = Version.versionInfo(versionFile, isSnapshot);
+            LOG.lifecycle("  Building version '{}' (value loaded from '{}' file).", info.getVersion(), versionFile.getName());
+        } else {
+            info = Version.defaultVersionInfo(versionFile, version.toString(), isSnapshot);
+            LOG.lifecycle("  Building version '{}'.", info.getVersion());
+        }
+        return info;
+    }
+}

--- a/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/version/VersioningPlugin.java
+++ b/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/version/VersioningPlugin.java
@@ -51,7 +51,7 @@ public class VersioningPlugin implements Plugin<Project> {
         final File versionFile = project.file(VERSION_FILE_NAME);
 
         final VersionInfo versionInfo = new VersionInfoFactory().createVersionInfo(versionFile,
-            project.getVersion(), snapshotPlugin.getSnapshotInfo().isSnapshot());
+            project.getVersion(), snapshotPlugin.isSnapshot());
 
         project.getExtensions().add(VersionInfo.class.getName(), versionInfo);
         final String version = versionInfo.getVersion();

--- a/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/version/VersioningPlugin.java
+++ b/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/version/VersioningPlugin.java
@@ -18,8 +18,10 @@ import static java.util.Collections.singletonList;
  * The plugin adds following tasks:
  *
  * <ul>
- *     <li>bumpVersionFile - increments version in "version.properties" file,
+ *     <li>Adds task 'bumpVersionFile' - increments version in "version.properties" file,
  *     see {@link BumpVersionFileTask}</li>
+ *     <li>Applies {@link LocalSnapshotPlugin} for 'snapshot' task.
+ *     Will add "-SNAPSHOT" postfix to version in case 'snapshot' task is requested</li>
  * </ul>
  *
  * The plugin adds following extensions:

--- a/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/version/VersioningPlugin.java
+++ b/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/version/VersioningPlugin.java
@@ -1,6 +1,5 @@
 package org.shipkit.internal.gradle.version;
 
-import org.gradle.api.Action;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.logging.Logger;
@@ -65,20 +64,13 @@ public class VersioningPlugin implements Plugin<Project> {
         project.getExtensions().add(VersionInfo.class.getName(), versionInfo);
         final String version = versionInfo.getVersion();
 
-        project.allprojects(new Action<Project>() {
-            @Override
-            public void execute(Project project) {
-                project.setVersion(version);
-            }
-        });
+        project.allprojects(project1 -> project1.setVersion(version));
 
-        TaskMaker.task(project, BUMP_VERSION_FILE_TASK, BumpVersionFileTask.class, new Action<BumpVersionFileTask>() {
-            public void execute(final BumpVersionFileTask t) {
-                t.setDescription("Increments version number in " + versionFile.getName());
-                t.setVersionFile(versionFile);
-                String versionChangeMessage = formatVersionInformationInCommitMessage(version, versionInfo.getPreviousVersion());
-                GitPlugin.registerChangesForCommitIfApplied(singletonList(versionFile), versionChangeMessage, t);
-            }
+        TaskMaker.task(project, BUMP_VERSION_FILE_TASK, BumpVersionFileTask.class, t -> {
+            t.setDescription("Increments version number in " + versionFile.getName());
+            t.setVersionFile(versionFile);
+            String versionChangeMessage = formatVersionInformationInCommitMessage(version, versionInfo.getPreviousVersion());
+            GitPlugin.registerChangesForCommitIfApplied(singletonList(versionFile), versionChangeMessage, t);
         });
     }
 

--- a/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/version/VersioningPlugin.java
+++ b/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/version/VersioningPlugin.java
@@ -46,12 +46,12 @@ public class VersioningPlugin implements Plugin<Project> {
     public static final String BUMP_VERSION_FILE_TASK = "bumpVersionFile";
 
     public void apply(final Project project) {
-        project.getPlugins().apply(LocalSnapshotPlugin.class);
+        LocalSnapshotPlugin snapshotPlugin = project.getPlugins().apply(LocalSnapshotPlugin.class);
 
         final File versionFile = project.file(VERSION_FILE_NAME);
 
         final VersionInfo versionInfo = new VersionInfoFactory().createVersionInfo(versionFile,
-            project.getVersion(), project.getGradle().getStartParameter().getTaskNames());
+            project.getVersion(), snapshotPlugin.getSnapshotInfo().isSnapshot());
 
         project.getExtensions().add(VersionInfo.class.getName(), versionInfo);
         final String version = versionInfo.getVersion();

--- a/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/version/tasks/BumpVersionFile.java
+++ b/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/version/tasks/BumpVersionFile.java
@@ -11,7 +11,7 @@ public class BumpVersionFile {
     private final static Logger LOG = Logging.getLogger(BumpVersionFileTask.class);
 
     public void bumpVersionFile(BumpVersionFileTask task) {
-        VersionInfo versionInfo = Version.versionInfo(task.getVersionFile());
+        VersionInfo versionInfo = Version.versionInfo(task.getVersionFile(), false);
         VersionInfo newVersion = versionInfo.bumpVersion();
         String versionFile = task.getVersionFile().getName();
         LOG.lifecycle(versionMessage(newVersion, versionFile, task.getPath()));

--- a/subprojects/shipkit/src/main/groovy/org/shipkit/internal/version/DefaultVersionInfo.java
+++ b/subprojects/shipkit/src/main/groovy/org/shipkit/internal/version/DefaultVersionInfo.java
@@ -24,15 +24,27 @@ class DefaultVersionInfo implements VersionInfo {
         this.previousVersion = previousVersion;
     }
 
-    static DefaultVersionInfo fromFile(File versionFile) {
+    static DefaultVersionInfo fromFile(File versionFile, boolean isSnapshot) {
         Properties properties = PropertiesUtil.readProperties(versionFile);
         String version = properties.getProperty("version");
         if (version == null) {
             throw new IllegalArgumentException("Missing 'version=' properties in file: " + versionFile);
         }
+        version = maybeSnapshot(isSnapshot, version);
         String previousVersion = properties.getProperty("previousVersion");
         LinkedList<String> notableVersions = parseNotableVersions(properties);
         return new DefaultVersionInfo(versionFile, version, notableVersions, previousVersion);
+    }
+
+    static VersionInfo fromString(File versionFile, String projectVersion, boolean isSnapshot) {
+        return new DefaultVersionInfo(versionFile, maybeSnapshot(isSnapshot, projectVersion), new LinkedList<>(), null);
+    }
+
+    private static String maybeSnapshot(boolean isSnapshot, String version) {
+        if (isSnapshot && !version.endsWith("-SNAPSHOT")) {
+            version += "-SNAPSHOT";
+        }
+        return version;
     }
 
     private static LinkedList<String> parseNotableVersions(Properties properties) {

--- a/subprojects/shipkit/src/main/groovy/org/shipkit/internal/version/Version.java
+++ b/subprojects/shipkit/src/main/groovy/org/shipkit/internal/version/Version.java
@@ -3,7 +3,6 @@ package org.shipkit.internal.version;
 import org.shipkit.version.VersionInfo;
 
 import java.io.File;
-import java.util.LinkedList;
 
 /**
  * Version utilities
@@ -11,13 +10,16 @@ import java.util.LinkedList;
 public class Version {
 
     /**
-     * Provides instance of version information
+     * Provides instance of version information, version is loaded from file
      */
-    public static VersionInfo versionInfo(File versionFile) {
-        return DefaultVersionInfo.fromFile(versionFile);
+    public static VersionInfo versionInfo(File versionFile, boolean isSnapshot) {
+        return DefaultVersionInfo.fromFile(versionFile, isSnapshot);
     }
 
-    public static VersionInfo defaultVersionInfo(File versionFile, String projectVersion) {
-        return new DefaultVersionInfo(versionFile, projectVersion, new LinkedList<>(), null);
+    /**
+     * Provides instance of version information, version has to be passed explicitly
+     */
+    public static VersionInfo defaultVersionInfo(File versionFile, String projectVersion, boolean isSnapshot) {
+        return DefaultVersionInfo.fromString(versionFile, projectVersion, isSnapshot);
     }
 }

--- a/subprojects/shipkit/src/test/groovy/org/shipkit/gradle/ShipkitGradlePluginIntegTest.groovy
+++ b/subprojects/shipkit/src/test/groovy/org/shipkit/gradle/ShipkitGradlePluginIntegTest.groovy
@@ -25,8 +25,6 @@ class ShipkitGradlePluginIntegTest extends GradleSpecification {
             ext.'gradle.publish.secret' = 'secret'
         """
 
-        file("version.properties") << "version=1.0.0"
-
         expect:
         BuildResult result = pass("performRelease", "-m", "-s")
         skippedTaskPathsGradleBugWorkaround(result.output).join("\n") == """:bumpVersionFile

--- a/subprojects/shipkit/src/test/groovy/org/shipkit/gradle/ShipkitGradlePluginIntegTest.groovy
+++ b/subprojects/shipkit/src/test/groovy/org/shipkit/gradle/ShipkitGradlePluginIntegTest.groovy
@@ -10,8 +10,7 @@ class ShipkitGradlePluginIntegTest extends GradleSpecification {
         gradleVersion = gradleVersionToTest
 
         and:
-        projectDir.newFolder("gradle")
-        projectDir.newFile("gradle/shipkit.gradle") << """
+        file("gradle/shipkit.gradle") << """
             shipkit {
                 gitHub.readOnlyAuthToken = "foo"
                 gitHub.repository = "repo"
@@ -26,7 +25,7 @@ class ShipkitGradlePluginIntegTest extends GradleSpecification {
             ext.'gradle.publish.secret' = 'secret'
         """
 
-        projectDir.newFile("version.properties") << "version=1.0.0"
+        file("version.properties") << "version=1.0.0"
 
         expect:
         BuildResult result = pass("performRelease", "-m", "-s")

--- a/subprojects/shipkit/src/test/groovy/org/shipkit/gradle/ShipkitJavaIntegTest.groovy
+++ b/subprojects/shipkit/src/test/groovy/org/shipkit/gradle/ShipkitJavaIntegTest.groovy
@@ -22,8 +22,7 @@ class ShipkitJavaIntegTest extends GradleSpecification {
         gradleVersion = gradleVersionToTest
 
         and:
-        projectDir.newFolder("gradle")
-        projectDir.newFile("gradle/shipkit.gradle") << """
+        file("gradle/shipkit.gradle") << """
             shipkit {
                 gitHub.readOnlyAuthToken = "foo"
                 gitHub.writeAuthToken = "secret"
@@ -48,11 +47,9 @@ class ShipkitJavaIntegTest extends GradleSpecification {
         """
 
         settingsFile << "include 'api', 'impl'"
-        projectDir.newFile("version.properties") << "version=1.0.0"
-        projectDir.newFolder('api')
-        projectDir.newFolder('impl')
-        projectDir.newFile('api/build.gradle') << "apply plugin: 'java'"
-        projectDir.newFile('impl/build.gradle') << "apply plugin: 'java'"
+        file("version.properties") << "version=1.0.0"
+        file('api/build.gradle') << "apply plugin: 'java'"
+        file('impl/build.gradle') << "apply plugin: 'java'"
 
         expect:
         BuildResult result = pass("performRelease", "-m", "-s")

--- a/subprojects/shipkit/src/test/groovy/org/shipkit/gradle/ShipkitJavaIntegTest.groovy
+++ b/subprojects/shipkit/src/test/groovy/org/shipkit/gradle/ShipkitJavaIntegTest.groovy
@@ -42,12 +42,9 @@ class ShipkitJavaIntegTest extends GradleSpecification {
             }
         """
 
-        buildFile << """
-            apply plugin: "org.shipkit.java"
-        """
+        buildFile << "apply plugin: 'org.shipkit.java'"
 
         settingsFile << "include 'api', 'impl'"
-        file("version.properties") << "version=1.0.0"
         file('api/build.gradle') << "apply plugin: 'java'"
         file('impl/build.gradle') << "apply plugin: 'java'"
 

--- a/subprojects/shipkit/src/test/groovy/org/shipkit/gradle/SnapshotIntegTest.groovy
+++ b/subprojects/shipkit/src/test/groovy/org/shipkit/gradle/SnapshotIntegTest.groovy
@@ -1,20 +1,39 @@
 package org.shipkit.gradle
 
+import org.gradle.testkit.runner.TaskOutcome
 import testutil.GradleSpecification
 
 class SnapshotIntegTest extends GradleSpecification {
 
-    def "snapshot build"() {
+    def "snapshot build for java submodule"() {
         given:
-        settingsFile << "include 'foo-module'"
-        file("foo-module/build.gradle") << "apply plugin: 'java'"
+        settingsFile << "include 'java-module'"
         buildFile << "apply plugin: 'org.shipkit.java'"
         file("version.properties") << "version=1.0.0"
+
+        file("java-module/build.gradle")   << "apply plugin: 'java'"
 
         when:
         def result = pass("snapshot")
 
         then:
-        println result.output
+        result.task(":java-module:snapshot").outcome == TaskOutcome.SUCCESS
+        result.task(":snapshot").outcome == TaskOutcome.UP_TO_DATE //this is how Gradle reports tasks with no behavior
+    }
+
+    def "snapshot build for Gradle plugin project"() {
+        given:
+        settingsFile << "include 'gradle-plugin-module'"
+        buildFile << "apply plugin: 'org.shipkit.gradle-plugin'"
+        file("version.properties") << "version=1.0.0"
+
+        file("gradle-plugin-module/build.gradle")   << "apply plugin: 'com.gradle.plugin-publish'"
+
+        when:
+        def result = pass("snapshot")
+
+        then:
+        result.task(":gradle-plugin-module:snapshot").outcome == TaskOutcome.SUCCESS
+        result.task(":snapshot").outcome == TaskOutcome.UP_TO_DATE
     }
 }

--- a/subprojects/shipkit/src/test/groovy/org/shipkit/gradle/SnapshotIntegTest.groovy
+++ b/subprojects/shipkit/src/test/groovy/org/shipkit/gradle/SnapshotIntegTest.groovy
@@ -9,7 +9,6 @@ class SnapshotIntegTest extends GradleSpecification {
         given:
         settingsFile << "include 'java-module'"
         buildFile << "apply plugin: 'org.shipkit.java'"
-        file("version.properties") << "version=1.0.0"
 
         file("java-module/build.gradle")   << "apply plugin: 'java'"
 
@@ -25,7 +24,6 @@ class SnapshotIntegTest extends GradleSpecification {
         given:
         settingsFile << "include 'gradle-plugin-module'"
         buildFile << "apply plugin: 'org.shipkit.gradle-plugin'"
-        file("version.properties") << "version=1.0.0"
 
         file("gradle-plugin-module/build.gradle")   << "apply plugin: 'com.gradle.plugin-publish'"
 

--- a/subprojects/shipkit/src/test/groovy/org/shipkit/gradle/SnapshotIntegTest.groovy
+++ b/subprojects/shipkit/src/test/groovy/org/shipkit/gradle/SnapshotIntegTest.groovy
@@ -1,0 +1,20 @@
+package org.shipkit.gradle
+
+import testutil.GradleSpecification
+
+class SnapshotIntegTest extends GradleSpecification {
+
+    def "snapshot build"() {
+        given:
+        settingsFile << "include 'foo-module'"
+        file("foo-module/build.gradle") << "apply plugin: 'java'"
+        buildFile << "apply plugin: 'org.shipkit.java'"
+        file("version.properties") << "version=1.0.0"
+
+        when:
+        def result = pass("snapshot")
+
+        then:
+        println result.output
+    }
+}

--- a/subprojects/shipkit/src/test/groovy/org/shipkit/internal/gradle/init/InitPluginIntegTest.groovy
+++ b/subprojects/shipkit/src/test/groovy/org/shipkit/internal/gradle/init/InitPluginIntegTest.groovy
@@ -7,11 +7,10 @@ class InitPluginIntegTest extends GradleSpecification {
     def "runs initShipkit task in a project without any Shipkit configuration (using gradle version #gradleVersionToTest)"() {
         given:
         gradleVersion = gradleVersionToTest
+        assert file("version.properties").delete()
 
         and:
-        buildFile << """
-            apply plugin: "org.shipkit.java"
-        """
+        buildFile << "apply plugin: 'org.shipkit.java'"
 
         expect:
         pass("initShipkit", "-s")

--- a/subprojects/shipkit/src/test/groovy/org/shipkit/internal/gradle/snapshot/LocalSnapshotPluginTest.groovy
+++ b/subprojects/shipkit/src/test/groovy/org/shipkit/internal/gradle/snapshot/LocalSnapshotPluginTest.groovy
@@ -1,0 +1,27 @@
+package org.shipkit.internal.gradle.snapshot
+
+import testutil.PluginSpecification
+
+class LocalSnapshotPluginTest extends PluginSpecification {
+
+    def plugin = new LocalSnapshotPlugin()
+
+    def "configures for snapshot"() {
+        def task = project.tasks.create("task")
+        def javadoc = project.tasks.create("javadoc")
+        def groovydoc = project.tasks.create("groovydoc")
+
+        when:
+        def result = LocalSnapshotPlugin.configureTask(task, tasks)
+
+        then:
+        result == isSnapshot
+        javadoc.enabled == documentationEnabled
+        groovydoc.enabled == documentationEnabled
+
+        where:
+        tasks               | isSnapshot | documentationEnabled
+        ['build']           | false      | true
+        ['foo', 'snapshot'] | true       | false
+    }
+}

--- a/subprojects/shipkit/src/test/groovy/org/shipkit/internal/gradle/version/VersionInfoFactoryTest.groovy
+++ b/subprojects/shipkit/src/test/groovy/org/shipkit/internal/gradle/version/VersionInfoFactoryTest.groovy
@@ -15,10 +15,10 @@ class VersionInfoFactoryTest extends Specification {
         def missingFile = new File("does not exist")
 
         expect:
-        new VersionInfoFactory().createVersionInfo(versionFile, "foo", ["foo", "build"]).version == "1.0.0"
-        new VersionInfoFactory().createVersionInfo(versionFile, "foo", ["foo", "snapshot"]).version == "1.0.0-SNAPSHOT"
+        new VersionInfoFactory().createVersionInfo(versionFile, "foo", false).version == "1.0.0"
+        new VersionInfoFactory().createVersionInfo(versionFile, "foo", true).version == "1.0.0-SNAPSHOT"
 
-        new VersionInfoFactory().createVersionInfo(missingFile, "0.9", ["foo", "build"]).version == "0.9"
-        new VersionInfoFactory().createVersionInfo(missingFile, "0.9", ["foo", "snapshot"]).version == "0.9-SNAPSHOT"
+        new VersionInfoFactory().createVersionInfo(missingFile, "0.9", false).version == "0.9"
+        new VersionInfoFactory().createVersionInfo(missingFile, "0.9", true).version == "0.9-SNAPSHOT"
     }
 }

--- a/subprojects/shipkit/src/test/groovy/org/shipkit/internal/gradle/version/VersionInfoFactoryTest.groovy
+++ b/subprojects/shipkit/src/test/groovy/org/shipkit/internal/gradle/version/VersionInfoFactoryTest.groovy
@@ -1,0 +1,24 @@
+package org.shipkit.internal.gradle.version
+
+import org.junit.Rule
+import org.junit.rules.TemporaryFolder
+import spock.lang.Specification
+
+class VersionInfoFactoryTest extends Specification {
+
+    @Rule public TemporaryFolder tmp = new TemporaryFolder()
+
+    def "provides version object"() {
+        def versionFile = tmp.newFile()
+        versionFile << "version=1.0.0"
+
+        def missingFile = new File("does not exist")
+
+        expect:
+        new VersionInfoFactory().createVersionInfo(versionFile, "foo", ["foo", "build"]).version == "1.0.0"
+        new VersionInfoFactory().createVersionInfo(versionFile, "foo", ["foo", "snapshot"]).version == "1.0.0-SNAPSHOT"
+
+        new VersionInfoFactory().createVersionInfo(missingFile, "0.9", ["foo", "build"]).version == "0.9"
+        new VersionInfoFactory().createVersionInfo(missingFile, "0.9", ["foo", "snapshot"]).version == "0.9-SNAPSHOT"
+    }
+}

--- a/subprojects/shipkit/src/test/groovy/org/shipkit/internal/gradle/version/tasks/BumpVersionFileTest.groovy
+++ b/subprojects/shipkit/src/test/groovy/org/shipkit/internal/gradle/version/tasks/BumpVersionFileTest.groovy
@@ -12,7 +12,7 @@ class BumpVersionFileTest extends Specification {
     def "shows informative message"() {
         def versionFile = tmp.newFile("version.properties")
         versionFile << "version=1.0.1\npreviousVersion=1.0.0"
-        def info = Version.versionInfo(versionFile)
+        def info = Version.versionInfo(versionFile, false)
 
         expect:
         BumpVersionFile.versionMessage(info, "version.properties", ":bumpVersionFile") == """:bumpVersionFile - updated version file 'version.properties'

--- a/subprojects/shipkit/src/test/groovy/org/shipkit/internal/gradle/versionupgrade/CiUpgradeDownstreamPluginIntegTest.groovy
+++ b/subprojects/shipkit/src/test/groovy/org/shipkit/internal/gradle/versionupgrade/CiUpgradeDownstreamPluginIntegTest.groovy
@@ -10,8 +10,7 @@ class CiUpgradeDownstreamPluginIntegTest extends GradleSpecification {
         gradleVersion = gradleVersionToTest
 
         and:
-        projectDir.newFolder("gradle")
-        projectDir.newFile("gradle/shipkit.gradle") << """
+        file("gradle/shipkit.gradle") << """
             shipkit {
                 gitHub.url = "http://github.com"
                 gitHub.readOnlyAuthToken = "token"
@@ -27,7 +26,7 @@ class CiUpgradeDownstreamPluginIntegTest extends GradleSpecification {
             }
         """
 
-        projectDir.newFile("version.properties") << "version=1.0.0"
+        file("version.properties") << "version=1.0.0"
 
         expect:
         BuildResult result = pass("upgradeDownstream", "-m", "-s")

--- a/subprojects/shipkit/src/test/groovy/org/shipkit/internal/gradle/versionupgrade/CiUpgradeDownstreamPluginIntegTest.groovy
+++ b/subprojects/shipkit/src/test/groovy/org/shipkit/internal/gradle/versionupgrade/CiUpgradeDownstreamPluginIntegTest.groovy
@@ -26,8 +26,6 @@ class CiUpgradeDownstreamPluginIntegTest extends GradleSpecification {
             }
         """
 
-        file("version.properties") << "version=1.0.0"
-
         expect:
         BuildResult result = pass("upgradeDownstream", "-m", "-s")
         skippedTaskPathsGradleBugWorkaround(result.output).join("\n") == """:cloneWwilkMockito

--- a/subprojects/shipkit/src/test/groovy/org/shipkit/internal/gradle/versionupgrade/UpgradeDependencyPluginIntegTest.groovy
+++ b/subprojects/shipkit/src/test/groovy/org/shipkit/internal/gradle/versionupgrade/UpgradeDependencyPluginIntegTest.groovy
@@ -10,8 +10,7 @@ class UpgradeDependencyPluginIntegTest extends GradleSpecification {
         gradleVersion = gradleVersionToTest
 
         and:
-        projectDir.newFolder("gradle")
-        projectDir.newFile("gradle/shipkit.gradle") << """
+        file("gradle/shipkit.gradle") << """
             shipkit {
                 gitHub.writeAuthToken = "secret"
                 gitHub.repository = "repo"
@@ -22,7 +21,7 @@ class UpgradeDependencyPluginIntegTest extends GradleSpecification {
             apply plugin: "org.shipkit.upgrade-dependency"
         """
 
-        projectDir.newFile("version.properties") << "version=1.0.0"
+        file("version.properties") << "version=1.0.0"
 
         expect:
         BuildResult result = pass("performVersionUpgrade", "-Pdependency=org.shipkit:shipkit:0.2.3", "-m", "-s")

--- a/subprojects/shipkit/src/test/groovy/org/shipkit/internal/gradle/versionupgrade/UpgradeDependencyPluginIntegTest.groovy
+++ b/subprojects/shipkit/src/test/groovy/org/shipkit/internal/gradle/versionupgrade/UpgradeDependencyPluginIntegTest.groovy
@@ -21,8 +21,6 @@ class UpgradeDependencyPluginIntegTest extends GradleSpecification {
             apply plugin: "org.shipkit.upgrade-dependency"
         """
 
-        file("version.properties") << "version=1.0.0"
-
         expect:
         BuildResult result = pass("performVersionUpgrade", "-Pdependency=org.shipkit:shipkit:0.2.3", "-m", "-s")
         skippedTaskPathsGradleBugWorkaround(result.output).join("\n") == """:checkoutBaseBranch

--- a/subprojects/shipkit/src/test/groovy/org/shipkit/internal/gradle/versionupgrade/UpgradeDownstreamPluginIntegTest.groovy
+++ b/subprojects/shipkit/src/test/groovy/org/shipkit/internal/gradle/versionupgrade/UpgradeDownstreamPluginIntegTest.groovy
@@ -24,8 +24,6 @@ class UpgradeDownstreamPluginIntegTest extends GradleSpecification {
             }
         """
 
-        file("version.properties") << "version=1.0.0"
-
         expect:
         BuildResult result = pass("upgradeDownstream", "-m", "-s")
         skippedTaskPathsGradleBugWorkaround(result.output).join("\n") == """:cloneWwilkMockito

--- a/subprojects/shipkit/src/test/groovy/org/shipkit/internal/gradle/versionupgrade/UpgradeDownstreamPluginIntegTest.groovy
+++ b/subprojects/shipkit/src/test/groovy/org/shipkit/internal/gradle/versionupgrade/UpgradeDownstreamPluginIntegTest.groovy
@@ -10,8 +10,7 @@ class UpgradeDownstreamPluginIntegTest extends GradleSpecification {
         gradleVersion = gradleVersionToTest
 
         and:
-        projectDir.newFolder("gradle")
-        projectDir.newFile("gradle/shipkit.gradle") << """
+        file("gradle/shipkit.gradle") << """
             shipkit {
                 gitHub.url = "http://github.com"
             }
@@ -25,7 +24,7 @@ class UpgradeDownstreamPluginIntegTest extends GradleSpecification {
             }
         """
 
-        projectDir.newFile("version.properties") << "version=1.0.0"
+        file("version.properties") << "version=1.0.0"
 
         expect:
         BuildResult result = pass("upgradeDownstream", "-m", "-s")

--- a/subprojects/shipkit/src/test/groovy/org/shipkit/internal/version/DefaultVersionInfoTest.groovy
+++ b/subprojects/shipkit/src/test/groovy/org/shipkit/internal/version/DefaultVersionInfoTest.groovy
@@ -10,7 +10,7 @@ class DefaultVersionInfoTest extends Specification {
 
     def "does not support files without 'version' property"() {
         def f = dir.newFile() << "asdf"
-        when: DefaultVersionInfo.fromFile(f)
+        when: DefaultVersionInfo.fromFile(f, false)
         then: thrown(IllegalArgumentException)
     }
 
@@ -22,7 +22,7 @@ version=2.0.0
 x
 """
         expect:
-        DefaultVersionInfo.fromFile(f).version == "2.0.0"
+        DefaultVersionInfo.fromFile(f, false).version == "2.0.0"
     }
 
     def "increments version in file"() {
@@ -34,7 +34,7 @@ x
 """
 
         when:
-        def v = DefaultVersionInfo.fromFile(f)
+        def v = DefaultVersionInfo.fromFile(f, false)
         def v2 = v.bumpVersion(false)
 
         then:
@@ -53,7 +53,7 @@ previousVersion=2.0.0
         def f = dir.newFile() << "foo=bar\nversion=2.0.0"
 
         when:
-        DefaultVersionInfo.fromFile(f).bumpVersion(false)
+        DefaultVersionInfo.fromFile(f, false).bumpVersion(false)
 
         then:
         f.text == "foo=bar\nversion=2.0.1\npreviousVersion=2.0.0\n"
@@ -62,7 +62,7 @@ previousVersion=2.0.0
     def "knows notable versions"() {
         expect:
         def f = dir.newFile() << "version=1.0\n" + file
-        DefaultVersionInfo.fromFile(f).notableVersions.toString() == versions.toString()
+        DefaultVersionInfo.fromFile(f, false).notableVersions.toString() == versions.toString()
 
         where:
         file                                       | versions
@@ -78,7 +78,7 @@ notableVersions=1.0.0
 """
 
         when:
-        def v = DefaultVersionInfo.fromFile(f)
+        def v = DefaultVersionInfo.fromFile(f, false)
         v.bumpVersion(true)
 
         then:
@@ -94,7 +94,7 @@ previousVersion=2.0.0
         def f = dir.newFile() << "version=1.0.0"
 
         when:
-        def v = DefaultVersionInfo.fromFile(f)
+        def v = DefaultVersionInfo.fromFile(f, false)
         v.bumpVersion(true)
 
         then:
@@ -109,7 +109,7 @@ previousVersion=1.0.0
         def f = dir.newFile() << "version=1.0.0"
 
         when:
-        def v = DefaultVersionInfo.fromFile(f)
+        def v = DefaultVersionInfo.fromFile(f, false)
         v.bumpVersion(true)
 
         then:
@@ -127,7 +127,7 @@ previousVersion=1.0.1
 """
 
         when:
-        def beforeBump = DefaultVersionInfo.fromFile(f)
+        def beforeBump = DefaultVersionInfo.fromFile(f, false)
         def afterBump = beforeBump.bumpVersion(false)
 
         then:
@@ -145,7 +145,7 @@ version=1.0.0
 """
 
         when:
-        def beforeBump = DefaultVersionInfo.fromFile(f)
+        def beforeBump = DefaultVersionInfo.fromFile(f, false)
         def afterBump = beforeBump.bumpVersion(false)
 
         then:
@@ -155,5 +155,18 @@ previousVersion=1.0.0
 """
         beforeBump.previousVersion == null
         afterBump.previousVersion == "1.0.0"
+    }
+
+    def "creates snapshot version"() {
+        def f = dir.newFile() << """
+version=1.0.0
+"""
+
+        expect:
+        DefaultVersionInfo.fromFile(f, true).version == "1.0.0-SNAPSHOT"
+        DefaultVersionInfo.fromFile(f, false).version == "1.0.0"
+
+        DefaultVersionInfo.fromString(f, "0.9", true).version == "0.9-SNAPSHOT"
+        DefaultVersionInfo.fromString(f, "0.9", false).version == "0.9"
     }
 }

--- a/subprojects/shipkit/src/test/groovy/testutil/GradleSpecification.groovy
+++ b/subprojects/shipkit/src/test/groovy/testutil/GradleSpecification.groovy
@@ -50,6 +50,7 @@ abstract class GradleSpecification extends Specification implements GradleVersio
             shipkit {
                 gitHub.readOnlyAuthToken = "foo"
                 gitHub.repository = "repo"
+                releaseNotes.publicationRepository = "repo"
             }
         """
     }

--- a/subprojects/shipkit/src/test/groovy/testutil/GradleSpecification.groovy
+++ b/subprojects/shipkit/src/test/groovy/testutil/GradleSpecification.groovy
@@ -53,6 +53,8 @@ abstract class GradleSpecification extends Specification implements GradleVersio
                 releaseNotes.publicationRepository = "repo"
             }
         """
+
+        file("version.properties") << "version=1.0.0"
     }
 
     /**

--- a/subprojects/shipkit/src/test/groovy/testutil/GradleSpecification.groovy
+++ b/subprojects/shipkit/src/test/groovy/testutil/GradleSpecification.groovy
@@ -44,6 +44,14 @@ abstract class GradleSpecification extends Specification implements GradleVersio
         }
         """
         settingsFile = file('settings.gradle')
+
+        //Shipkit configuration with sensible defaults
+        file("gradle/shipkit.gradle") << """
+            shipkit {
+                gitHub.readOnlyAuthToken = "foo"
+                gitHub.repository = "repo"
+            }
+        """
     }
 
     /**


### PR DESCRIPTION
It is now possible to conveniently build and locally install snapshot artifacts using:

```
./gradlew snapshot
```

See all details in the [design spec](https://github.com/mockito/shipkit/blob/sf-snapshot/docs/design-specs/local-snapshots.md).

Tested with Mockito project:

```
~/mockito/src$ ./gradlew snapshot
Parallel execution is an incubating feature.

> Configure project : 
  Building version '2.18.1-SNAPSHOT' (value loaded from 'version.properties' file).

> Task :compileJava 
Note: Some input files use or override a deprecated API.
Note: Recompile with -Xlint:deprecation for details.
Note: Some input files use unchecked or unsafe operations.
Note: Recompile with -Xlint:unchecked for details.


BUILD SUCCESSFUL in 12s
56 actionable tasks: 51 executed, 5 up-to-date
```