### PR TITLE
Add Gradle 5.0 to gradle versions to test

### DIFF
--- a/subprojects/shipkit/src/test/groovy/testutil/GradleVersionsDeterminer.groovy
+++ b/subprojects/shipkit/src/test/groovy/testutil/GradleVersionsDeterminer.groovy
@@ -24,7 +24,7 @@ trait GradleVersionsDeterminer {
             case null:
                 return [currentGradleVersion()]
             case QUICK_GRADLE_VERSIONS_VALUE:
-                return [currentGradleVersion(), "4.10.2", "4.9", "4.5.1", "4.0.2"].unique()
+                return [currentGradleVersion(), "5.0", "4.10.2", "4.5.1", "4.0.2"].unique()
             default:
                 log.warn("Unsupported $REGRESSION_TESTS_ENV_NAME value '$regressionTestsLevel' (expected '$CURRENT_GRADLE_VERSION_ONLY_VALUE' or " +
                     "'$QUICK_GRADLE_VERSIONS_VALUE'). Assuming '$CURRENT_GRADLE_VERSION_ONLY_VALUE'.")


### PR DESCRIPTION
Let's also use gradle 5.0 in our tests.