### PR TITLE
Improved coverage, added handy assertion method

### DIFF
--- a/subprojects/shipkit/src/test/groovy/org/shipkit/gradle/ShipkitGradlePluginIntegTest.groovy
+++ b/subprojects/shipkit/src/test/groovy/org/shipkit/gradle/ShipkitGradlePluginIntegTest.groovy
@@ -10,7 +10,7 @@ class ShipkitGradlePluginIntegTest extends GradleSpecification {
         gradleVersion = gradleVersionToTest
 
         and:
-        file("gradle/shipkit.gradle") << """
+        newFile("gradle/shipkit.gradle") << """
             shipkit {
                 gitHub.readOnlyAuthToken = "foo"
                 gitHub.repository = "repo"

--- a/subprojects/shipkit/src/test/groovy/org/shipkit/gradle/ShipkitJavaIntegTest.groovy
+++ b/subprojects/shipkit/src/test/groovy/org/shipkit/gradle/ShipkitJavaIntegTest.groovy
@@ -22,7 +22,7 @@ class ShipkitJavaIntegTest extends GradleSpecification {
         gradleVersion = gradleVersionToTest
 
         and:
-        file("gradle/shipkit.gradle") << """
+        newFile("gradle/shipkit.gradle") << """
             shipkit {
                 gitHub.readOnlyAuthToken = "foo"
                 gitHub.writeAuthToken = "secret"
@@ -45,8 +45,8 @@ class ShipkitJavaIntegTest extends GradleSpecification {
         buildFile << "apply plugin: 'org.shipkit.java'"
 
         settingsFile << "include 'api', 'impl'"
-        file('api/build.gradle') << "apply plugin: 'java'"
-        file('impl/build.gradle') << "apply plugin: 'java'"
+        newFile('api/build.gradle') << "apply plugin: 'java'"
+        newFile('impl/build.gradle') << "apply plugin: 'java'"
 
         expect:
         BuildResult result = pass("performRelease", "-m", "-s")

--- a/subprojects/shipkit/src/test/groovy/org/shipkit/gradle/SnapshotIntegTest.groovy
+++ b/subprojects/shipkit/src/test/groovy/org/shipkit/gradle/SnapshotIntegTest.groovy
@@ -10,7 +10,7 @@ class SnapshotIntegTest extends GradleSpecification {
         settingsFile << "include 'java-module'"
         buildFile << "apply plugin: 'org.shipkit.java'"
 
-        file("java-module/build.gradle")   << "apply plugin: 'java'"
+        newFile("java-module/build.gradle")   << "apply plugin: 'java'"
 
         when:
         def result = pass("snapshot")
@@ -25,7 +25,7 @@ class SnapshotIntegTest extends GradleSpecification {
         settingsFile << "include 'gradle-plugin-module'"
         buildFile << "apply plugin: 'org.shipkit.gradle-plugin'"
 
-        file("gradle-plugin-module/build.gradle")   << "apply plugin: 'com.gradle.plugin-publish'"
+        newFile("gradle-plugin-module/build.gradle")   << "apply plugin: 'com.gradle.plugin-publish'"
 
         when:
         def result = pass("snapshot")

--- a/subprojects/shipkit/src/test/groovy/org/shipkit/gradle/SnapshotIntegTest.groovy
+++ b/subprojects/shipkit/src/test/groovy/org/shipkit/gradle/SnapshotIntegTest.groovy
@@ -18,6 +18,7 @@ class SnapshotIntegTest extends GradleSpecification {
         then:
         result.task(":java-module:snapshot").outcome == TaskOutcome.SUCCESS
         result.task(":snapshot").outcome == TaskOutcome.UP_TO_DATE //this is how Gradle reports tasks with no behavior
+        file("java-module/build/libs/java-module-1.0.0-SNAPSHOT.jar").exists()
     }
 
     def "snapshot build for Gradle plugin project"() {
@@ -33,5 +34,6 @@ class SnapshotIntegTest extends GradleSpecification {
         then:
         result.task(":gradle-plugin-module:snapshot").outcome == TaskOutcome.SUCCESS
         result.task(":snapshot").outcome == TaskOutcome.UP_TO_DATE
+        file("gradle-plugin-module/build/libs/gradle-plugin-module-1.0.0-SNAPSHOT.jar").exists()
     }
 }

--- a/subprojects/shipkit/src/test/groovy/org/shipkit/gradle/SnapshotIntegTest.groovy
+++ b/subprojects/shipkit/src/test/groovy/org/shipkit/gradle/SnapshotIntegTest.groovy
@@ -18,7 +18,7 @@ class SnapshotIntegTest extends GradleSpecification {
         then:
         result.task(":java-module:snapshot").outcome == TaskOutcome.SUCCESS
         result.task(":snapshot").outcome == TaskOutcome.UP_TO_DATE //this is how Gradle reports tasks with no behavior
-        file("java-module/build/libs/java-module-1.0.0-SNAPSHOT.jar").exists()
+        assertFileExists("java-module/build/libs/java-module-1.0.0-SNAPSHOT.jar")
     }
 
     def "snapshot build for Gradle plugin project"() {
@@ -34,6 +34,6 @@ class SnapshotIntegTest extends GradleSpecification {
         then:
         result.task(":gradle-plugin-module:snapshot").outcome == TaskOutcome.SUCCESS
         result.task(":snapshot").outcome == TaskOutcome.UP_TO_DATE
-        file("gradle-plugin-module/build/libs/gradle-plugin-module-1.0.0-SNAPSHOT.jar").exists()
+        assertFileExists("gradle-plugin-module/build/libs/gradle-plugin-module-1.0.0-SNAPSHOT.jar")
     }
 }

--- a/subprojects/shipkit/src/test/groovy/org/shipkit/internal/gradle/init/InitPluginIntegTest.groovy
+++ b/subprojects/shipkit/src/test/groovy/org/shipkit/internal/gradle/init/InitPluginIntegTest.groovy
@@ -7,7 +7,7 @@ class InitPluginIntegTest extends GradleSpecification {
     def "runs initShipkit task in a project without any Shipkit configuration (using gradle version #gradleVersionToTest)"() {
         given:
         gradleVersion = gradleVersionToTest
-        assert !file("version.properties").exists()
+        assert file("version.properties").delete() //simulate clean state
 
         and:
         buildFile << "apply plugin: 'org.shipkit.java'"

--- a/subprojects/shipkit/src/test/groovy/org/shipkit/internal/gradle/init/InitPluginIntegTest.groovy
+++ b/subprojects/shipkit/src/test/groovy/org/shipkit/internal/gradle/init/InitPluginIntegTest.groovy
@@ -7,7 +7,7 @@ class InitPluginIntegTest extends GradleSpecification {
     def "runs initShipkit task in a project without any Shipkit configuration (using gradle version #gradleVersionToTest)"() {
         given:
         gradleVersion = gradleVersionToTest
-        assert file("version.properties").delete()
+        assert !file("version.properties").exists()
 
         and:
         buildFile << "apply plugin: 'org.shipkit.java'"

--- a/subprojects/shipkit/src/test/groovy/org/shipkit/internal/gradle/versionupgrade/CiUpgradeDownstreamPluginIntegTest.groovy
+++ b/subprojects/shipkit/src/test/groovy/org/shipkit/internal/gradle/versionupgrade/CiUpgradeDownstreamPluginIntegTest.groovy
@@ -10,7 +10,7 @@ class CiUpgradeDownstreamPluginIntegTest extends GradleSpecification {
         gradleVersion = gradleVersionToTest
 
         and:
-        file("gradle/shipkit.gradle") << """
+        newFile("gradle/shipkit.gradle") << """
             shipkit {
                 gitHub.url = "http://github.com"
                 gitHub.readOnlyAuthToken = "token"

--- a/subprojects/shipkit/src/test/groovy/org/shipkit/internal/gradle/versionupgrade/UpgradeDependencyPluginIntegTest.groovy
+++ b/subprojects/shipkit/src/test/groovy/org/shipkit/internal/gradle/versionupgrade/UpgradeDependencyPluginIntegTest.groovy
@@ -10,7 +10,7 @@ class UpgradeDependencyPluginIntegTest extends GradleSpecification {
         gradleVersion = gradleVersionToTest
 
         and:
-        file("gradle/shipkit.gradle") << """
+        newFile("gradle/shipkit.gradle") << """
             shipkit {
                 gitHub.writeAuthToken = "secret"
                 gitHub.repository = "repo"

--- a/subprojects/shipkit/src/test/groovy/org/shipkit/internal/gradle/versionupgrade/UpgradeDownstreamPluginIntegTest.groovy
+++ b/subprojects/shipkit/src/test/groovy/org/shipkit/internal/gradle/versionupgrade/UpgradeDownstreamPluginIntegTest.groovy
@@ -10,7 +10,7 @@ class UpgradeDownstreamPluginIntegTest extends GradleSpecification {
         gradleVersion = gradleVersionToTest
 
         and:
-        file("gradle/shipkit.gradle") << """
+        newFile("gradle/shipkit.gradle") << """
             shipkit {
                 gitHub.url = "http://github.com"
             }

--- a/subprojects/shipkit/src/test/groovy/testutil/GradleSpecification.groovy
+++ b/subprojects/shipkit/src/test/groovy/testutil/GradleSpecification.groovy
@@ -80,6 +80,22 @@ abstract class GradleSpecification extends Specification implements GradleVersio
     }
 
     /**
+     * Asserts if file exists, throwing informative exception if not.
+     * File path is evaluated as {@link #file(java.lang.String)}
+     */
+    protected void assertFileExists(String filePath) {
+        File file = file(filePath)
+        if (!file.exists()) {
+            if (!file.parentFile.exists()) {
+                throw new AssertionError("Directory does not exist: ${file.parentFile}")
+            } else {
+                throw new AssertionError("File does not exist: ${filePath}. All files in this dir:\n  " +
+                    file.parentFile.list().join("\n  "))
+            }
+        }
+    }
+
+    /**
      * Runs Gradle with given arguments, prints the build.gradle file to the standard output if the test fails
      */
     protected BuildResult pass(String... args) {

--- a/subprojects/shipkit/src/test/groovy/testutil/GradleSpecification.groovy
+++ b/subprojects/shipkit/src/test/groovy/testutil/GradleSpecification.groovy
@@ -27,7 +27,7 @@ abstract class GradleSpecification extends Specification implements GradleVersio
     private static final String RESOURCES_DIR = findResourcesDir(CLASSES_DIR)
 
     void setup() {
-        buildFile = file('build.gradle')
+        buildFile = newFile('build.gradle')
         buildFile << """buildscript {
             dependencies {
                 classpath files("${CLASSES_DIR}")
@@ -43,10 +43,11 @@ abstract class GradleSpecification extends Specification implements GradleVersio
             }
         }
         """
-        settingsFile = file('settings.gradle')
+        settingsFile = newFile('settings.gradle')
+        settingsFile << ""
 
         //Shipkit configuration with sensible defaults
-        file("gradle/shipkit.gradle") << """
+        newFile("gradle/shipkit.gradle") << """
             shipkit {
                 gitHub.readOnlyAuthToken = "foo"
                 gitHub.repository = "repo"
@@ -54,18 +55,27 @@ abstract class GradleSpecification extends Specification implements GradleVersio
             }
         """
 
-        file("version.properties") << "version=1.0.0"
+        newFile("version.properties") << "version=1.0.0"
     }
 
     /**
-     * Convenience method for creating files using path.
+     * Convenience method for creating new files using path.
      * You can pass "foo.txt" or "foo/bar/baz.txt".
      * Creates empty file (including parent dirs) and returns it.
      */
-    protected File file(String fileName) {
-        File file = new File(projectDir.root, fileName)
+    protected File newFile(String filePath) {
+        File file = file(filePath)
         file.getParentFile().mkdirs()
         file.createNewFile()
+        file
+    }
+
+    /**
+     * Convenience method for selecting files using path.
+     * You can pass "foo.txt" or "foo/bar/baz.txt".
+     */
+    protected File file(String filePath) {
+        File file = new File(projectDir.root, filePath)
         file
     }
 


### PR DESCRIPTION
- one test was missing an assertion
- renamed 'file' -> 'newFile' for clarity in the integration testing
- added new methods to test utilities useful for Gradle integration tests:
  - convenience 'assertFileExists' method
  - 2 methods: 'file' and 'newFile', the former one creates a File object for given path, the latter creates a new file.