### PR TITLE
Update plugin-publish-plugin (v0.9.10)

### DIFF
--- a/subprojects/shipkit/shipkit.gradle
+++ b/subprojects/shipkit/shipkit.gradle
@@ -21,7 +21,7 @@ dependencies {
 
     compile "com.github.cliftonlabs:json-simple:2.1.2"
     compile 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.3'
-    compile "com.gradle.publish:plugin-publish-plugin:0.9.7"
+    compile "com.gradle.publish:plugin-publish-plugin:0.9.10"
     compile 'com.googlecode.java-diff-utils:diffutils:1.3.0'
 
     testCompile("org.spockframework:spock-core:1.1-groovy-2.4") {

--- a/subprojects/shipkit/src/test/groovy/testutil/GradleSpecification.groovy
+++ b/subprojects/shipkit/src/test/groovy/testutil/GradleSpecification.groovy
@@ -34,7 +34,7 @@ abstract class GradleSpecification extends Specification implements GradleVersio
                 classpath files("${RESOURCES_DIR}")
                 classpath "com.github.cliftonlabs:json-simple:2.1.2"
                 classpath "com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.3"
-                classpath "com.gradle.publish:plugin-publish-plugin:0.9.7"
+                classpath "com.gradle.publish:plugin-publish-plugin:0.9.10"
             }
 
             repositories {


### PR DESCRIPTION
We are using a pretty old version of plugin-publish-plugin.
Let's update to a more recent one.
Release notes:
[v0.9.8](https://plugins.gradle.org/plugin/com.gradle.plugin-publish/0.9.8)
[v0.9.9](https://plugins.gradle.org/plugin/com.gradle.plugin-publish/0.9.9)
[v0.9.10](https://plugins.gradle.org/plugin/com.gradle.plugin-publish/0.9.10)