### PR TITLE
Windows compatiblity

### DIFF
--- a/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/downstream/test/TestDownstreamTask.java
+++ b/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/downstream/test/TestDownstreamTask.java
@@ -9,6 +9,7 @@ import org.shipkit.internal.exec.SilentExecTask;
 import org.shipkit.internal.gradle.git.CloneGitRepositoryTaskFactory;
 import org.shipkit.internal.gradle.git.tasks.CloneGitRepositoryTask;
 import org.shipkit.internal.gradle.release.tasks.UploadGistsTask;
+import org.shipkit.internal.gradle.util.GradleWrapper;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -16,7 +17,8 @@ import java.util.List;
 
 import static java.util.Arrays.asList;
 import static org.shipkit.internal.gradle.util.StringUtil.capitalize;
-import static org.shipkit.internal.util.RepositoryNameUtil.*;
+import static org.shipkit.internal.util.RepositoryNameUtil.extractRepoNameFromGitHubUrl;
+import static org.shipkit.internal.util.RepositoryNameUtil.repositoryNameToCamelCase;
 
 /**
  * Aggregates all downstream-test-related tasks. It can be configured to run e2e tests on provided repositories.
@@ -69,7 +71,7 @@ public class TestDownstreamTask extends DefaultTask {
         dependsOn(run);
 
         // Using Gradle's composite builds ("--include-build") so that we're picking up current version of tools
-        run.setCommand(asList("./gradlew",
+        run.setCommand(asList(GradleWrapper.getWrapperCommand(),
                 "releaseNeeded", "performRelease",
                 "releaseCleanUp", "-PdryRun",
                 "-x", "gitPush", "-x", "bintrayUpload",

--- a/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/release/CiReleasePlugin.java
+++ b/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/release/CiReleasePlugin.java
@@ -7,6 +7,7 @@ import org.gradle.api.tasks.StopExecutionException;
 import org.shipkit.gradle.exec.ShipkitExecTask;
 import org.shipkit.internal.gradle.git.GitSetupPlugin;
 import org.shipkit.internal.gradle.release.tasks.ReleaseNeeded;
+import org.shipkit.internal.gradle.util.GradleWrapper;
 import org.shipkit.internal.gradle.util.TaskMaker;
 import org.shipkit.internal.gradle.util.TaskSuccessfulMessage;
 
@@ -54,15 +55,15 @@ public class CiReleasePlugin implements Plugin<Project> {
             public void execute(ShipkitExecTask task) {
                 task.setDescription("Checks if release is needed. If so it will prepare for ci release and perform release.");
                 task.getExecCommands().add(execCommand(
-                    "Checking if release is needed", asList("./gradlew", ReleaseNeededPlugin.RELEASE_NEEDED), execResult -> {
+                    "Checking if release is needed", asList(GradleWrapper.getWrapperCommand(), ReleaseNeededPlugin.RELEASE_NEEDED), execResult -> {
                         if (!new File(project.getBuildDir(), ReleaseNeeded.RELEASE_NEEDED_FILENAME).exists()) {
                             throw new StopExecutionException();
                         }
                     }));
                 task.getExecCommands().add(execCommand(
-                        "Preparing working copy for the release", asList("./gradlew", GitSetupPlugin.CI_RELEASE_PREPARE_TASK)));
+                        "Preparing working copy for the release", asList(GradleWrapper.getWrapperCommand(), GitSetupPlugin.CI_RELEASE_PREPARE_TASK)));
                 task.getExecCommands().add(execCommand(
-                        "Performing the release", asList("./gradlew", ReleasePlugin.PERFORM_RELEASE_TASK)));
+                        "Performing the release", asList(GradleWrapper.getWrapperCommand(), ReleasePlugin.PERFORM_RELEASE_TASK)));
 
                 TaskSuccessfulMessage.logOnSuccess(task, "  Release " + project.getVersion() + " was shipped! Thank you for using Shipkit!");
             }

--- a/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/release/ReleasePlugin.java
+++ b/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/release/ReleasePlugin.java
@@ -10,6 +10,7 @@ import org.shipkit.internal.gradle.git.GitBranchPlugin;
 import org.shipkit.internal.gradle.git.GitPlugin;
 import org.shipkit.internal.gradle.notes.ReleaseNotesPlugin;
 import org.shipkit.internal.gradle.notes.tasks.UpdateReleaseNotes;
+import org.shipkit.internal.gradle.util.GradleWrapper;
 import org.shipkit.internal.gradle.util.TaskMaker;
 import org.shipkit.internal.gradle.util.TaskSuccessfulMessage;
 import org.shipkit.internal.gradle.version.VersioningPlugin;
@@ -85,7 +86,7 @@ public class ReleasePlugin implements Plugin<Project> {
             //releaseCleanUp is already set up to run all his "subtasks" after performRelease is performed
             //releaseNeeded is used here only to execute the code paths in the release needed task (extra testing)
             t.getExecCommands().add(execCommand("Performing release in dry run, with cleanup",
-                asList("./gradlew", RELEASE_NEEDED, PERFORM_RELEASE_TASK, RELEASE_CLEAN_UP_TASK, "-PdryRun")));
+                asList(GradleWrapper.getWrapperCommand(), RELEASE_NEEDED, PERFORM_RELEASE_TASK, RELEASE_CLEAN_UP_TASK, "-PdryRun")));
             TaskSuccessfulMessage.logOnSuccess(t, "  The release test was successful. Ship it!");
         });
 
@@ -109,7 +110,7 @@ public class ReleasePlugin implements Plugin<Project> {
 
     private static ExecCommand contributorTestCommand(String... additionalArguments) {
         List<String> commandLine = new LinkedList<>(asList(
-            "./gradlew", RELEASE_NEEDED, PERFORM_RELEASE_TASK, RELEASE_CLEAN_UP_TASK, "-PdryRun", "-x", GitPlugin.GIT_PUSH_TASK));
+            GradleWrapper.getWrapperCommand(), RELEASE_NEEDED, PERFORM_RELEASE_TASK, RELEASE_CLEAN_UP_TASK, "-PdryRun", "-x", GitPlugin.GIT_PUSH_TASK));
         commandLine.addAll(asList(additionalArguments));
         return execCommand("Performing release in dry run, with cleanup", commandLine);
     }

--- a/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/util/GradleWrapper.java
+++ b/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/util/GradleWrapper.java
@@ -1,0 +1,18 @@
+package org.shipkit.internal.gradle.util;
+
+import java.util.Locale;
+
+/**
+ * Utilities for Gradle Wrapper
+ */
+public class GradleWrapper {
+
+    private final static boolean WINDOWS = System.getProperty("os.name").toLowerCase(Locale.ENGLISH).contains("win");
+
+    /**
+     * Gets Gradle wrapper command safely for Linux ("./gradlew") and for Windows ("gradlew.bat")
+     */
+    public static String getWrapperCommand() {
+        return WINDOWS ? "gradlew.bat" : "./gradlew";
+    }
+}

