### PR TITLE
Make license used for pom configurable

### DIFF
--- a/subprojects/shipkit/src/main/groovy/org/shipkit/gradle/configuration/ShipkitConfiguration.java
+++ b/subprojects/shipkit/src/main/groovy/org/shipkit/gradle/configuration/ShipkitConfiguration.java
@@ -26,6 +26,7 @@ public class ShipkitConfiguration {
 
     private final GitHub gitHub = new GitHub();
     private final ReleaseNotes releaseNotes = new ReleaseNotes();
+    private final LicenseInfo licenseInfo = new LicenseInfo();
     private final Git git = new Git();
     private final Team team = new Team();
 
@@ -87,6 +88,10 @@ public class ShipkitConfiguration {
 
     public ReleaseNotes getReleaseNotes() {
         return releaseNotes;
+    }
+
+    public LicenseInfo getLicenseInfo() {
+        return licenseInfo;
     }
 
     public Git getGit() {
@@ -219,6 +224,24 @@ public class ShipkitConfiguration {
 
         public void setWriteAuthToken(String writeAuthToken) {
             store.put("gitHub.writeAuthToken", writeAuthToken);
+        }
+    }
+
+    public class LicenseInfo {
+        public String getLicense() {
+            return store.getString("licenseInfo.license");
+        }
+
+        public void setLicense(String license) {
+            store.put("licenseInfo.license", license);
+        }
+
+        public String getUrl() {
+            return store.getString("licenseInfo.url");
+        }
+
+        public void setUrl(String url) {
+            store.put("licenseInfo.url", url);
         }
     }
 

--- a/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/util/PomCustomizer.java
+++ b/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/util/PomCustomizer.java
@@ -76,8 +76,8 @@ public class PomCustomizer {
         }
 
         Node license = root.appendNode("licenses").appendNode("license");
-        license.appendNode("name", "The MIT License");
-        license.appendNode("url", repoLink + "/blob/master/LICENSE");
+        license.appendNode("name", conf.getLicenseInfo().getLicense());
+        license.appendNode("url", conf.getLicenseInfo().getUrl());
         license.appendNode("distribution", "repo");
 
         root.appendNode("scm").appendNode("url", repoLink + ".git");

--- a/subprojects/shipkit/src/test/groovy/org/shipkit/internal/gradle/util/PomCustomizerTest.groovy
+++ b/subprojects/shipkit/src/test/groovy/org/shipkit/internal/gradle/util/PomCustomizerTest.groovy
@@ -34,6 +34,9 @@ class PomCustomizerTest extends Specification {
         //wwilk will not be duplicated in developers/contributors
         conf.team.contributors = ["mstachniuk:Marcin Stachniuk", "wwilk:Wojtek Wilk"]
 
+        conf.licenseInfo.license = "The MIT License"
+        conf.licenseInfo.url = "https://github.com/repo/blob/master/LICENSE"
+
         PomCustomizer.customizePom(node, conf, "foo", "Foo library", new DefaultProjectContributorsSet())
 
         expect:
@@ -92,6 +95,10 @@ class PomCustomizerTest extends Specification {
         conf.gitHub.repository = "repo"
         conf.team.developers = ["mockitoguy:Szczepan Faber", "wwilk:Wojtek Wilk"]
         conf.team.contributors = []
+
+        conf.licenseInfo.license = "The MIT License"
+        conf.licenseInfo.url = "https://github.com/repo/blob/master/LICENSE"
+
         //wwilk will not be duplicated in developers/contributors
         def contributorsSet = new DefaultProjectContributorsSet()
         contributorsSet.addContributor(new DefaultProjectContributor("Wojtek Wilk", "wwilk", "https://github.com/wwilk", 5))
@@ -156,6 +163,9 @@ class PomCustomizerTest extends Specification {
         conf.team.developers = []
         conf.team.contributors = []
 
+        conf.licenseInfo.license = "The MIT License"
+        conf.licenseInfo.url = "https://github.com/repo/blob/master/LICENSE"
+
         PomCustomizer.customizePom(node, conf, "foo", "Foo library", new DefaultProjectContributorsSet())
 
         expect:
@@ -168,6 +178,44 @@ class PomCustomizerTest extends Specification {
     <license>
       <name>The MIT License</name>
       <url>https://github.com/repo/blob/master/LICENSE</url>
+      <distribution>repo</distribution>
+    </license>
+  </licenses>
+  <scm>
+    <url>https://github.com/repo.git</url>
+  </scm>
+  <issueManagement>
+    <url>https://github.com/repo/issues</url>
+    <system>GitHub issues</system>
+  </issueManagement>
+  <ciManagement>
+    <url>https://travis-ci.org/repo</url>
+    <system>TravisCI</system>
+  </ciManagement>
+</project>
+"""
+    }
+
+    def "use epl v2.0 license"() {
+        conf.gitHub.repository = "repo"
+        conf.team.developers = []
+        conf.team.contributors = []
+
+        conf.licenseInfo.license = "Eclipse Public License v2.0"
+        conf.licenseInfo.url = "http://www.eclipse.org/legal/epl-v20.html"
+
+        PomCustomizer.customizePom(node, conf, "foo", "Foo library", new DefaultProjectContributorsSet())
+
+        expect:
+        printXml(node) == """<project>
+  <name>foo</name>
+  <packaging>jar</packaging>
+  <url>https://github.com/repo</url>
+  <description>Foo library</description>
+  <licenses>
+    <license>
+      <name>Eclipse Public License v2.0</name>
+      <url>http://www.eclipse.org/legal/epl-v20.html</url>
       <distribution>repo</distribution>
     </license>
   </licenses>

--- a/subprojects/shipkit/src/test/groovy/testutil/GradleSpecification.groovy
+++ b/subprojects/shipkit/src/test/groovy/testutil/GradleSpecification.groovy
@@ -52,6 +52,9 @@ abstract class GradleSpecification extends Specification implements GradleVersio
                 gitHub.readOnlyAuthToken = "foo"
                 gitHub.repository = "repo"
                 releaseNotes.publicationRepository = "repo"
+
+                licenseInfo.license = "The MIT License"
+                licenseInfo.url = "https://github.com/repo/blob/master/LICENSE"
             }
         """
 


### PR DESCRIPTION
Very first draft (#755).

This pr extends shipkit configuration in a way that we have to configure the license used (incl url now).

```
shipkit {
    ...

    licenseInfo.license = "Eclipse Public License v2.0"
    licenseInfo.url = "http://www.eclipse.org/legal/epl-v20.html"
}
```

This will end up in a pom like 

```
<?xml version="1.0" encoding="UTF-8"?>
<project xmlns="http://maven.apache.org/POM/4.0.0" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
  ...
  <licenses>
    <license>
      <name>Eclipse Public License v2.0</name>
      <url>http://www.eclipse.org/legal/epl-v20.html</url>
      <distribution>repo</distribution>
    </license>
  </licenses>
  ...
```

The downside of this approach is that we still have to configure the license used by gradle bintray plugin, e.g.:

```
        bintray {
            pkg {
                ...
                licenses = ['EPL-2.0']
        ...
```

We could add this one also to shipkit config and do the configuration in our gradle plugin. As a result we'd have the license config in one place.

Note: this is a breaking change and will cause builds without a shipkit.licenseInfo configuration to fail:

````
Execution failed for task ':api:generatePomFileForJavaLibraryPublication'.
> Could not apply withXml() to generated POM
   > Please configure 'shipkit.licenseInfo.license' value (String).

```