### PR TITLE
Make sure that gitPush is executed before updateReleaseNotesOnGithub

### DIFF
--- a/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/notes/ReleaseNotesPlugin.java
+++ b/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/notes/ReleaseNotesPlugin.java
@@ -85,6 +85,7 @@ public class ReleaseNotesPlugin implements Plugin<Project> {
 
         UpdateReleaseNotesOnGitHubTask updateReleaseNotesOnGitHubTask = TaskMaker.task(project, UPDATE_NOTES_ON_GITHUB_TASK, UpdateReleaseNotesOnGitHubTask.class, task -> {
             task.setDescription("Updates release notes on GitHub releases page. Run with '-Ppreview' if you only want to see the preview.");
+            task.mustRunAfter(GitPlugin.GIT_PUSH_TASK);
 
             configureDetailedNotes(task, releaseNotesFetcher, project, conf, contributorsFetcher);
 


### PR DESCRIPTION
fixes #781 

should we also make sure that the updateReleaseNotesOnGithub is executed before publishing (or the other way around)?