### PR TITLE
fix deprecation warning -> use onfigurableReport.setDestination(File)

### DIFF
--- a/subprojects/shipkit/shipkit.gradle
+++ b/subprojects/shipkit/shipkit.gradle
@@ -100,7 +100,7 @@ task codeCoverageReport(type:JacocoReport) {
 
     reports {
         xml.enabled true
-        xml.destination "${buildDir}/reports/jacoco/report.xml"
+        xml.destination file("${buildDir}/reports/jacoco/report.xml")
         html.enabled false
         csv.enabled false
     }


### PR DESCRIPTION
basically, getting rid of this warning
```
> Configure project :shipkit
The ConfigurableReport.setDestination(Object) method has been deprecated and is scheduled to be removed in Gradle 5.0. Please use the method ConfigurableReport.setDestination(File) instead.
        at shipkit_2cr6fz4tp44wkkz1iroi80u1s$_run_closure9$_closure18.doCall(/home/ep/projects/github/mockito-project/mockito-release-tools/subprojects/shipkit/shipkit.gradle:103)
```