### PR TITLE
New plugin for shipping Javadoc to GitHub repo

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -16,13 +16,28 @@ Using Gradle vocabulary: all archives produced by all subprojects in your build 
 Say that one of your subprojects is a "test" or "sample" project that you don't want to publish.
 To prevent publication, disable ```bintrayUpload``` task:
 
-```java
+```groovy
 //build.gradle of a subproject that you don't want to publish
 apply plugin: 'java'
 ...
 bintrayUpload.enabled = false
 ```
 
-See [docs/getting-started.md](/docs/getting-started.md) document.
+### How to build my library against different JDK versions?
 
+Sometimes projects are build against different Java versions, but you can't release the same 
+artifact version twice. To avoid failed builds on Travis, you can configure it like that:
 
+```yaml
+matrix:
+  include:
+  - jdk: oraclejdk8
+  - jdk: oraclejdk9
+    env: SKIP_RELEASE=true
+  - jdk: openjdk10
+    env: SKIP_RELEASE=true
+  - jdk: openjdk11
+    env: SKIP_RELEASE=true
+```   
+
+Now only artifacts produced by JDK8 build will be published.

--- a/subprojects/shipkit/src/main/groovy/org/shipkit/gradle/configuration/ShipkitConfiguration.java
+++ b/subprojects/shipkit/src/main/groovy/org/shipkit/gradle/configuration/ShipkitConfiguration.java
@@ -25,6 +25,7 @@ public class ShipkitConfiguration {
     private final ShipkitConfigurationStore store;
 
     private final GitHub gitHub = new GitHub();
+    private final Javadoc javadoc = new Javadoc();
     private final ReleaseNotes releaseNotes = new ReleaseNotes();
     private final Git git = new Git();
     private final Team team = new Team();
@@ -84,6 +85,10 @@ public class ShipkitConfiguration {
 
     public GitHub getGitHub() {
         return gitHub;
+    }
+
+    public Javadoc getJavadoc() {
+        return javadoc;
     }
 
     public ReleaseNotes getReleaseNotes() {
@@ -224,22 +229,24 @@ public class ShipkitConfiguration {
         public void setWriteAuthToken(String writeAuthToken) {
             store.put("gitHub.writeAuthToken", writeAuthToken);
         }
+    }
 
+    public class Javadoc {
         /**
          * GitHub Javadoc repository name, for example: "mockito/shipkit-javadoc".
          * The default value is repository with "-javadoc" suffix.
          * @since 2.2.0
          */
-        public String getJavadocRepository() {
-            return store.getString("gitHub.javadocRepository");
+        public String getRepository() {
+            return store.getString("javadoc.repository");
         }
 
         /**
-         * @see {@link #getJavadocRepository()}
+         * @see {@link #getRepository()}
          * @since 2.2.0
          */
-        public void setJavadocRepository(String javadocRepository) {
-            store.put("gitHub.javadocRepository", javadocRepository);
+        public void setRepository(String javadocRepository) {
+            store.put("javadoc.repository", javadocRepository);
         }
 
         /**
@@ -247,32 +254,50 @@ public class ShipkitConfiguration {
          * By default it's using the branch set as main in GitHub repo, usually master.
          * @since 2.2.0
          */
-        public String getJavadocRepositoryBranch() {
-            return store.getString("gitHub.javadocRepositoryBranch");
+        public String getRepositoryBranch() {
+            return store.getString("javadoc.repositoryBranch");
         }
 
         /**
-         * @see {@link #getJavadocRepositoryBranch()}
+         * @see {@link #getRepositoryBranch()}
          * @since 2.2.0
          */
-        public void setJavadocRepositoryBranch(String javadocRepositoryBranch) {
-            store.put("gitHub.javadocRepositoryBranch", javadocRepositoryBranch);
+        public void setRepositoryBranch(String javadocRepositoryBranch) {
+            store.put("javadoc.repositoryBranch", javadocRepositoryBranch);
         }
 
         /**
          * GitHub Javadoc repository directory where put javadoc files. By default it's root directory.
          * @since 2.2.0
          */
-        public String getJavadocRepositoryDirectory() {
-            return store.getString("gitHub.javadocRepositoryDirectory");
+        public String getRepositoryDirectory() {
+            return store.getString("javadoc.repositoryDirectory");
         }
 
         /**
-         * @see {@link #getJavadocRepositoryDirectory()}
+         * @see {@link #getRepositoryDirectory()}
          * @since 2.2.0
          */
-        public void setJavadocRepositoryDirectory(String javadocRepositoryDirectory) {
-            store.put("gitHub.javadocRepositoryDirectory", javadocRepositoryDirectory);
+        public void setRepositoryDirectory(String javadocRepositoryDirectory) {
+            store.put("javadoc.repositoryDirectory", javadocRepositoryDirectory);
+        }
+
+        /**
+         * Commit message used to commit Javadocs. Default: "Update current and ${version} Javadocs. [ci skip]"
+         * You can override this message and ${version} will be replaced by currently build version.
+         * You don't need to specify "[ci skip]" in your message - it will be added automatically.
+         * @since 2.2.0
+         */
+        public String getCommitMessage() {
+            return store.getString("javadoc.commitMessage");
+        }
+
+        /**
+         * @see {@link #getCommitMessage()}
+         * @since 2.2.0
+         */
+        public void setCommitMessage(String commitMessage) {
+            store.put("javadoc.commitMessage", commitMessage);
         }
     }
 

--- a/subprojects/shipkit/src/main/groovy/org/shipkit/gradle/configuration/ShipkitConfiguration.java
+++ b/subprojects/shipkit/src/main/groovy/org/shipkit/gradle/configuration/ShipkitConfiguration.java
@@ -218,8 +218,61 @@ public class ShipkitConfiguration {
                 "  shipkit.gitHub.writeAuthToken = 'secret'");
         }
 
+        /**
+         * @see {@link #getWriteAuthToken()}
+         */
         public void setWriteAuthToken(String writeAuthToken) {
             store.put("gitHub.writeAuthToken", writeAuthToken);
+        }
+
+        /**
+         * GitHub Javadoc repository name, for example: "mockito/shipkit-javadoc".
+         * The default value is repository with "-javadoc" suffix.
+         * @since 2.2.0
+         */
+        public String getJavadocRepository() {
+            return store.getString("gitHub.javadocRepository");
+        }
+
+        /**
+         * @see {@link #getJavadocRepository()}
+         * @since 2.2.0
+         */
+        public void setJavadocRepository(String javadocRepository) {
+            store.put("gitHub.javadocRepository", javadocRepository);
+        }
+
+        /**
+         * GitHub Javadoc repository branch name. The branch needs to exist.
+         * By default it's using the branch set as main in GitHub repo, usually master.
+         * @since 2.2.0
+         */
+        public String getJavadocRepositoryBranch() {
+            return store.getString("gitHub.javadocRepositoryBranch");
+        }
+
+        /**
+         * @see {@link #getJavadocRepositoryBranch()}
+         * @since 2.2.0
+         */
+        public void setJavadocRepositoryBranch(String javadocRepositoryBranch) {
+            store.put("gitHub.javadocRepositoryBranch", javadocRepositoryBranch);
+        }
+
+        /**
+         * GitHub Javadoc repository directory where put javadoc files. By default it's root directory.
+         * @since 2.2.0
+         */
+        public String getJavadocRepositoryDirectory() {
+            return store.getString("gitHub.javadocRepositoryDirectory");
+        }
+
+        /**
+         * @see {@link #getJavadocRepositoryDirectory()}
+         * @since 2.2.0
+         */
+        public void setJavadocRepositoryDirectory(String javadocRepositoryDirectory) {
+            store.put("gitHub.javadocRepositoryDirectory", javadocRepositoryDirectory);
         }
     }
 
@@ -303,7 +356,7 @@ public class ShipkitConfiguration {
          * Get the Publication Plugin Name
          *
          * @see @setPublicationPluginName(String)
-         *
+         * @since 2.0.32
          * @deprecated since 2.1.6 because we no longer are using this one. It is scheduled to be removed in 3.0.0.
          */
         @Deprecated
@@ -327,6 +380,8 @@ public class ShipkitConfiguration {
          *     https://img.shields.io/maven-metadata/v/https/plugins.gradle.org/m2/org/shipkit/java/org.shipkit.java.gradle.plugin/maven-metadata.xml.svg?colorB=007ec6&label=Gradle
          * </pre>
          * This will show nice badge with actual plugin version in Gradle Plugin Portal.
+         *
+         * @since 2.0.32
          *
          * @deprecated since 2.1.6 because we no longer are using this one. It is scheduled to be removed in 3.0.0.
          */

--- a/subprojects/shipkit/src/main/groovy/org/shipkit/gradle/exec/ShipkitExecTask.java
+++ b/subprojects/shipkit/src/main/groovy/org/shipkit/gradle/exec/ShipkitExecTask.java
@@ -20,7 +20,7 @@ public class ShipkitExecTask extends DefaultTask {
      * Executes all commands
      */
     @TaskAction public void execCommands() {
-        new ShipkitExec().execCommands(this.getExecCommands(), this.getProject());
+        new ShipkitExec().execCommands(this.getExecCommands(), this.getProject(), null);
     }
 
     /**

--- a/subprojects/shipkit/src/main/groovy/org/shipkit/gradle/git/GitCommitTask.java
+++ b/subprojects/shipkit/src/main/groovy/org/shipkit/gradle/git/GitCommitTask.java
@@ -19,13 +19,12 @@ import java.util.List;
 public class GitCommitTask extends DefaultTask {
 
     @Input @SkipWhenEmpty private List<File> filesToCommit = new ArrayList<>();
-    @Input @SkipWhenEmpty private List<File> directoriesToCommit = new ArrayList<>();
     private List<String> descriptions = new ArrayList<>();
 
     @Input String gitUserName;
     @Input String gitUserEmail;
     @Input String commitMessagePostfix;
-    @Input @Optional String workingDir;
+    @Input @Optional File workingDir;
 
     @TaskAction public void commit() {
         new GitCommitImpl().commit(this);
@@ -40,20 +39,11 @@ public class GitCommitTask extends DefaultTask {
      * @param taskMakingChange  task that makes the change, we will automatically set 'dependsOn' this task
      */
     public void addChange(List<File> files, String changeDescription, Task taskMakingChange) {
-        dependsOn(taskMakingChange);
+        if (taskMakingChange != null) {
+            dependsOn(taskMakingChange);
+        }
         filesToCommit.addAll(files);
         descriptions.add(changeDescription);
-    }
-
-    /**
-     * Register a directory to be committed.
-     *
-     * @param directory     to be committed
-     * @param description   description to be included in commit message
-     */
-    public void addDirectory(String directory, String description) {
-        directoriesToCommit.add(new File(directory));
-        descriptions.add(description);
     }
 
     /**
@@ -114,18 +104,10 @@ public class GitCommitTask extends DefaultTask {
     }
 
     /**
-     * The directories to be committed as registered using {@link #addDirectory(String, String)} method.
-     * @since 2.2.0
-     */
-    public List<File> getDirectoriesToCommit() {
-        return directoriesToCommit;
-    }
-
-    /**
      * Gets working directory where commands are executed. By default it is project root directory.
      * @since 2.2.0
      */
-    public String getWorkingDir() {
+    public File getWorkingDir() {
         return workingDir;
     }
 
@@ -133,7 +115,7 @@ public class GitCommitTask extends DefaultTask {
      * @see {@link #getWorkingDir()}
      * @since 2.2.0
      */
-    public void setWorkingDir(String workingDir) {
+    public void setWorkingDir(File workingDir) {
         this.workingDir = workingDir;
     }
 }

--- a/subprojects/shipkit/src/main/groovy/org/shipkit/gradle/git/GitCommitTask.java
+++ b/subprojects/shipkit/src/main/groovy/org/shipkit/gradle/git/GitCommitTask.java
@@ -115,6 +115,7 @@ public class GitCommitTask extends DefaultTask {
 
     /**
      * The directories to be committed as registered using {@link #addDirectory(String, String)} method.
+     * @since 2.2.0
      */
     public List<File> getDirectoriesToCommit() {
         return directoriesToCommit;

--- a/subprojects/shipkit/src/main/groovy/org/shipkit/gradle/git/GitCommitTask.java
+++ b/subprojects/shipkit/src/main/groovy/org/shipkit/gradle/git/GitCommitTask.java
@@ -3,6 +3,7 @@ package org.shipkit.gradle.git;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.Task;
 import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.Optional;
 import org.gradle.api.tasks.SkipWhenEmpty;
 import org.gradle.api.tasks.TaskAction;
 import org.shipkit.internal.gradle.git.tasks.GitCommitImpl;
@@ -18,11 +19,13 @@ import java.util.List;
 public class GitCommitTask extends DefaultTask {
 
     @Input @SkipWhenEmpty private List<File> filesToCommit = new ArrayList<>();
+    @Input @SkipWhenEmpty private List<File> directoriesToCommit = new ArrayList<>();
     private List<String> descriptions = new ArrayList<>();
 
     @Input String gitUserName;
     @Input String gitUserEmail;
     @Input String commitMessagePostfix;
+    @Input @Optional String workingDir;
 
     @TaskAction public void commit() {
         new GitCommitImpl().commit(this);
@@ -40,6 +43,17 @@ public class GitCommitTask extends DefaultTask {
         dependsOn(taskMakingChange);
         filesToCommit.addAll(files);
         descriptions.add(changeDescription);
+    }
+
+    /**
+     * Register a directory to be committed.
+     *
+     * @param directory     to be committed
+     * @param description   description to be included in commit message
+     */
+    public void addDirectory(String directory, String description) {
+        directoriesToCommit.add(new File(directory));
+        descriptions.add(description);
     }
 
     /**
@@ -92,10 +106,33 @@ public class GitCommitTask extends DefaultTask {
     }
 
     /**
-     * Change descriptions to be included in the commit message.
+     * Get descriptions to be included in the commit message.
      * Descriptions are registered using {@link #addChange(List, String, Task)}
      */
     public List<String> getDescriptions() {
         return descriptions;
+    }
+
+    /**
+     * The directories to be committed as registered using {@link #addDirectory(String, String)} method.
+     */
+    public List<File> getDirectoriesToCommit() {
+        return directoriesToCommit;
+    }
+
+    /**
+     * Gets working directory where commands are executed. By default it is project root directory.
+     * @since 2.2.0
+     */
+    public String getWorkingDir() {
+        return workingDir;
+    }
+
+    /**
+     * @see {@link #getWorkingDir()}
+     * @since 2.2.0
+     */
+    public void setWorkingDir(String workingDir) {
+        this.workingDir = workingDir;
     }
 }

--- a/subprojects/shipkit/src/main/groovy/org/shipkit/gradle/git/GitPushTask.java
+++ b/subprojects/shipkit/src/main/groovy/org/shipkit/gradle/git/GitPushTask.java
@@ -2,6 +2,7 @@ package org.shipkit.gradle.git;
 
 import org.gradle.api.DefaultTask;
 import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.Optional;
 import org.gradle.api.tasks.TaskAction;
 import org.shipkit.internal.gradle.git.tasks.GitPush;
 
@@ -20,6 +21,7 @@ public class GitPushTask extends DefaultTask {
     @Input private List<String> targets = new LinkedList<>();
     @Input private String url;
     @Input private boolean dryRun;
+    @Input @Optional private String workingDir;
     private String secretValue;
 
     @TaskAction public void gitPush() {
@@ -81,5 +83,21 @@ public class GitPushTask extends DefaultTask {
      */
     public void setSecretValue(String secretValue) {
         this.secretValue = secretValue;
+    }
+
+    /**
+     * Gets working directory where commands are executed. By default it is project root directory.
+     * @since 2.2.0
+     */
+    public String getWorkingDir() {
+        return workingDir;
+    }
+
+    /**
+     * @see {@link #getWorkingDir()}
+     * @since 2.2.0
+     */
+    public void setWorkingDir(String workingDir) {
+        this.workingDir = workingDir;
     }
 }

--- a/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/exec/ShipkitExec.java
+++ b/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/exec/ShipkitExec.java
@@ -10,6 +10,7 @@ import org.shipkit.gradle.exec.ExecCommand;
 import org.shipkit.internal.exec.ExternalProcessStream;
 import org.shipkit.internal.gradle.util.StringUtil;
 
+import java.io.File;
 import java.util.Collection;
 
 public class ShipkitExec {
@@ -22,7 +23,7 @@ public class ShipkitExec {
      * @param project       Gradle Project instance
      * @param workingDir    Working directory where command will be executed, it may be null
      */
-    public void execCommands(Collection<ExecCommand> execCommands, Project project, String workingDir) {
+    public void execCommands(Collection<ExecCommand> execCommands, Project project, File workingDir) {
         for (final ExecCommand execCommand : execCommands) {
             ExecResult result = project.exec(new Action<ExecSpec>() {
                 @Override

--- a/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/exec/ShipkitExec.java
+++ b/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/exec/ShipkitExec.java
@@ -16,7 +16,13 @@ public class ShipkitExec {
 
     private final static Logger LOG = Logging.getLogger(ShipkitExec.class);
 
-    public void execCommands(Collection<ExecCommand> execCommands, Project project) {
+    /**
+     * Execute commands and print execution summary.
+     * @param execCommands  Commands to execute
+     * @param project       Gradle Project instance
+     * @param workingDir    Working directory where command will be executed, it may be null
+     */
+    public void execCommands(Collection<ExecCommand> execCommands, Project project, String workingDir) {
         for (final ExecCommand execCommand : execCommands) {
             ExecResult result = project.exec(new Action<ExecSpec>() {
                 @Override
@@ -25,6 +31,9 @@ public class ShipkitExec {
                     spec.commandLine(execCommand.getCommandLine());
                     spec.setStandardOutput(new ExternalProcessStream(execCommand.getLoggingPrefix(), System.out));
                     spec.setErrorOutput(new ExternalProcessStream(execCommand.getLoggingPrefix(), System.err));
+                    if (workingDir != null) {
+                        spec.setWorkingDir(workingDir);
+                    }
 
                     execCommand.getSetupAction().execute(spec);
 

--- a/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/git/GitCommitTaskFactory.java
+++ b/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/git/GitCommitTaskFactory.java
@@ -1,0 +1,21 @@
+package org.shipkit.internal.gradle.git;
+
+import org.gradle.api.Project;
+import org.shipkit.gradle.configuration.ShipkitConfiguration;
+import org.shipkit.gradle.git.GitCommitTask;
+import org.shipkit.internal.gradle.configuration.ShipkitConfigurationPlugin;
+import org.shipkit.internal.gradle.util.TaskMaker;
+
+public class GitCommitTaskFactory {
+
+    public static GitCommitTask createGitCommitTask(Project project, String taskName, String description) {
+        final ShipkitConfiguration conf = project.getPlugins().apply(ShipkitConfigurationPlugin.class).getConfiguration();
+
+        return TaskMaker.task(project, taskName, GitCommitTask.class, task -> {
+            task.setDescription(description);
+            task.setGitUserName(conf.getGit().getUser());
+            task.setGitUserEmail(conf.getGit().getEmail());
+            task.setCommitMessagePostfix(conf.getGit().getCommitMessagePostfix());
+        });
+    }
+}

--- a/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/git/GitCommitTaskFactory.java
+++ b/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/git/GitCommitTaskFactory.java
@@ -9,7 +9,7 @@ import org.shipkit.internal.gradle.util.TaskMaker;
 public class GitCommitTaskFactory {
 
     public static GitCommitTask createGitCommitTask(Project project, String taskName, String description) {
-        final ShipkitConfiguration conf = project.getPlugins().apply(ShipkitConfigurationPlugin.class).getConfiguration();
+        ShipkitConfiguration conf = project.getPlugins().apply(ShipkitConfigurationPlugin.class).getConfiguration();
 
         return TaskMaker.task(project, taskName, GitCommitTask.class, task -> {
             task.setDescription(description);

--- a/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/git/GitPlugin.java
+++ b/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/git/GitPlugin.java
@@ -76,7 +76,7 @@ public class GitPlugin implements Plugin<Project> {
                 t.getTargets().add(GitUtil.getTag(conf, project));
                 t.setDryRun(conf.isDryRun());
 
-                GitUrlInfo info = new GitUrlInfo(conf);
+                GitUrlInfo info = new GitUrlInfo(conf, conf.getGitHub().getRepository());
                 t.setUrl(info.getGitUrl());
                 t.setSecretValue(info.getWriteToken());
 

--- a/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/git/GitPlugin.java
+++ b/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/git/GitPlugin.java
@@ -54,14 +54,8 @@ public class GitPlugin implements Plugin<Project> {
     public void apply(final Project project) {
         final ShipkitConfiguration conf = project.getPlugins().apply(ShipkitConfigurationPlugin.class).getConfiguration();
 
-        TaskMaker.task(project, GIT_COMMIT_TASK, GitCommitTask.class, new Action<GitCommitTask>() {
-            public void execute(final GitCommitTask t) {
-                t.setDescription("Commits all changed files using generic --author and aggregated commit message");
-                t.setGitUserName(conf.getGit().getUser());
-                t.setGitUserEmail(conf.getGit().getEmail());
-                t.setCommitMessagePostfix(conf.getGit().getCommitMessagePostfix());
-            }
-        });
+        GitCommitTaskFactory.createGitCommitTask(project, GIT_COMMIT_TASK,
+            "Commits all changed files using generic --author and aggregated commit message");
 
         TaskMaker.task(project, GIT_TAG_TASK, ShipkitExecTask.class, new Action<ShipkitExecTask>() {
             public void execute(final ShipkitExecTask t) {

--- a/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/git/GitUrlInfo.java
+++ b/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/git/GitUrlInfo.java
@@ -9,8 +9,8 @@ public class GitUrlInfo {
     private final String gitUrl;
     private final String writeToken;
 
-    public GitUrlInfo(ShipkitConfiguration conf) {
-        gitUrl = getGitHubUrl(conf.getGitHub().getRepository(), conf);
+    public GitUrlInfo(ShipkitConfiguration conf, String repository) {
+        gitUrl = getGitHubUrl(repository, conf);
         writeToken = conf.getLenient().getGitHub().getWriteAuthToken();
     }
 

--- a/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/git/tasks/GitCheckOutTask.java
+++ b/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/git/tasks/GitCheckOutTask.java
@@ -1,14 +1,16 @@
 package org.shipkit.internal.gradle.git.tasks;
 
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+
 import org.gradle.api.DefaultTask;
 import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.Optional;
 import org.gradle.api.tasks.TaskAction;
 import org.shipkit.internal.exec.DefaultProcessRunner;
 import org.shipkit.internal.exec.ProcessRunner;
 import org.shipkit.internal.util.ExposedForTesting;
-
-import java.util.ArrayList;
-import java.util.List;
 
 /**
  * This task will checkout a certain revision.
@@ -19,6 +21,8 @@ public class GitCheckOutTask extends DefaultTask {
     private String rev;
     @Input
     private boolean newBranch;
+    @Input @Optional
+    private File directory;
 
     private ProcessRunner processRunner;
 
@@ -50,6 +54,20 @@ public class GitCheckOutTask extends DefaultTask {
         return newBranch;
     }
 
+    /**
+     * A directory where execute git command
+     */
+    public File getDirectory() {
+        return directory;
+    }
+
+    /**
+     * See {@link #getDirectory()}
+     */
+    public void setDirectory(File directory) {
+        this.directory = directory;
+    }
+
     @TaskAction
     public void checkOut() {
         getProcessRunner().run(getCommandLine());
@@ -68,7 +86,11 @@ public class GitCheckOutTask extends DefaultTask {
 
     private ProcessRunner getProcessRunner() {
         if (processRunner == null) {
-            return new DefaultProcessRunner(getProject().getProjectDir());
+            if (directory == null) {
+                return new DefaultProcessRunner(getProject().getProjectDir());
+            } else {
+                return new DefaultProcessRunner(directory);
+            }
         }
         return processRunner;
     }

--- a/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/git/tasks/GitCommitImpl.java
+++ b/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/git/tasks/GitCommitImpl.java
@@ -18,7 +18,7 @@ public class GitCommitImpl {
     public void commit(GitCommitTask task) {
         Collection<ExecCommand> commands = new LinkedList<>();
         commands.add(execCommand("Adding files to git",
-            getAddCommand(task.getFilesToCommit(), task.getDirectoriesToCommit())));
+            getAddCommand(task.getFilesToCommit())));
         commands.add(execCommand("Performing git commit",
             getCommitCommand(task.getGitUserName(), task.getGitUserEmail(), task.getDescriptions(), task.getCommitMessagePostfix())));
         new ShipkitExec().execCommands(commands, task.getProject(), task.getWorkingDir());
@@ -35,15 +35,12 @@ public class GitCommitImpl {
         return result.toString();
     }
 
-    static List<String> getAddCommand(List<File> files, List<File> directories) {
+    static List<String> getAddCommand(List<File> files) {
         List<String> args = new ArrayList<>();
         args.add("git");
         args.add("add");
         for (File file : files) {
             args.add(file.getAbsolutePath());
-        }
-        for (File directory : directories) {
-            args.add(directory.getAbsolutePath());
         }
         return args;
     }

--- a/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/git/tasks/GitCommitImpl.java
+++ b/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/git/tasks/GitCommitImpl.java
@@ -18,10 +18,10 @@ public class GitCommitImpl {
     public void commit(GitCommitTask task) {
         Collection<ExecCommand> commands = new LinkedList<>();
         commands.add(execCommand("Adding files to git",
-            getAddCommand(task.getFilesToCommit())));
+            getAddCommand(task.getFilesToCommit(), task.getDirectoriesToCommit())));
         commands.add(execCommand("Performing git commit",
             getCommitCommand(task.getGitUserName(), task.getGitUserEmail(), task.getDescriptions(), task.getCommitMessagePostfix())));
-        new ShipkitExec().execCommands(commands, task.getProject());
+        new ShipkitExec().execCommands(commands, task.getProject(), task.getWorkingDir());
     }
 
     static String getAggregatedCommitMessage(List<String> descriptions) {
@@ -35,12 +35,15 @@ public class GitCommitImpl {
         return result.toString();
     }
 
-    static List<String> getAddCommand(List<File> files) {
+    static List<String> getAddCommand(List<File> files, List<File> directories) {
         List<String> args = new ArrayList<>();
         args.add("git");
         args.add("add");
         for (File file : files) {
             args.add(file.getAbsolutePath());
+        }
+        for (File directory : directories) {
+            args.add(directory.getAbsolutePath());
         }
         return args;
     }

--- a/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/git/tasks/GitPush.java
+++ b/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/git/tasks/GitPush.java
@@ -4,6 +4,7 @@ import org.shipkit.gradle.git.GitPushTask;
 import org.shipkit.internal.exec.DefaultProcessRunner;
 import org.shipkit.internal.gradle.util.handler.GitPushExceptionHandler;
 
+import java.io.File;
 import java.util.LinkedList;
 import java.util.List;
 
@@ -33,12 +34,19 @@ public class GitPush {
 
         Runnable gitPush = new Runnable() {
             public void run() {
-                new DefaultProcessRunner(task.getProject().getProjectDir())
+                new DefaultProcessRunner(getWorkDir(task))
                     .setSecretValue(task.getSecretValue())
                     .run(GitPush.gitPushArgs(task.getUrl(), task.getTargets(), task.isDryRun()));
             }
         };
 
         withExceptionHandling(gitPush, new GitPushExceptionHandler(task.getSecretValue()));
+    }
+
+    private File getWorkDir(GitPushTask task) {
+        if (task.getWorkingDir() != null) {
+            return new File(task.getWorkingDir());
+        }
+        return task.getProject().getProjectDir();
     }
 }

--- a/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/javadoc/JavadocPlugin.java
+++ b/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/javadoc/JavadocPlugin.java
@@ -1,0 +1,116 @@
+package org.shipkit.internal.gradle.javadoc;
+
+import org.gradle.api.Plugin;
+import org.gradle.api.Project;
+import org.gradle.api.Task;
+import org.gradle.api.logging.Logger;
+import org.gradle.api.logging.Logging;
+import org.gradle.api.tasks.Copy;
+import org.gradle.jvm.tasks.Jar;
+import org.shipkit.gradle.configuration.ShipkitConfiguration;
+import org.shipkit.internal.gradle.configuration.ShipkitConfigurationPlugin;
+import org.shipkit.internal.gradle.git.tasks.CloneGitRepositoryTask;
+import org.shipkit.internal.gradle.git.tasks.GitCheckOutTask;
+import org.shipkit.internal.gradle.util.TaskMaker;
+
+import java.io.File;
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.shipkit.internal.util.RepositoryNameUtil.repositoryNameToCamelCase;
+
+/**
+ * TODO
+ */
+public class JavadocPlugin implements Plugin<Project> {
+
+    private static final Logger LOG = Logging.getLogger(JavadocPlugin.class);
+    private static final String CLONE_JAVADOC_REPO = "cloneJavadocRepo";
+    private static final String REFRESH_CURRENT_JAVADOC_TASK = "refreshCurrentJavadoc";
+    private static final String REFRESH_VERSION_JAVADOC_TASK = "refreshVersionJavadoc";
+    private static final String CHECKOUT_JAVADOC_REPO_BRANCH = "checkoutJavadocRepoBranch";
+    public static final String COPY_JAVADOC_TO_STAGE_VERSION_DIR_TASK = "copyJavadocToStageVersionDir";
+    public static final String COPY_JAVADOC_TO_STAGE_CURRENT_DIR_TASK = "copyJavadocToStageCurrentDir";
+
+
+    @Override
+    public void apply(Project project) {
+        ShipkitConfiguration conf = project.getPlugins().apply(ShipkitConfigurationPlugin.class).getConfiguration();
+        ShipkitConfiguration lenientConf = conf.getLenient();
+        String javadocRepository = getJavadocRepository(conf);
+        String gitHubUrl = conf.getGitHub().getUrl();
+
+        //TODO what when repo doesn't exist? Fail or warning?
+        CloneGitRepositoryTask cloneJavadocTask = TaskMaker.task(project, CLONE_JAVADOC_REPO, CloneGitRepositoryTask.class,
+            task -> {
+                task.setDescription("Clones Javadoc repo " + javadocRepository + " into a temporary directory.");
+                task.setRepositoryUrl(gitHubUrl + "/" + javadocRepository);
+                task.setTargetDir(new File(getJavadocRepoCloneDir(project, javadocRepository)));
+                task.setDepth(10);
+                // TODO onlyIf { stagingDir not empty }
+            });
+
+        TaskMaker.task(project, CHECKOUT_JAVADOC_REPO_BRANCH, GitCheckOutTask.class, task -> {
+            String branch = lenientConf.getGitHub().getJavadocRepositoryBranch();
+            task.setDescription("Checkout branch in Javadoc repository");
+            task.dependsOn(cloneJavadocTask);
+            task.onlyIf(foo -> branch != null);
+            task.setRev(branch);
+            task.setNewBranch(false);
+        });
+
+        Set<Copy> copyToVersionTasks = new HashSet<>();
+        Set<Copy> copyToCurrentTasks = new HashSet<>();
+
+        project.getTasksByName("javadocJar", true).stream()
+            .map(task -> (Jar) task)
+            .forEach(javadocJarTask -> {
+                Copy copyToVersionTask = TaskMaker.task(javadocJarTask.getProject(), COPY_JAVADOC_TO_STAGE_VERSION_DIR_TASK, Copy.class, copyTask -> {
+                    copyTask.setDescription("Extracts contents of javadoc jar to the staging /version directory");
+                    copyTask.dependsOn(javadocJarTask);
+                    //build javadoc first so that if there is no javadoc we will avoid cloning
+                    cloneJavadocTask.mustRunAfter(javadocJarTask);
+                    copyTask.from(project.zipTree(javadocJarTask.getArchivePath()));
+                    // TODO how? : note that we need to use Closure/Callable because 'baseName' can be set by user later
+                    copyTask.into(getJavadocStageDir(project) + "/" + javadocJarTask.getBaseName() + "/" + project.getVersion());
+                });
+                copyToVersionTasks.add(copyToVersionTask);
+
+                Copy copyToCurrentTask = TaskMaker.task(javadocJarTask.getProject(), COPY_JAVADOC_TO_STAGE_CURRENT_DIR_TASK, Copy.class, copyTask -> {
+                    copyTask.setDescription("Extracts contents of javadoc jar to the staging /current directory");
+                    copyTask.dependsOn(copyToVersionTask);
+                    copyTask.from(copyToVersionTask.getDestinationDir());
+                    // TODO how? : note that we need to use Closure/Callable because 'baseName' can be set by user later
+                    copyTask.into(getJavadocStageDir(project) + "/" + javadocJarTask.getBaseName() + "/current");
+                });
+                copyToCurrentTasks.add(copyToCurrentTask);
+            });
+
+        Task refreshVersionJavadocTask = TaskMaker.task(project, REFRESH_VERSION_JAVADOC_TASK, task -> {
+            task.dependsOn(copyToVersionTasks);
+            task.setDescription("Copy Javadocs from all modules to the staging /version directory");
+        });
+
+        Task refreshCurrentJavadocTask = TaskMaker.task(project, REFRESH_CURRENT_JAVADOC_TASK, task -> {
+            task.dependsOn(copyToCurrentTasks);
+            task.setDescription("Copy Javadocs from all modules to the staging /version directory");
+        });
+
+    }
+
+    private String getJavadocRepository(ShipkitConfiguration conf) {
+        String javadocRepository = conf.getLenient().getGitHub().getJavadocRepository();
+        if (javadocRepository == null) {
+            javadocRepository = conf.getGitHub().getRepository() + "-javadoc";  // sensible default
+        }
+        return javadocRepository;
+    }
+
+    private String getJavadocRepoCloneDir(Project project, String javadocRepository) {
+        return project.getRootProject().getBuildDir().getAbsolutePath() + "/javadoc-repo/" + repositoryNameToCamelCase(javadocRepository);
+    }
+
+    private String getJavadocStageDir(Project project) {
+        return project.getRootProject().getBuildDir().getAbsolutePath() + "/javadoc-stage";
+    }
+}

--- a/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/javadoc/JavadocPlugin.java
+++ b/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/javadoc/JavadocPlugin.java
@@ -20,7 +20,6 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 

--- a/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/javadoc/JavadocPlugin.java
+++ b/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/javadoc/JavadocPlugin.java
@@ -3,8 +3,6 @@ package org.shipkit.internal.gradle.javadoc;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.Task;
-import org.gradle.api.logging.Logger;
-import org.gradle.api.logging.Logging;
 import org.gradle.api.tasks.Copy;
 import org.gradle.jvm.tasks.Jar;
 import org.shipkit.gradle.configuration.ShipkitConfiguration;
@@ -19,17 +17,46 @@ import org.shipkit.internal.gradle.git.tasks.GitCheckOutTask;
 import org.shipkit.internal.gradle.util.TaskMaker;
 
 import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.HashSet;
 import java.util.Set;
 
 import static java.util.Objects.isNull;
 
 /**
- * TODO
+ * Release Javadoc to git repository.
+ * <p>
+ * Applies:
+ *
+ * <ul>
+ *      <li>{@link GitPlugin}</li>
+ *      <li>{@link ShipkitConfigurationPlugin}</li>
+ * </ul>
+ *
+ * <p>
+ * Adds tasks:
+ *
+ * <ul>
+ *      <li>cloneJavadocRepo - clones Javadoc repository into a temporary directory. Javadoc will be published in this
+ *          repository.</li>
+ *      <li>checkoutJavadocRepoBranch - checkouts a branch in Javadoc repository, where Javadoc will be published.</li>
+ *      <li>copyJavadocToStageVersionDir - extracts and copies Javadoc from Javadoc jar to stage directory to version
+ *          (eg.: "/1.2.3") subdirectory. This task is added to each subproject.</li>
+ *      <li>copyJavadocToStageCurrentDir - extracts and copies Javadoc from Javadoc jar to stage directory to /current
+ *          current directory. This task is added to each subproject.</li>
+ *      <li>refreshVersionJavadoc - aggregates all copyJavadocToStageVersionDir tasks.</li>
+ *      <li>refreshCurrentJavadoc - aggregates all copyJavadocToStageCurrentDir tasks.</li>
+ *      <li>copyJavadocStageToRepoDir - copies all Javadocs from stage directory to Javadoc repository directory.</li>
+ *      <li>commitJavadoc - commits all changes in Javadoc repository.</li>
+ *      <li>pushJavadoc - pushes Javadocs to remote Javadoc repository.</li>
+ *      <li>releaseJavadoc - aggregate all tasks needed to release Javadocs: clone, checkout, copy, commit, push.</li>
+ *      <li>clean - additionally removes build directory in project root</li>
+ * </ul>
  */
 public class JavadocPlugin implements Plugin<Project> {
 
-    private static final Logger LOG = Logging.getLogger(JavadocPlugin.class);
     private static final String CHECKOUT_JAVADOC_REPO_BRANCH = "checkoutJavadocRepoBranch";
     private static final String CLONE_JAVADOC_REPO = "cloneJavadocRepo";
     private static final String COMMIT_JAVADOC_TASK = "commitJavadoc";
@@ -44,31 +71,60 @@ public class JavadocPlugin implements Plugin<Project> {
     @Override
     public void apply(Project project) {
         project.getPlugins().apply(GitPlugin.class);
-
         ShipkitConfiguration conf = project.getPlugins().apply(ShipkitConfigurationPlugin.class).getConfiguration();
-        ShipkitConfiguration lenientConf = conf.getLenient();
-        String directory = lenientConf.getJavadoc().getRepositoryDirectory();
-        String branch = lenientConf.getJavadoc().getRepositoryBranch();
+
+        CloneGitRepositoryTask cloneJavadocTask = createCloneJavadocTask(project, conf);
+
+        GitCheckOutTask checkoutJavadocRepoBranch = createCheckoutJavadocReposBranch(project, conf);
+        checkoutJavadocRepoBranch.dependsOn(cloneJavadocTask);
+
+        CopyTasks copyTasks = createCopyJavadocToStageTasks(project);
+        Task refreshVersionJavadocTask = createRefreshVersionJavadocTask(project, copyTasks.copyToVersionTasks);
+        Task refreshCurrentJavadocTask = createRefreshCurrentJavadocTask(project, copyTasks.copyToCurrentTasks);
+
+        //refresh javadoc first so that if there is no javadoc we will avoid cloning
+        cloneJavadocTask.mustRunAfter(refreshVersionJavadocTask);
+
+        Copy copyStageToRepoDir = createCopyStageToRepoDirTask(project, conf);
+        copyStageToRepoDir.dependsOn(checkoutJavadocRepoBranch, refreshVersionJavadocTask, refreshCurrentJavadocTask);
+
+        GitCommitTask commitJavadocTask = createGitCommitTask(project, conf);
+        commitJavadocTask.dependsOn(copyStageToRepoDir);
+
+        GitPushTask pushJavadoc = createPushJavadocTask(project, conf);
+        pushJavadoc.dependsOn(commitJavadocTask);
+
+        Task releaseJavadocTask = createReleaseJavadocTask(project, cloneJavadocTask, commitJavadocTask, pushJavadoc);
+        releaseJavadocTask.dependsOn(cloneJavadocTask, commitJavadocTask, pushJavadoc);
+
+        deleteBuildDIrInRootProjectWhenCleanTask(project);
+    }
+
+    private CloneGitRepositoryTask createCloneJavadocTask(Project project, ShipkitConfiguration conf) {
         String javadocRepository = getJavadocRepository(conf);
         String gitHubUrl = conf.getGitHub().getUrl();
-
-        CloneGitRepositoryTask cloneJavadocTask = TaskMaker.task(project, CLONE_JAVADOC_REPO, CloneGitRepositoryTask.class,
+        return TaskMaker.task(project, CLONE_JAVADOC_REPO, CloneGitRepositoryTask.class,
             task -> {
                 task.setDescription("Clones Javadoc repo " + javadocRepository + " into a temporary directory.");
                 task.setRepositoryUrl(gitHubUrl + "/" + javadocRepository);
                 task.setTargetDir(new File(getJavadocRepoCloneDir(project)));
-                task.setDepth(10);
-                // TODO onlyIf { stagingDir not empty }
+                // onlyIf { stagingDir not empty }
+                task.onlyIf(t -> containsFileInDir(getJavadocStageDir(project)));
             });
+    }
 
-        GitCheckOutTask checkoutJavadocRepoBranch = TaskMaker.task(project, CHECKOUT_JAVADOC_REPO_BRANCH, GitCheckOutTask.class, task -> {
+    private GitCheckOutTask createCheckoutJavadocReposBranch(Project project, ShipkitConfiguration conf) {
+        String branch = conf.getLenient().getJavadoc().getRepositoryBranch();
+        return TaskMaker.task(project, CHECKOUT_JAVADOC_REPO_BRANCH, GitCheckOutTask.class, task -> {
             task.setDescription("Checkout branch in Javadoc repository");
-            task.dependsOn(cloneJavadocTask);
             task.onlyIf(foo -> branch != null);
             task.setRev(branch);
             task.setNewBranch(false);
+            task.setDirectory(new File(getJavadocRepoCloneDir(project)));
         });
+    }
 
+    private CopyTasks createCopyJavadocToStageTasks(Project project) {
         Set<Copy> copyToVersionTasks = new HashSet<>();
         Set<Copy> copyToCurrentTasks = new HashSet<>();
 
@@ -78,8 +134,6 @@ public class JavadocPlugin implements Plugin<Project> {
                 Copy copyToVersionTask = TaskMaker.task(javadocJarTask.getProject(), COPY_JAVADOC_TO_STAGE_VERSION_DIR_TASK, Copy.class, copyTask -> {
                     copyTask.setDescription("Extracts contents of javadoc jar to the staging /version directory");
                     copyTask.dependsOn(javadocJarTask);
-                    //build javadoc first so that if there is no javadoc we will avoid cloning
-                    cloneJavadocTask.mustRunAfter(javadocJarTask);
                     copyTask.from(project.zipTree(javadocJarTask.getArchivePath()));
                     // TODO how? : note that we need to use Closure/Callable because 'baseName' can be set by user later
                     copyTask.into(getJavadocStageDir(project) + "/" + javadocJarTask.getBaseName() + "/" + project.getVersion());
@@ -95,62 +149,68 @@ public class JavadocPlugin implements Plugin<Project> {
                 });
                 copyToCurrentTasks.add(copyToCurrentTask);
             });
+        return new CopyTasks(copyToVersionTasks, copyToCurrentTasks);
+    }
 
-        Task refreshVersionJavadocTask = TaskMaker.task(project, REFRESH_VERSION_JAVADOC_TASK, task -> {
+    private Task createRefreshVersionJavadocTask(Project project, Set<Copy> copyToVersionTasks) {
+        return TaskMaker.task(project, REFRESH_VERSION_JAVADOC_TASK, task -> {
             task.dependsOn(copyToVersionTasks);
             task.setDescription("Copy Javadocs from all modules to the staging /version directory");
         });
+    }
 
-        Task refreshCurrentJavadocTask = TaskMaker.task(project, REFRESH_CURRENT_JAVADOC_TASK, task -> {
+    private Task createRefreshCurrentJavadocTask(Project project, Set<Copy> copyToCurrentTasks) {
+        return TaskMaker.task(project, REFRESH_CURRENT_JAVADOC_TASK, task -> {
             task.dependsOn(copyToCurrentTasks);
             task.setDescription("Copy Javadocs from all modules to the staging /current directory");
         });
+    }
 
-        Copy copyStageToRepoDir = TaskMaker.task(project, COPY_JAVADOC_STAGE_TO_REPO_DIR_TASK, Copy.class, task -> {
+    private Copy createCopyStageToRepoDirTask(Project project,
+                                              ShipkitConfiguration conf) {
+        String directory = conf.getLenient().getJavadoc().getRepositoryDirectory();
+
+        return TaskMaker.task(project, COPY_JAVADOC_STAGE_TO_REPO_DIR_TASK, Copy.class, task -> {
             task.setDescription("Copy prepared Javadocs from stage directory to the repository directory");
-            task.dependsOn(checkoutJavadocRepoBranch, refreshVersionJavadocTask, refreshCurrentJavadocTask);
             task.from(getJavadocStageDir(project));
             task.into(getJavadocRepoCloneDir(project, directory));
         });
+    }
+
+    private GitCommitTask createGitCommitTask(Project project, ShipkitConfiguration conf) {
+        String directory = conf.getLenient().getJavadoc().getRepositoryDirectory();
 
         GitCommitTask commitJavadocTask = GitCommitTaskFactory.createGitCommitTask(project, COMMIT_JAVADOC_TASK,
             "Commit changes in Javadoc repository directory");
 
-        commitJavadocTask.dependsOn(copyStageToRepoDir);
-        String commitMessage = getCommitMessage(project, lenientConf);
+        String commitMessage = getCommitMessage(project, conf.getLenient());
         commitJavadocTask.addDirectory(getJavadocRepoCloneDir(project, directory), commitMessage);
         commitJavadocTask.setWorkingDir(getJavadocRepoCloneDir(project));
+        return commitJavadocTask;
+    }
 
-        GitPushTask pushJavadoc = TaskMaker.task(project, PUSH_JAVADOC_TASK, GitPushTask.class, task -> {
-            task.setDescription("Pushes Javadocs to remote Javadoc repo.");
-            task.dependsOn(commitJavadocTask);
+    private GitPushTask createPushJavadocTask(Project project, ShipkitConfiguration conf) {
+        String branch = conf.getLenient().getJavadoc().getRepositoryBranch();
+        String javadocRepository = getJavadocRepository(conf);
+
+        return TaskMaker.task(project, PUSH_JAVADOC_TASK, GitPushTask.class, task -> {
+            task.setDescription("Pushes Javadocs to remote Javadoc repository");
             task.setDryRun(conf.isDryRun());
             task.setWorkingDir(getJavadocRepoCloneDir(project));
 
-            task.setUrl(cloneJavadocTask.getRepositoryUrl());
-            GitUrlInfo info = new GitUrlInfo(conf);
+            GitUrlInfo info = new GitUrlInfo(conf, javadocRepository);
+            task.setUrl(info.getGitUrl());
             task.setSecretValue(info.getWriteToken());
-            LOG.lifecycle(" Create pushJavadoc task token: " + info.getWriteToken());
             if (branch != null) {
                 task.getTargets().add(branch);
             }
         });
-
-        TaskMaker.task(project, RELEASE_JAVADOC_TASK, task -> {
-            task.setDescription("Clone Javadoc repository, copy Javadocs, commit and push");
-            task.dependsOn(cloneJavadocTask, commitJavadocTask, pushJavadoc);
-        });
-
-        deleteBuildDIrInRootProjectWhenCleanTask(project);
     }
 
-    private String getCommitMessage(Project project, ShipkitConfiguration lenientConf) {
-        String commitMessage = lenientConf.getJavadoc().getCommitMessage();
-        if (isNull(commitMessage)) {
-            commitMessage = "Update current and ${version} Javadocs.";
-        }
-        commitMessage = commitMessage.replaceAll("\\$\\{version\\}", project.getVersion().toString());
-        return commitMessage;
+    private Task createReleaseJavadocTask(Project project, CloneGitRepositoryTask cloneJavadocTask, GitCommitTask commitJavadocTask, GitPushTask pushJavadoc) {
+        return TaskMaker.task(project, RELEASE_JAVADOC_TASK, task -> {
+            task.setDescription("Clone Javadoc repository, copy Javadocs, commit and push");
+        });
     }
 
     private String getJavadocRepository(ShipkitConfiguration conf) {
@@ -174,10 +234,38 @@ public class JavadocPlugin implements Plugin<Project> {
         return project.getRootProject().getBuildDir().getAbsolutePath() + "/javadoc-stage";
     }
 
+    private boolean containsFileInDir(String directory) {
+        try {
+            return Files.walk(Paths.get(directory))
+                .anyMatch(path -> path.toFile().isFile());
+        } catch (IOException e) {
+            return false;
+        }
+    }
+
+    private String getCommitMessage(Project project, ShipkitConfiguration lenientConf) {
+        String commitMessage = lenientConf.getJavadoc().getCommitMessage();
+        if (isNull(commitMessage)) {
+            commitMessage = "Update current and ${version} Javadocs.";
+        }
+        commitMessage = commitMessage.replaceAll("\\$\\{version\\}", project.getVersion().toString());
+        return commitMessage;
+    }
+
     private void deleteBuildDIrInRootProjectWhenCleanTask(Project project) {
         Set<Task> cleanTasks = project.getTasksByName("clean", true);
-        cleanTasks.forEach(task -> task.doLast(task1 -> {
+        cleanTasks.forEach(task -> task.doLast(t -> {
             project.delete(project.getBuildDir().getAbsolutePath());
         }));
+    }
+
+    private class CopyTasks {
+        private final Set<Copy> copyToVersionTasks;
+        private final Set<Copy> copyToCurrentTasks;
+
+        private CopyTasks(Set<Copy> copyToVersionTasks, Set<Copy> copyToCurrentTasks) {
+            this.copyToVersionTasks = copyToVersionTasks;
+            this.copyToCurrentTasks = copyToCurrentTasks;
+        }
     }
 }

--- a/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/javadoc/JavadocPlugin.java
+++ b/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/javadoc/JavadocPlugin.java
@@ -20,9 +20,11 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 
+import static java.util.Collections.singletonList;
 import static java.util.Objects.isNull;
 
 /**
@@ -184,8 +186,9 @@ public class JavadocPlugin implements Plugin<Project> {
             "Commit changes in Javadoc repository directory");
 
         String commitMessage = getCommitMessage(project, conf.getLenient());
-        commitJavadocTask.addDirectory(getJavadocRepoCloneDir(project, directory), commitMessage);
-        commitJavadocTask.setWorkingDir(getJavadocRepoCloneDir(project));
+        File file = new File(getJavadocRepoCloneDir(project, directory));
+        commitJavadocTask.addChange(singletonList(file), commitMessage, null);
+        commitJavadocTask.setWorkingDir(new File(getJavadocRepoCloneDir(project)));
         return commitJavadocTask;
     }
 

--- a/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/javadoc/JavadocPlugin.java
+++ b/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/javadoc/JavadocPlugin.java
@@ -8,7 +8,12 @@ import org.gradle.api.logging.Logging;
 import org.gradle.api.tasks.Copy;
 import org.gradle.jvm.tasks.Jar;
 import org.shipkit.gradle.configuration.ShipkitConfiguration;
+import org.shipkit.gradle.git.GitCommitTask;
+import org.shipkit.gradle.git.GitPushTask;
 import org.shipkit.internal.gradle.configuration.ShipkitConfigurationPlugin;
+import org.shipkit.internal.gradle.git.GitCommitTaskFactory;
+import org.shipkit.internal.gradle.git.GitPlugin;
+import org.shipkit.internal.gradle.git.GitUrlInfo;
 import org.shipkit.internal.gradle.git.tasks.CloneGitRepositoryTask;
 import org.shipkit.internal.gradle.git.tasks.GitCheckOutTask;
 import org.shipkit.internal.gradle.util.TaskMaker;
@@ -25,22 +30,28 @@ import static org.shipkit.internal.util.RepositoryNameUtil.repositoryNameToCamel
 public class JavadocPlugin implements Plugin<Project> {
 
     private static final Logger LOG = Logging.getLogger(JavadocPlugin.class);
+    private static final String CHECKOUT_JAVADOC_REPO_BRANCH = "checkoutJavadocRepoBranch";
     private static final String CLONE_JAVADOC_REPO = "cloneJavadocRepo";
+    private static final String COMMIT_JAVADOC_TASK = "commitJavadoc";
+    private static final String COPY_JAVADOC_STAGE_TO_REPO_DIR_TASK = "copyJavadocStageToRepoDir";
+    private static final String COPY_JAVADOC_TO_STAGE_VERSION_DIR_TASK = "copyJavadocToStageVersionDir";
+    private static final String COPY_JAVADOC_TO_STAGE_CURRENT_DIR_TASK = "copyJavadocToStageCurrentDir";
+    private static final String PUSH_JAVADOC_TASK = "pushJavadoc";
+    private static final String RELEASE_JAVADOC_TASK = "releaseJavadoc";
     private static final String REFRESH_CURRENT_JAVADOC_TASK = "refreshCurrentJavadoc";
     private static final String REFRESH_VERSION_JAVADOC_TASK = "refreshVersionJavadoc";
-    private static final String CHECKOUT_JAVADOC_REPO_BRANCH = "checkoutJavadocRepoBranch";
-    public static final String COPY_JAVADOC_TO_STAGE_VERSION_DIR_TASK = "copyJavadocToStageVersionDir";
-    public static final String COPY_JAVADOC_TO_STAGE_CURRENT_DIR_TASK = "copyJavadocToStageCurrentDir";
-
 
     @Override
     public void apply(Project project) {
+        project.getPlugins().apply(GitPlugin.class);
+
         ShipkitConfiguration conf = project.getPlugins().apply(ShipkitConfigurationPlugin.class).getConfiguration();
         ShipkitConfiguration lenientConf = conf.getLenient();
+        String directory = lenientConf.getGitHub().getJavadocRepositoryDirectory();
+        String branch = lenientConf.getGitHub().getJavadocRepositoryBranch();
         String javadocRepository = getJavadocRepository(conf);
         String gitHubUrl = conf.getGitHub().getUrl();
 
-        //TODO what when repo doesn't exist? Fail or warning?
         CloneGitRepositoryTask cloneJavadocTask = TaskMaker.task(project, CLONE_JAVADOC_REPO, CloneGitRepositoryTask.class,
             task -> {
                 task.setDescription("Clones Javadoc repo " + javadocRepository + " into a temporary directory.");
@@ -51,7 +62,6 @@ public class JavadocPlugin implements Plugin<Project> {
             });
 
         TaskMaker.task(project, CHECKOUT_JAVADOC_REPO_BRANCH, GitCheckOutTask.class, task -> {
-            String branch = lenientConf.getGitHub().getJavadocRepositoryBranch();
             task.setDescription("Checkout branch in Javadoc repository");
             task.dependsOn(cloneJavadocTask);
             task.onlyIf(foo -> branch != null);
@@ -93,9 +103,43 @@ public class JavadocPlugin implements Plugin<Project> {
 
         Task refreshCurrentJavadocTask = TaskMaker.task(project, REFRESH_CURRENT_JAVADOC_TASK, task -> {
             task.dependsOn(copyToCurrentTasks);
-            task.setDescription("Copy Javadocs from all modules to the staging /version directory");
+            task.setDescription("Copy Javadocs from all modules to the staging /current directory");
         });
 
+        Copy copyStageToRepoDir = TaskMaker.task(project, COPY_JAVADOC_STAGE_TO_REPO_DIR_TASK, Copy.class, task -> {
+            task.setDescription("Copy prepared Javadocs from stage directory to the repository directory");
+            task.dependsOn(refreshVersionJavadocTask, refreshCurrentJavadocTask);
+            task.from(getJavadocStageDir(project));
+            task.into(getJavadocRepoCloneDir(project, javadocRepository, directory));
+        });
+
+        GitCommitTask commitJavadocTask = GitCommitTaskFactory.createGitCommitTask(project, COMMIT_JAVADOC_TASK,
+            "Commit changes in Javadoc repository directory");
+
+        commitJavadocTask.dependsOn(copyStageToRepoDir);
+        commitJavadocTask.addDirectory(getJavadocRepoCloneDir(project, javadocRepository, directory),
+                "Update current and " + project.getVersion() + " Javadocs");
+        commitJavadocTask.setWorkingDir(getJavadocRepoCloneDir(project, javadocRepository));
+
+        GitPushTask pushJavadoc = TaskMaker.task(project, PUSH_JAVADOC_TASK, GitPushTask.class, task -> {
+            task.setDescription("Pushes Javadocs to remote Javadoc repo.");
+            task.dependsOn(commitJavadocTask);
+            task.setDryRun(conf.isDryRun());
+            task.setWorkingDir(getJavadocRepoCloneDir(project, javadocRepository));
+
+            task.setUrl(cloneJavadocTask.getRepositoryUrl());
+            GitUrlInfo info = new GitUrlInfo(conf);
+            task.setSecretValue(info.getWriteToken());
+            LOG.lifecycle(" Create pushJavadoc task token: " + info.getWriteToken());
+            if (branch != null) {
+                task.getTargets().add(branch);
+            }
+        });
+
+        TaskMaker.task(project, RELEASE_JAVADOC_TASK, task -> {
+            task.setDescription("Clone Javadoc repository, copy Javadocs, commit and push");
+            task.dependsOn(cloneJavadocTask, commitJavadocTask, pushJavadoc);
+        });
     }
 
     private String getJavadocRepository(ShipkitConfiguration conf) {
@@ -108,6 +152,11 @@ public class JavadocPlugin implements Plugin<Project> {
 
     private String getJavadocRepoCloneDir(Project project, String javadocRepository) {
         return project.getRootProject().getBuildDir().getAbsolutePath() + "/javadoc-repo/" + repositoryNameToCamelCase(javadocRepository);
+    }
+
+    private String getJavadocRepoCloneDir(Project project, String javadocRepository, String subdirectory) {
+        return getJavadocRepoCloneDir(project, javadocRepository)
+            + "/" + (subdirectory != null ? subdirectory : ".");
     }
 
     private String getJavadocStageDir(Project project) {

--- a/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/notes/tasks/UpdateReleaseNotes.java
+++ b/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/notes/tasks/UpdateReleaseNotes.java
@@ -94,6 +94,7 @@ public class UpdateReleaseNotes {
 
         Map<String, Contributor> contributorsMap = contributorsMap(task.getContributors(), contributorsFromGitHub, task.getDevelopers(), task.getGitHubUrl());
         BadgeFormatter badgeFormatter = new BadgeFormatter();
+        // TODO release notes contain link to new javadoc
         String notes = ReleaseNotesFormatters.detailedFormatter(headerMessage,
             "", task.getGitHubLabelMapping(), vcsCommitTemplate, task.getPublicationRepository(),
             contributorsMap, task.isEmphasizeVersion(), badgeFormatter)

--- a/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/versionupgrade/UpgradeDependencyPlugin.java
+++ b/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/versionupgrade/UpgradeDependencyPlugin.java
@@ -137,7 +137,7 @@ public class UpgradeDependencyPlugin implements Plugin<Project> {
 
                 gitOriginPlugin.provideOriginRepo(task, new Action<String>() {
                     public void execute(String originRepo) {
-                        GitUrlInfo info = new GitUrlInfo(conf);
+                        GitUrlInfo info = new GitUrlInfo(conf, conf.getGitHub().getRepository());
                         task.setUrl(info.getGitUrl());
                         task.setSecretValue(info.getWriteToken());
                     }
@@ -230,7 +230,7 @@ public class UpgradeDependencyPlugin implements Plugin<Project> {
 
                 gitOriginPlugin.provideOriginRepo(task, new Action<String>() {
                     public void execute(String originRepo) {
-                        GitUrlInfo info = new GitUrlInfo(conf);
+                        GitUrlInfo info = new GitUrlInfo(conf, conf.getGitHub().getRepository());
                         task.setUrl(info.getGitUrl());
                         task.setSecretValue(info.getWriteToken());
                     }

--- a/subprojects/shipkit/src/main/groovy/org/shipkit/internal/notes/format/DetailedFormatter.java
+++ b/subprojects/shipkit/src/main/groovy/org/shipkit/internal/notes/format/DetailedFormatter.java
@@ -76,6 +76,7 @@ class DetailedFormatter implements MultiReleaseNotesFormatter {
 
     String releaseSummary(Date date, String version, ContributionSet contributions, Map<String, Contributor>
         contributors, String vcsCommitsLink, String publicationRepository) {
+        // TODO the message at the end of the release points to new javadoc
         return summaryDatePrefix(date) + authorsSummary(contributions, contributors, vcsCommitsLink)
             + " - published to " + badgeFormatter.getRepositoryBadge(version, publicationRepository) + "\n" +
             authorsSummaryAppendix(contributions, contributors);

--- a/subprojects/shipkit/src/main/resources/META-INF/gradle-plugins/org.shipkit.javadoc.properties
+++ b/subprojects/shipkit/src/main/resources/META-INF/gradle-plugins/org.shipkit.javadoc.properties
@@ -1,0 +1,1 @@
+implementation-class=org.shipkit.internal.gradle.javadoc.JavadocPlugin

--- a/subprojects/shipkit/src/test/groovy/org/shipkit/internal/gradle/git/tasks/GitCommitImplTest.groovy
+++ b/subprojects/shipkit/src/test/groovy/org/shipkit/internal/gradle/git/tasks/GitCommitImplTest.groovy
@@ -19,23 +19,7 @@ class GitCommitImplTest extends Specification {
         def f2 = new File("f2")
 
         expect:
-        getAddCommand([f1, f2], []) == ["git", "add", f1.absolutePath, f2.absolutePath]
-    }
-
-    def "git add command for directories"() {
-        def d1 = new File("d1")
-        def d2 = new File("d2")
-
-        expect:
-        getAddCommand([], [d1, d2]) == ["git", "add", d1.absolutePath, d2.absolutePath]
-    }
-
-    def "git add command for files and directories"() {
-        def f1 = new File("f1")
-        def d1 = new File("d1")
-
-        expect:
-        getAddCommand([f1], [d1]) == ["git", "add", f1.absolutePath, d1.absolutePath]
+        getAddCommand([f1, f2]) == ["git", "add", f1.absolutePath, f2.absolutePath]
     }
 
     def "git commit command"() {

--- a/subprojects/shipkit/src/test/groovy/org/shipkit/internal/gradle/git/tasks/GitCommitImplTest.groovy
+++ b/subprojects/shipkit/src/test/groovy/org/shipkit/internal/gradle/git/tasks/GitCommitImplTest.groovy
@@ -14,12 +14,28 @@ class GitCommitImplTest extends Specification {
         getAggregatedCommitMessage(["release notes updated", "version bumped"]) == "release notes updated + version bumped"
     }
 
-    def "git add command"() {
+    def "git add command for files"() {
         def f1 = new File("f1")
         def f2 = new File("f2")
 
         expect:
-        getAddCommand([f1, f2]) == ["git", "add", f1.absolutePath, f2.absolutePath]
+        getAddCommand([f1, f2], []) == ["git", "add", f1.absolutePath, f2.absolutePath]
+    }
+
+    def "git add command for directories"() {
+        def d1 = new File("d1")
+        def d2 = new File("d2")
+
+        expect:
+        getAddCommand([], [d1, d2]) == ["git", "add", d1.absolutePath, d2.absolutePath]
+    }
+
+    def "git add command for files and directories"() {
+        def f1 = new File("f1")
+        def d1 = new File("d1")
+
+        expect:
+        getAddCommand([f1], [d1]) == ["git", "add", f1.absolutePath, d1.absolutePath]
     }
 
     def "git commit command"() {

--- a/subprojects/shipkit/src/test/groovy/org/shipkit/internal/gradle/git/tasks/GitCommitTaskTest.groovy
+++ b/subprojects/shipkit/src/test/groovy/org/shipkit/internal/gradle/git/tasks/GitCommitTaskTest.groovy
@@ -22,14 +22,17 @@ class GitCommitTaskTest extends Specification {
         gitCommit.dependsOn.contains(task)
     }
 
-    def "enables adding directory to commit"() {
+    def "enables adding changes to commit and null task"() {
+        def f = new File("foo")
         def gitCommit = project.tasks.create("foo", GitCommitTask)
+        def numberOfDepended = gitCommit.dependsOn.size()
 
         when:
-        gitCommit.addDirectory("foo", "description")
+        gitCommit.addChange([f], "description", null)
 
         then:
         gitCommit.descriptions == ["description"]
-        gitCommit.directoriesToCommit == [new File("foo")]
+        gitCommit.filesToCommit == [f]
+        gitCommit.dependsOn.size() == numberOfDepended
     }
 }

--- a/subprojects/shipkit/src/test/groovy/org/shipkit/internal/gradle/git/tasks/GitCommitTaskTest.groovy
+++ b/subprojects/shipkit/src/test/groovy/org/shipkit/internal/gradle/git/tasks/GitCommitTaskTest.groovy
@@ -19,5 +19,17 @@ class GitCommitTaskTest extends Specification {
         then:
         gitCommit.descriptions == ["description"]
         gitCommit.filesToCommit == [f]
+        gitCommit.dependsOn.contains(task)
+    }
+
+    def "enables adding directory to commit"() {
+        def gitCommit = project.tasks.create("foo", GitCommitTask)
+
+        when:
+        gitCommit.addDirectory("foo", "description")
+
+        then:
+        gitCommit.descriptions == ["description"]
+        gitCommit.directoriesToCommit == [new File("foo")]
     }
 }

--- a/version.properties
+++ b/version.properties
@@ -1,6 +1,6 @@
 #Version of the produced binaries. This file is intended to be checked-in.
 #It will be automatically bumped by release automation.
-version=2.1.9
+version=2.2.0
 
 #Last previous release version
 previousVersion=2.1.8


### PR DESCRIPTION
New plugin that enables the project to ship Javadoc to specific GitHub repo. This way, one can leverage GitHub pages for the presenting the docs to the users.

Fixes #233