--- a/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/versionupgrade/CiUpgradeDownstreamPlugin.java
+++ b/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/versionupgrade/CiUpgradeDownstreamPlugin.java
@@ -4,6 +4,7 @@ import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.shipkit.gradle.exec.ShipkitExecTask;
 import org.shipkit.internal.gradle.release.CiReleasePlugin;
+import org.shipkit.internal.gradle.util.GradleWrapper;
 
 import static java.util.Arrays.asList;
 import static org.shipkit.internal.gradle.exec.ExecCommandFactory.execCommand;
@@ -29,6 +30,6 @@ public class CiUpgradeDownstreamPlugin implements Plugin<Project> {
         ShipkitExecTask ciPerformReleaseTask = (ShipkitExecTask) project.getRootProject().getTasks().findByName(CiReleasePlugin.CI_PERFORM_RELEASE_TASK);
 
         ciPerformReleaseTask.getExecCommands().add(execCommand(
-                "Upgrading downstream projects", asList("./gradlew", UpgradeDownstreamPlugin.UPGRADE_DOWNSTREAM_TASK)));
+                "Upgrading downstream projects", asList(GradleWrapper.getWrapperCommand(), UpgradeDownstreamPlugin.UPGRADE_DOWNSTREAM_TASK)));
     }
 }

