### PR TITLE
use sourceSets.main for JacocoReport

### DIFF
--- a/subprojects/shipkit/shipkit.gradle
+++ b/subprojects/shipkit/shipkit.gradle
@@ -96,7 +96,7 @@ jacoco {
 
 task codeCoverageReport(type:JacocoReport) {
     executionData fileTree(project.rootDir.absolutePath).include("**/build/jacoco/*.exec")
-    sourceSets sourceSets.test
+    sourceSets sourceSets.main
 
     reports {
         xml.enabled true


### PR DESCRIPTION
it looks like we do get coverage for the test source set now, let's change it to the main source set.