### PR TITLE
Fix updateReleaseNotesOnGitHub task #775

### DIFF
--- a/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/notes/tasks/UpdateReleaseNotesOnGitHub.java
+++ b/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/notes/tasks/UpdateReleaseNotesOnGitHub.java
@@ -36,7 +36,6 @@ public class UpdateReleaseNotesOnGitHub {
     private String findReleaseByTagName(UpdateReleaseNotesOnGitHubTask task) throws Exception {
         String tagName = tagName(task);
         String url = "/repos/" + task.getUpstreamRepositoryName() + "/releases/tags/" + tagName;
-        LOG.debug("GitHub release id by tag name GET {}", url);
         LOG.lifecycle("GET {}", url);
 
         try {
@@ -68,7 +67,6 @@ public class UpdateReleaseNotesOnGitHub {
         body.put("name", tagName);
         body.put("body", text);
 
-        LOG.debug("GitHub create release by tag name POST {}", url);
         LOG.lifecycle("POST {}", url);
 
         try {
@@ -99,7 +97,6 @@ public class UpdateReleaseNotesOnGitHub {
             releaseId = findReleaseByTagName(task);
         } catch (Exception e) {
             LOG.lifecycle("Can't find release on GitHub to remove");
-            LOG.debug("GitHub find release by tag returned: " + e.getMessage(), e);
             return;
         }
 
@@ -107,7 +104,6 @@ public class UpdateReleaseNotesOnGitHub {
             removeRelease(releaseId, task);
         } catch (IOException e) {
             LOG.lifecycle("Can't delete release {} from GitHub", releaseId);
-            LOG.debug("GitHub can't delete release " + releaseId + ": " + e.getMessage(), e);
         }
     }
 

--- a/subprojects/shipkit/src/test/groovy/org/shipkit/internal/gradle/notes/tasks/UpdateReleaseNotesOnGitHubTest.groovy
+++ b/subprojects/shipkit/src/test/groovy/org/shipkit/internal/gradle/notes/tasks/UpdateReleaseNotesOnGitHubTest.groovy
@@ -8,13 +8,15 @@ import spock.lang.Specification
 
 class UpdateReleaseNotesOnGitHubTest extends Specification {
 
+    def urlCreateReleaseByTagName = "/repos/mockito/shipkit-example/releases"
     def urlReleaseIdByTagName = "/repos/mockito/shipkit-example/releases/tags/v1.0.0"
-    def urlEditRelease = "/repos/mockito/shipkit-example/releases/1234"
-    def body = '{"body":"text"}'
+    def body = '{"tag_name":"v1.0.0",' +
+        '"name":"v1.0.0",' +
+        '"body":"text"}'
     def responseReleaseIdByTagName = "{\n" +
         "  \"id\": 1234\n" +
         "}"
-    def responseEditRelease = "{\n" +
+    def responseCreateReleaseByTagName = "{\n" +
         "  \"html_url\": \"https://github.com/mockito/shipkit-example/releases/v1.0.0\"" +
         "}"
 
@@ -35,8 +37,7 @@ class UpdateReleaseNotesOnGitHubTest extends Specification {
 
         then:
         1 * updateReleaseNotes.generateNewContent(task, header) >> "text"
-        1 * gitHubApi.get(urlReleaseIdByTagName) >> responseReleaseIdByTagName
-        1 * gitHubApi.patch(urlEditRelease, body) >> responseEditRelease
+        1 * gitHubApi.post(urlCreateReleaseByTagName, body) >> responseCreateReleaseByTagName
     }
 
     def "should not call GitHub API when preview mode"() {
@@ -78,9 +79,9 @@ class UpdateReleaseNotesOnGitHubTest extends Specification {
         update.updateReleaseNotes(task, header)
 
         then:
-        1 * gitHubApi.get(_)
+        0 * gitHubApi.get(_)
         0 * gitHubApi.delete(_)
-        0 * gitHubApi.patch(_)
+        0 * gitHubApi.post(_, _)
     }
 
     def "should clean up release notes on GitHub"() {


### PR DESCRIPTION
Tag in GitHub doesn't automatically create GitHub Release
GitHub Release needs to be created by API