### PR TITLE
add additional error info for identifyGitOrigin

### DIFF
--- a/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/git/tasks/IdentifyGitOriginRepoTask.java
+++ b/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/git/tasks/IdentifyGitOriginRepoTask.java
@@ -80,8 +80,9 @@ public class IdentifyGitOriginRepoTask extends DefaultTask {
 
     private String getAdditionalInfo(Exception e) {
         Throwable cause = e.getCause();
-        if(cause == null)
+        if (cause == null) {
             return "";
+        }
 
         return "  Error message:\n    " + cause.getMessage() + "\n";
     }

--- a/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/git/tasks/IdentifyGitOriginRepoTask.java
+++ b/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/git/tasks/IdentifyGitOriginRepoTask.java
@@ -44,6 +44,7 @@ public class IdentifyGitOriginRepoTask extends DefaultTask {
             LOG.lifecycle("  Identified Git origin repository: " + repository);
         } catch (Exception e) {
             LOG.lifecycle("  Problems getting url of git remote origin (run with -i or -d for more info).\n" +
+                getAdditionalInfo(e) +
                 "  Using fallback '" + FALLBACK_GITHUB_REPO + "' instead.\n" +
                 "  Please update it in the shipkit file.\n");
             LOG.debug("  Problems getting url of git remote origin", e);
@@ -75,5 +76,13 @@ public class IdentifyGitOriginRepoTask extends DefaultTask {
     @ExposedForTesting
     void setOriginRepoProvider(GitOriginRepoProvider originRepoProvider) {
         this.originRepoProvider = originRepoProvider;
+    }
+
+    private String getAdditionalInfo(Exception e) {
+        Throwable cause = e.getCause();
+        if(cause == null)
+            return "";
+
+        return "  Error message:\n    " + cause.getMessage() + "\n";
     }
 }


### PR DESCRIPTION
fix #797

> If the PATH variable does not contain git, then after running the command **./gradlew initShipkit** you get:
> ```
> ...
> Task :identifyGitOrigin
>   Executing:
>     git remote get-url origin
>   Problems getting url of git remote origin (run with -i or -d for more info).
>   Using fallback 'unspecified-user/unspecified-repo' instead.
>   Please update it in the shipkit file.
> ...
> ```
> 

This pr adds Error message subsection to identifyGitOrigin section.
The Error message is extracted from thrown exception.

Example of a new output if Git is absent:
```
...
:identifyGitOrigin
  Executing:
    git remote get-url origin
  Problems getting url of git remote origin (run with -i or -d for more info).
  Error message:
    Cannot run program "git" (in directory "xxx"): error=2, No such file or directory
  Using fallback 'unspecified-user/unspecified-repo' instead.
  Please update it in the shipkit file.
...
```
