### PR TITLE
Enable UnusedImports checkstyle rule again

### DIFF
--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -45,10 +45,7 @@
 
         <!-- Imports -->
         <module name="RedundantImport"/>
-        <!--
-        Disabled, does not work correctly when imports are used for classes referenced in javadocs.
         <module name="UnusedImports"/>
-        -->
 
         <!-- Naming -->
         <module name="ConstantName"/>

--- a/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/downstream/test/TestDownstreamTask.java
+++ b/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/downstream/test/TestDownstreamTask.java
@@ -5,7 +5,6 @@ import org.gradle.api.DefaultTask;
 import org.gradle.api.Task;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
-import org.shipkit.gradle.configuration.ShipkitConfiguration;
 import org.shipkit.internal.exec.SilentExecTask;
 import org.shipkit.internal.gradle.git.CloneGitRepositoryTaskFactory;
 import org.shipkit.internal.gradle.git.tasks.CloneGitRepositoryTask;

--- a/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/versionupgrade/FindOpenPullRequestTask.java
+++ b/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/versionupgrade/FindOpenPullRequestTask.java
@@ -4,7 +4,6 @@ import org.gradle.api.Action;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.Task;
 import org.gradle.api.tasks.TaskAction;
-import org.shipkit.gradle.configuration.ShipkitConfiguration;
 import org.shipkit.internal.gradle.git.domain.PullRequest;
 
 import java.io.IOException;

--- a/subprojects/shipkit/src/main/groovy/org/shipkit/internal/notes/contributors/github/Contributors.java
+++ b/subprojects/shipkit/src/main/groovy/org/shipkit/internal/notes/contributors/github/Contributors.java
@@ -1,6 +1,5 @@
 package org.shipkit.internal.notes.contributors.github;
 
-import org.shipkit.gradle.configuration.ShipkitConfiguration;
 import org.shipkit.internal.notes.contributors.ContributorsSerializer;
 
 import java.io.File;


### PR DESCRIPTION
The problem with unused import checks seems to be fixed in checkstyle 8.9