### PR TITLE
Update build-scan-plugin (v1.15.1) and gradle-animalsniffer-plugin (v…

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,8 +6,8 @@ buildscript {
     }
     dependencies {
         classpath 'org.shipkit:shipkit:2.0.28'
-        classpath 'com.gradle:build-scan-plugin:1.14'
-        classpath 'ru.vyarus:gradle-animalsniffer-plugin:1.4.3'
+        classpath 'com.gradle:build-scan-plugin:1.15.1'
+        classpath 'ru.vyarus:gradle-animalsniffer-plugin:1.4.4'
     }
 }
 


### PR DESCRIPTION
…1.4.4)

Release notes:
-  build scan plugin [v1.15](https://plugins.gradle.org/plugin/com.gradle.build-scan/1.15) and [v1.15.1](https://plugins.gradle.org/plugin/com.gradle.build-scan/1.15.1) 
- gradle-animalsniffer-plugin [v1.4.4](https://github.com/xvik/gradle-animalsniffer-plugin/releases/tag/1.4.4)