--- a/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/versionupgrade/UpgradeDownstreamPlugin.java
+++ b/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/versionupgrade/UpgradeDownstreamPlugin.java
@@ -10,6 +10,7 @@ import org.shipkit.internal.gradle.configuration.DeferredConfiguration;
 import org.shipkit.internal.gradle.configuration.ShipkitConfigurationPlugin;
 import org.shipkit.internal.gradle.exec.ExecCommandFactory;
 import org.shipkit.internal.gradle.git.CloneGitRepositoryTaskFactory;
+import org.shipkit.internal.gradle.util.GradleWrapper;
 import org.shipkit.internal.gradle.util.TaskMaker;
 import org.shipkit.internal.util.ExposedForTesting;
 import org.shipkit.version.VersionInfo;
@@ -89,7 +90,7 @@ public class UpgradeDownstreamPlugin implements Plugin<Project> {
                 task.setDescription("Performs dependency upgrade in " + consumerRepository);
                 task.execCommand(ExecCommandFactory.execCommand("Upgrading dependency",
                     CloneGitRepositoryTaskFactory.getConsumerRepoCloneDir(project, consumerRepository),
-                    "./gradlew", "performVersionUpgrade", getDependencyProperty(project)));
+                    GradleWrapper.getWrapperCommand(), "performVersionUpgrade", getDependencyProperty(project)));
             }
         });
     }

--- a/subprojects/shipkit/src/test/groovy/org/shipkit/internal/gradle/versionupgrade/CiUpgradeDownstreamPluginTest.groovy
+++ b/subprojects/shipkit/src/test/groovy/org/shipkit/internal/gradle/versionupgrade/CiUpgradeDownstreamPluginTest.groovy
@@ -1,6 +1,7 @@
 package org.shipkit.internal.gradle.versionupgrade
 
 import org.shipkit.gradle.exec.ShipkitExecTask
+import org.shipkit.internal.gradle.util.GradleWrapper
 import testutil.PluginSpecification
 
 class CiUpgradeDownstreamPluginTest extends PluginSpecification {
@@ -12,7 +13,7 @@ class CiUpgradeDownstreamPluginTest extends PluginSpecification {
         then:
         ShipkitExecTask performReleaseTask = project.tasks['ciPerformRelease']
         performReleaseTask.execCommands.size() == 4
-        performReleaseTask.execCommands[3].commandLine == ["./gradlew", "upgradeDownstream"]
+        performReleaseTask.execCommands[3].commandLine == [GradleWrapper.getWrapperCommand(), "upgradeDownstream"]
     }
 
 }

--- a/subprojects/shipkit/src/test/groovy/org/shipkit/internal/gradle/versionupgrade/UpgradeDownstreamPluginTest.groovy
+++ b/subprojects/shipkit/src/test/groovy/org/shipkit/internal/gradle/versionupgrade/UpgradeDownstreamPluginTest.groovy
@@ -5,6 +5,7 @@ import org.gradle.testfixtures.ProjectBuilder
 import org.shipkit.gradle.exec.ShipkitExecTask
 import org.shipkit.internal.gradle.git.tasks.CloneGitRepositoryTask
 import org.shipkit.internal.gradle.java.ShipkitJavaPlugin
+import org.shipkit.internal.gradle.util.GradleWrapper
 import testutil.PluginSpecification
 
 class UpgradeDownstreamPluginTest extends PluginSpecification {
@@ -61,7 +62,7 @@ class UpgradeDownstreamPluginTest extends PluginSpecification {
 
         then:
         ShipkitExecTask task = project.tasks['upgradeWwilkMockito']
-        task.execCommands[0].commandLine == ["./gradlew", "performVersionUpgrade", "-Pdependency=depGroup:depName:0.1.2"]
+        task.execCommands[0].commandLine == [GradleWrapper.getWrapperCommand(), "performVersionUpgrade", "-Pdependency=depGroup:depName:0.1.2"]
     }
 
     @Override


### PR DESCRIPTION
When forking off Gradle processes we will use the Linux wrapper './gradlew' or Windows 'gradlew.bat'

Fixes #739