### PR TITLE
Removed TODO we are not going to fix

### DIFF
--- a/subprojects/shipkit/src/main/groovy/org/shipkit/internal/exec/DefaultProcessRunner.java
+++ b/subprojects/shipkit/src/main/groovy/org/shipkit/internal/exec/DefaultProcessRunner.java
@@ -71,9 +71,6 @@ public class DefaultProcessRunner implements ProcessRunner {
             String output = mask(readFully(new BufferedReader(new InputStreamReader(process.getInputStream()))));
             storeOutputToFile(output);
 
-            //TODO add sanity timeout when we move to Java 1.7
-            // 1. we can do something like process.waitFor(15, TimeUnit.MINUTES)
-            // 2. first, we need to change the compatibility, push to Gradle 3.0, stop building with Java 1.6.
             process.waitFor();
 
             result = new ProcessResult(output, process);


### PR DESCRIPTION
We are fully reading the process output so there is no good way to set timeout other than spinning extra threads. That's too much complexity.