### PR TITLE
Incubating warning opt out 

### DIFF
--- a/subprojects/shipkit/src/main/groovy/org/shipkit/gradle/configuration/ShipkitConfiguration.java
+++ b/subprojects/shipkit/src/main/groovy/org/shipkit/gradle/configuration/ShipkitConfiguration.java
@@ -60,6 +60,8 @@ public class ShipkitConfiguration {
         team.setContributors(Collections.<String>emptyList());
         team.setDevelopers(Collections.<String>emptyList());
         team.setIgnoredContributors(Collections.<String>emptyList());
+
+        incubatingWarnings.setAcknowledged(Collections.emptyList());
     }
 
     ShipkitConfiguration(ShipkitConfigurationStore store) {
@@ -96,6 +98,10 @@ public class ShipkitConfiguration {
 
     public Team getTeam() {
         return team;
+    }
+
+    public IncubatingWarnings getIncubatingWarnings() {
+        return incubatingWarnings;
     }
 
     /**
@@ -443,13 +449,14 @@ public class ShipkitConfiguration {
     }
 
     /**
-     * Incubating warnings configuraction
+     * Incubating warnings configuration
      */
     public class IncubatingWarnings {
         private static final String INCUBATING_WARNINGS_ACKNOWLEDGED_KEY = "incubatingWarnings.acknowledged";
 
         /**
-         * Plugin names, which are in incubating state that will not have [INCUBATING] warning printed during runs
+         * Plugins/tasks names in incubating state that will not have [INCUBATING] warning printed during
+         * runs
          */
         public Collection<String> getAcknowledged() {
             return store.getCollection(INCUBATING_WARNINGS_ACKNOWLEDGED_KEY);

--- a/subprojects/shipkit/src/main/groovy/org/shipkit/gradle/configuration/ShipkitConfiguration.java
+++ b/subprojects/shipkit/src/main/groovy/org/shipkit/gradle/configuration/ShipkitConfiguration.java
@@ -28,6 +28,7 @@ public class ShipkitConfiguration {
     private final ReleaseNotes releaseNotes = new ReleaseNotes();
     private final Git git = new Git();
     private final Team team = new Team();
+    private final IncubatingWarnings incubatingWarnings = new IncubatingWarnings();
 
     private String previousReleaseVersion;
     private boolean dryRun;
@@ -438,6 +439,27 @@ public class ShipkitConfiguration {
          */
         public void setIgnoredContributors(Collection<String> ignoredContributors) {
             store.put("team.ignoredContributors", ignoredContributors);
+        }
+    }
+
+    /**
+     * Incubating warnings configuraction
+     */
+    public class IncubatingWarnings {
+        private static final String INCUBATING_WARNINGS_ACKNOWLEDGED_KEY = "incubatingWarnings.acknowledged";
+
+        /**
+         * Plugin names, which are in incubating state that will not have [INCUBATING] warning printed during runs
+         */
+        public Collection<String> getAcknowledged() {
+            return store.getCollection(INCUBATING_WARNINGS_ACKNOWLEDGED_KEY);
+        }
+
+        /**
+         * See {@link #getAcknowledged()}
+         */
+        public void setAcknowledged(Collection<String> acknowledged) {
+            store.put("incubatingWarnings.acknowledged", acknowledged);
         }
     }
 }

--- a/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/downstream/test/TestDownstreamPlugin.java
+++ b/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/downstream/test/TestDownstreamPlugin.java
@@ -18,6 +18,7 @@ import org.shipkit.internal.util.IncubatingWarningAcknowledged;
 
 import javax.inject.Inject;
 import java.io.File;
+import java.util.function.Predicate;
 
 /**
  * This plugin tests your library end-to-end (e2e) using downstream projects.
@@ -56,7 +57,7 @@ public class TestDownstreamPlugin implements Plugin<Project> {
         project.getPlugins().apply(UploadGistsPlugin.class);
         final ShipkitConfiguration conf = project.getPlugins().apply(ShipkitConfigurationPlugin.class).getConfiguration();
 
-        IncubatingWarningAcknowledged acknowledgedIncubatingWarningPredicate = new IncubatingWarningAcknowledged(conf);
+        Predicate acknowledgedIncubatingWarningPredicate = new IncubatingWarningAcknowledged(conf).negate();
         IncubatingWarning.warn("downstream-testing plugin", acknowledgedIncubatingWarningPredicate);
 
         final File logsDirectory = project.getBuildDir();

--- a/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/downstream/test/TestDownstreamPlugin.java
+++ b/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/downstream/test/TestDownstreamPlugin.java
@@ -14,6 +14,7 @@ import org.shipkit.internal.gradle.release.tasks.UploadGistsTask;
 import org.shipkit.internal.gradle.util.StringUtil;
 import org.shipkit.internal.gradle.util.TaskMaker;
 import org.shipkit.internal.util.IncubatingWarning;
+import org.shipkit.internal.util.IncubatingWarningAcknowledged;
 
 import javax.inject.Inject;
 import java.io.File;
@@ -52,10 +53,11 @@ public class TestDownstreamPlugin implements Plugin<Project> {
     }
 
     public void apply(final Project project) {
-        IncubatingWarning.warn("downstream-testing plugin");
-
         project.getPlugins().apply(UploadGistsPlugin.class);
         final ShipkitConfiguration conf = project.getPlugins().apply(ShipkitConfigurationPlugin.class).getConfiguration();
+
+        IncubatingWarningAcknowledged acknowledgedIncubatingWarningPredicate = new IncubatingWarningAcknowledged(conf);
+        IncubatingWarning.warn("downstream-testing plugin", acknowledgedIncubatingWarningPredicate);
 
         final File logsDirectory = project.getBuildDir();
 

--- a/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/versionupgrade/CreatePullRequest.java
+++ b/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/versionupgrade/CreatePullRequest.java
@@ -4,10 +4,13 @@ import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
 import org.json.simple.JsonObject;
 import org.json.simple.Jsoner;
+import org.shipkit.gradle.configuration.ShipkitConfiguration;
+import org.shipkit.internal.gradle.configuration.ShipkitConfigurationPlugin;
 import org.shipkit.internal.gradle.git.domain.PullRequest;
 import org.shipkit.internal.gradle.util.BranchUtils;
 import org.shipkit.internal.util.GitHubApi;
 import org.shipkit.internal.util.IncubatingWarning;
+import org.shipkit.internal.util.IncubatingWarningAcknowledged;
 
 import java.io.IOException;
 
@@ -29,7 +32,11 @@ class CreatePullRequest {
 
         String headBranch = BranchUtils.getHeadBranch(task.getForkRepositoryName(), task.getVersionBranch());
 
-        IncubatingWarning.warn("creating pull requests");
+        final ShipkitConfiguration configuration = task.getProject().getPlugins()
+            .apply(ShipkitConfigurationPlugin.class).getConfiguration();
+        IncubatingWarningAcknowledged acknowledgedIncubatingWarningPredicate = new IncubatingWarningAcknowledged(configuration);
+        IncubatingWarning.warn("creating pull requests", acknowledgedIncubatingWarningPredicate);
+
         LOG.lifecycle("  Creating a pull request of title '{}' in repository '{}' between base = '{}' and head = '{}'.",
             task.getPullRequestTitle(), task.getUpstreamRepositoryName(), task.getBaseBranch(), headBranch);
 

--- a/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/versionupgrade/CreatePullRequest.java
+++ b/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/versionupgrade/CreatePullRequest.java
@@ -13,6 +13,7 @@ import org.shipkit.internal.util.IncubatingWarning;
 import org.shipkit.internal.util.IncubatingWarningAcknowledged;
 
 import java.io.IOException;
+import java.util.function.Predicate;
 
 import static org.shipkit.internal.gradle.util.PullRequestUtils.toPullRequest;
 
@@ -34,7 +35,7 @@ class CreatePullRequest {
 
         final ShipkitConfiguration configuration = task.getProject().getPlugins()
             .apply(ShipkitConfigurationPlugin.class).getConfiguration();
-        IncubatingWarningAcknowledged acknowledgedIncubatingWarningPredicate = new IncubatingWarningAcknowledged(configuration);
+        Predicate acknowledgedIncubatingWarningPredicate = new IncubatingWarningAcknowledged(configuration).negate();
         IncubatingWarning.warn("creating pull requests", acknowledgedIncubatingWarningPredicate);
 
         LOG.lifecycle("  Creating a pull request of title '{}' in repository '{}' between base = '{}' and head = '{}'.",

--- a/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/versionupgrade/MergePullRequest.java
+++ b/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/versionupgrade/MergePullRequest.java
@@ -12,6 +12,8 @@ import org.shipkit.internal.util.GitHubStatusCheck;
 import org.shipkit.internal.util.IncubatingWarning;
 import org.shipkit.internal.util.IncubatingWarningAcknowledged;
 
+import java.util.function.Predicate;
+
 class MergePullRequest {
 
     private static final Logger LOG = Logging.getLogger(MergePullRequest.class);
@@ -31,7 +33,7 @@ class MergePullRequest {
 
         final ShipkitConfiguration configuration = task.getProject().getPlugins()
             .apply(ShipkitConfigurationPlugin.class).getConfiguration();
-        IncubatingWarningAcknowledged acknowledgedIncubatingWarningPredicate = new IncubatingWarningAcknowledged(configuration);
+        Predicate acknowledgedIncubatingWarningPredicate = new IncubatingWarningAcknowledged(configuration).negate();
         IncubatingWarning.warn("merge pull requests", acknowledgedIncubatingWarningPredicate);
 
         LOG.lifecycle("Waiting for status of a pull request in repository '{}' between base = '{}' and head = '{}'.", task.getUpstreamRepositoryName(), task.getBaseBranch(), headBranch);

--- a/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/versionupgrade/MergePullRequest.java
+++ b/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/versionupgrade/MergePullRequest.java
@@ -3,11 +3,14 @@ package org.shipkit.internal.gradle.versionupgrade;
 import org.gradle.api.GradleException;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
+import org.shipkit.gradle.configuration.ShipkitConfiguration;
+import org.shipkit.internal.gradle.configuration.ShipkitConfigurationPlugin;
 import org.shipkit.internal.gradle.git.domain.PullRequestStatus;
 import org.shipkit.internal.gradle.util.BranchUtils;
 import org.shipkit.internal.util.GitHubApi;
 import org.shipkit.internal.util.GitHubStatusCheck;
 import org.shipkit.internal.util.IncubatingWarning;
+import org.shipkit.internal.util.IncubatingWarningAcknowledged;
 
 class MergePullRequest {
 
@@ -26,7 +29,11 @@ class MergePullRequest {
 
         String headBranch = BranchUtils.getHeadBranch(task.getForkRepositoryName(), task.getVersionBranch());
 
-        IncubatingWarning.warn("merge pull requests");
+        final ShipkitConfiguration configuration = task.getProject().getPlugins()
+            .apply(ShipkitConfigurationPlugin.class).getConfiguration();
+        IncubatingWarningAcknowledged acknowledgedIncubatingWarningPredicate = new IncubatingWarningAcknowledged(configuration);
+        IncubatingWarning.warn("merge pull requests", acknowledgedIncubatingWarningPredicate);
+
         LOG.lifecycle("Waiting for status of a pull request in repository '{}' between base = '{}' and head = '{}'.", task.getUpstreamRepositoryName(), task.getBaseBranch(), headBranch);
 
         String url = task.getPullRequestUrl();

--- a/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/versionupgrade/UpgradeDependencyPlugin.java
+++ b/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/versionupgrade/UpgradeDependencyPlugin.java
@@ -25,6 +25,7 @@ import org.shipkit.internal.util.IncubatingWarning;
 import org.shipkit.internal.util.IncubatingWarningAcknowledged;
 
 import java.util.Optional;
+import java.util.function.Predicate;
 
 import static org.shipkit.internal.gradle.configuration.DeferredConfiguration.deferredConfiguration;
 import static org.shipkit.internal.gradle.exec.ExecCommandFactory.execCommand;
@@ -97,7 +98,7 @@ public class UpgradeDependencyPlugin implements Plugin<Project> {
         final GitOriginPlugin gitOriginPlugin = project.getRootProject().getPlugins().apply(GitOriginPlugin.class);
         project.getPlugins().apply(GitConfigPlugin.class);
 
-        IncubatingWarningAcknowledged acknowledgedIncubatingWarningPredicate = new IncubatingWarningAcknowledged(conf);
+        Predicate acknowledgedIncubatingWarningPredicate = new IncubatingWarningAcknowledged(conf).negate();
         IncubatingWarning.warn("upgrade-dependency plugin", acknowledgedIncubatingWarningPredicate);
 
         upgradeDependencyExtension = project.getExtensions().create("upgradeDependency", UpgradeDependencyExtension.class);

--- a/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/versionupgrade/UpgradeDependencyPlugin.java
+++ b/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/versionupgrade/UpgradeDependencyPlugin.java
@@ -22,6 +22,7 @@ import org.shipkit.internal.gradle.git.tasks.GitPullTask;
 import org.shipkit.internal.gradle.util.GitUtil;
 import org.shipkit.internal.gradle.util.TaskMaker;
 import org.shipkit.internal.util.IncubatingWarning;
+import org.shipkit.internal.util.IncubatingWarningAcknowledged;
 
 import java.util.Optional;
 
@@ -92,10 +93,12 @@ public class UpgradeDependencyPlugin implements Plugin<Project> {
 
     @Override
     public void apply(final Project project) {
-        IncubatingWarning.warn("upgrade-dependency plugin");
         final ShipkitConfiguration conf = project.getPlugins().apply(ShipkitConfigurationPlugin.class).getConfiguration();
         final GitOriginPlugin gitOriginPlugin = project.getRootProject().getPlugins().apply(GitOriginPlugin.class);
         project.getPlugins().apply(GitConfigPlugin.class);
+
+        IncubatingWarningAcknowledged acknowledgedIncubatingWarningPredicate = new IncubatingWarningAcknowledged(conf);
+        IncubatingWarning.warn("upgrade-dependency plugin", acknowledgedIncubatingWarningPredicate);
 
         upgradeDependencyExtension = project.getExtensions().create("upgradeDependency", UpgradeDependencyExtension.class);
 

--- a/subprojects/shipkit/src/main/groovy/org/shipkit/internal/util/IncubatingWarning.java
+++ b/subprojects/shipkit/src/main/groovy/org/shipkit/internal/util/IncubatingWarning.java
@@ -3,11 +3,15 @@ package org.shipkit.internal.util;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
 
+import java.util.function.Predicate;
+
 public class IncubatingWarning {
 
     private final static Logger LOG = Logging.getLogger(IncubatingWarning.class);
 
-    public static void warn(String feature) {
-        LOG.lifecycle("  [INCUBATING] {} is incubating and may change in any version.", feature);
+    public static void warn(String feature, Predicate<String> incubatingWarningAcknowledged) {
+        if (incubatingWarningAcknowledged.test(feature)) {
+            LOG.lifecycle("  [INCUBATING] {} is incubating and may change in any version.", feature);
+        }
     }
 }

--- a/subprojects/shipkit/src/main/groovy/org/shipkit/internal/util/IncubatingWarningAcknowledged.java
+++ b/subprojects/shipkit/src/main/groovy/org/shipkit/internal/util/IncubatingWarningAcknowledged.java
@@ -9,7 +9,7 @@ public class IncubatingWarningAcknowledged implements Predicate<String> {
 
     private Collection<String> acknowledgedWarnings;
 
-    private IncubatingWarningAcknowledged(ShipkitConfiguration configuration) {
+    public IncubatingWarningAcknowledged(ShipkitConfiguration configuration) {
         this.acknowledgedWarnings = configuration.getIncubatingWarnings().getAcknowledged();
     }
 

--- a/subprojects/shipkit/src/main/groovy/org/shipkit/internal/util/IncubatingWarningAcknowledged.java
+++ b/subprojects/shipkit/src/main/groovy/org/shipkit/internal/util/IncubatingWarningAcknowledged.java
@@ -15,6 +15,6 @@ public class IncubatingWarningAcknowledged implements Predicate<String> {
 
     @Override
     public boolean test(String test) {
-     return acknowledgedWarnings.stream().anyMatch((acknowledged) -> test.startsWith(acknowledged));
+        return acknowledgedWarnings.stream().anyMatch(acknowledged -> test.startsWith(acknowledged));
     }
 }

--- a/subprojects/shipkit/src/main/groovy/org/shipkit/internal/util/IncubatingWarningAcknowledged.java
+++ b/subprojects/shipkit/src/main/groovy/org/shipkit/internal/util/IncubatingWarningAcknowledged.java
@@ -1,0 +1,20 @@
+package org.shipkit.internal.util;
+
+import org.shipkit.gradle.configuration.ShipkitConfiguration;
+
+import java.util.Collection;
+import java.util.function.Predicate;
+
+public class IncubatingWarningAcknowledged implements Predicate<String> {
+
+    private Collection<String> acknowledgedWarnings;
+
+    private IncubatingWarningAcknowledged(ShipkitConfiguration configuration) {
+        this.acknowledgedWarnings = configuration.getIncubatingWarnings().getAcknowledged();
+    }
+
+    @Override
+    public boolean test(String test) {
+     return acknowledgedWarnings.stream().anyMatch((acknowledged) -> test.startsWith(acknowledged));
+    }
+}

--- a/subprojects/shipkit/src/test/groovy/org/shipkit/internal/util/IncubatingWarningAcknowledgedTest.groovy
+++ b/subprojects/shipkit/src/test/groovy/org/shipkit/internal/util/IncubatingWarningAcknowledgedTest.groovy
@@ -5,7 +5,7 @@ import spock.lang.Specification
 
 class IncubatingWarningAcknowledgedTest extends Specification {
 
-    def "name in acknowledged warnings"(){
+    def "name in acknowledged warnings"() {
         given:
         ShipkitConfiguration configuration = new ShipkitConfiguration()
         configuration.incubatingWarnings.acknowledged = Arrays.asList("test2", "test")
@@ -15,7 +15,7 @@ class IncubatingWarningAcknowledgedTest extends Specification {
         incubatingWarningAcknowledged.test("test")
     }
 
-    def "name starts with acknowledged entry in acknowledged warnings"(){
+    def "name starts with acknowledged entry in acknowledged warnings"() {
         given:
         ShipkitConfiguration configuration = new ShipkitConfiguration()
         configuration.incubatingWarnings.acknowledged = Arrays.asList("test2", "test")
@@ -25,7 +25,7 @@ class IncubatingWarningAcknowledgedTest extends Specification {
         incubatingWarningAcknowledged.test("test plugin")
     }
 
-    def "no acknowledged incubating warnings"(){
+    def "no acknowledged incubating warnings"() {
         given:
         ShipkitConfiguration configuration = new ShipkitConfiguration()
         configuration.incubatingWarnings.acknowledged = Collections.emptyList()
@@ -35,7 +35,7 @@ class IncubatingWarningAcknowledgedTest extends Specification {
         !incubatingWarningAcknowledged.test("test")
     }
 
-    def "name not in acknowledged warnings"(){
+    def "name not in acknowledged warnings"() {
         given:
         ShipkitConfiguration configuration = new ShipkitConfiguration()
         configuration.incubatingWarnings.acknowledged = Arrays.asList("not1", "not2")
@@ -45,7 +45,7 @@ class IncubatingWarningAcknowledgedTest extends Specification {
         !incubatingWarningAcknowledged.test("test")
     }
 
-    def "name with acknowledged text, but does not start with it"(){
+    def "name with acknowledged text, but does not start with it"() {
         given:
         ShipkitConfiguration configuration = new ShipkitConfiguration()
         configuration.incubatingWarnings.acknowledged = Arrays.asList("test", "ot")

--- a/subprojects/shipkit/src/test/groovy/org/shipkit/internal/util/IncubatingWarningAcknowledgedTest.groovy
+++ b/subprojects/shipkit/src/test/groovy/org/shipkit/internal/util/IncubatingWarningAcknowledgedTest.groovy
@@ -1,0 +1,57 @@
+package org.shipkit.internal.util
+
+import org.shipkit.gradle.configuration.ShipkitConfiguration
+import spock.lang.Specification
+
+class IncubatingWarningAcknowledgedTest extends Specification {
+
+    def "name in acknowledged warnings"(){
+        given:
+        ShipkitConfiguration configuration = new ShipkitConfiguration()
+        configuration.incubatingWarnings.acknowledged = Arrays.asList("test2", "test")
+        def incubatingWarningAcknowledged = new IncubatingWarningAcknowledged(configuration)
+
+        expect:
+        incubatingWarningAcknowledged.test("test")
+    }
+
+    def "name starts with acknowledged entry in acknowledged warnings"(){
+        given:
+        ShipkitConfiguration configuration = new ShipkitConfiguration()
+        configuration.incubatingWarnings.acknowledged = Arrays.asList("test2", "test")
+        def incubatingWarningAcknowledged = new IncubatingWarningAcknowledged(configuration)
+
+        expect:
+        incubatingWarningAcknowledged.test("test plugin")
+    }
+
+    def "no acknowledged incubating warnings"(){
+        given:
+        ShipkitConfiguration configuration = new ShipkitConfiguration()
+        configuration.incubatingWarnings.acknowledged = Collections.emptyList()
+        def incubatingWarningAcknowledged = new IncubatingWarningAcknowledged(configuration)
+
+        expect:
+        !incubatingWarningAcknowledged.test("test")
+    }
+
+    def "name not in acknowledged warnings"(){
+        given:
+        ShipkitConfiguration configuration = new ShipkitConfiguration()
+        configuration.incubatingWarnings.acknowledged = Arrays.asList("not1", "not2")
+        def incubatingWarningAcknowledged = new IncubatingWarningAcknowledged(configuration)
+
+        expect:
+        !incubatingWarningAcknowledged.test("test")
+    }
+
+    def "name with acknowledged text, but does not start with it"(){
+        given:
+        ShipkitConfiguration configuration = new ShipkitConfiguration()
+        configuration.incubatingWarnings.acknowledged = Arrays.asList("test", "ot")
+        def incubatingWarningAcknowledged = new IncubatingWarningAcknowledged(configuration)
+
+        expect:
+        !incubatingWarningAcknowledged.test("nottest")
+    }
+}


### PR DESCRIPTION
As suggested by @mockitoguy in #394. I have added logic to acknowledge incubating warnings. This will result in not printing such warning. 

May be configured by:

```
shipkit { 
  incubatingWarnings.acknowlege = ['name', 'another name']
}
```