### PR TITLE
Make shipkit gradle 4.8 ready 

### DIFF
--- a/subprojects/shipkit/shipkit.gradle
+++ b/subprojects/shipkit/shipkit.gradle
@@ -20,7 +20,7 @@ dependencies {
     compile gradleApi()
 
     compile "com.github.cliftonlabs:json-simple:2.1.2"
-    compile 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.1'
+    compile 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.3'
     compile "com.gradle.publish:plugin-publish-plugin:0.9.7"
     compile 'com.googlecode.java-diff-utils:diffutils:1.3.0'
 

--- a/subprojects/shipkit/shipkit.gradle
+++ b/subprojects/shipkit/shipkit.gradle
@@ -20,7 +20,7 @@ dependencies {
     compile gradleApi()
 
     compile "com.github.cliftonlabs:json-simple:2.1.2"
-    compile 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.0'
+    compile 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.1'
     compile "com.gradle.publish:plugin-publish-plugin:0.9.7"
     compile 'com.googlecode.java-diff-utils:diffutils:1.3.0'
 

--- a/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/bintray/ShipkitBintrayPlugin.java
+++ b/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/bintray/ShipkitBintrayPlugin.java
@@ -1,8 +1,8 @@
 package org.shipkit.internal.gradle.bintray;
 
-import com.jfrog.bintray.gradle.Artifact;
 import com.jfrog.bintray.gradle.BintrayExtension;
-import com.jfrog.bintray.gradle.BintrayUploadTask;
+import com.jfrog.bintray.gradle.tasks.BintrayUploadTask;
+import com.jfrog.bintray.gradle.tasks.entities.Artifact;
 import org.gradle.api.GradleException;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;

--- a/subprojects/shipkit/src/test/groovy/org/shipkit/gradle/ShipkitJavaIntegTest.groovy
+++ b/subprojects/shipkit/src/test/groovy/org/shipkit/gradle/ShipkitJavaIntegTest.groovy
@@ -82,6 +82,7 @@ class ShipkitJavaIntegTest extends GradleSpecification {
 :performGitPush
 :api:bintrayUpload
 :impl:bintrayUpload
+:bintrayPublish
 :performRelease"""
 
         where:

--- a/subprojects/shipkit/src/test/groovy/testutil/GradleSpecification.groovy
+++ b/subprojects/shipkit/src/test/groovy/testutil/GradleSpecification.groovy
@@ -33,8 +33,8 @@ abstract class GradleSpecification extends Specification implements GradleVersio
                 classpath files("${CLASSES_DIR}")
                 classpath files("${RESOURCES_DIR}")
                 classpath "com.github.cliftonlabs:json-simple:2.1.2"
-                classpath "com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.1"
-                classpath "com.gradle.publish:plugin-publish-plugin:0.9.6"
+                classpath "com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.3"
+                classpath "com.gradle.publish:plugin-publish-plugin:0.9.7"
             }
 
             repositories {

--- a/subprojects/shipkit/src/test/groovy/testutil/GradleSpecification.groovy
+++ b/subprojects/shipkit/src/test/groovy/testutil/GradleSpecification.groovy
@@ -33,7 +33,7 @@ abstract class GradleSpecification extends Specification implements GradleVersio
                 classpath files("${CLASSES_DIR}")
                 classpath files("${RESOURCES_DIR}")
                 classpath "com.github.cliftonlabs:json-simple:2.1.2"
-                classpath "com.jfrog.bintray.gradle:gradle-bintray-plugin:1.7.3"
+                classpath "com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.1"
                 classpath "com.gradle.publish:plugin-publish-plugin:0.9.6"
             }
 


### PR DESCRIPTION
fixes #727

I did some local testing (up to now just dryRun=true tests) using Gradle 4.8.1 and the version of the plugin provided in this pr:

> 
> Gradle Bintray Plugin version: 1.8.3
> Uploading to https://api.bintray.com/content/shipkit/examples/basic/0.16.14/org/mockito/shipkit-example/impl/0.16.14/impl-0.16.14-sources.jar...
> (Dry run) Uploaded to 'https://api.bintray.com/content/shipkit/examples/basic/0.16.14/org/mockito/shipkit-example/impl/0.16.14/impl-0.16.14-sources.jar'.
> Uploading to https://api.bintray.com/content/shipkit/examples/basic/0.16.14/org/mockito/shipkit-example/impl/0.16.14/impl-0.16.14-javadoc.jar...
> (Dry run) Uploaded to 'https://api.bintray.com/content/shipkit/examples/basic/0.16.14/org/mockito/shipkit-example/impl/0.16.14/impl-0.16.14-javadoc.jar'.
> Uploading to https://api.bintray.com/content/shipkit/examples/basic/0.16.14/org/mockito/shipkit-example/impl/0.16.14/impl-0.16.14.jar...
> (Dry run) Uploaded to 'https://api.bintray.com/content/shipkit/examples/basic/0.16.14/org/mockito/shipkit-example/impl/0.16.14/impl-0.16.14.jar'.
> Uploading to https://api.bintray.com/content/shipkit/examples/basic/0.16.14/org/mockito/shipkit-example/impl/0.16.14/impl-0.16.14.pom...
> (Dry run) Uploaded to 'https://api.bintray.com/content/shipkit/examples/basic/0.16.14/org/mockito/shipkit-example/impl/0.16.14/impl-0.16.14.pom'.
> :impl:bintrayUpload (Thread[Task worker for ':' Thread 3,5,main]) completed. Took 0.012 secs.
> :bintrayUpload (Thread[Task worker for ':' Thread 3,5,main]) started.
> 
> \> Task :bintrayUpload SKIPPED
> Skipping task ':bintrayUpload' as task onlyIf is false.
> :bintrayUpload (Thread[Task worker for ':' Thread 3,5,main]) completed. Took 0.0 secs.
> :bintrayPublish (Thread[Task worker for ':' Thread 3,5,main]) started.
> 
> \> Task :bintrayPublish
> Task ':bintrayPublish' is not up-to-date because:
>   Task has not declared any outputs despite executing actions.
> (Dry run) Signed version 'shipkit/examples/basic/0.16.14'.
> (Dry run) Published version 'shipkit/examples/basic/0.16.14'.
> (Dry run) Signed version 'shipkit/examples/basic/0.16.14'.
> (Dry run) Published version 'shipkit/examples/basic/0.16.14'.
> :bintrayPublish (Thread[Task worker for ':' Thread 3,5,main]) completed. Took 0.0 secs.
> 

