### PR TITLE
fix broken link in docs

### DIFF
--- a/docs/features/publishing-binaries.md
+++ b/docs/features/publishing-binaries.md
@@ -41,7 +41,7 @@ All tasks:
 ```
 
 Normally, we don't run any of those tasks.
-Travis CI is configured to publish automatically but only [when the release is needed](docs/gradle-plugins/release-needed-plugin.md).
+Travis CI is configured to publish automatically but only [when the release is needed](/docs/gradle-plugins/release-needed-plugin.md).
 Here's an example [.travis.yml file](https://github.com/mockito/shipkit-example/blob/master/.travis.yml) from our example project.
 
 ```


### PR DESCRIPTION
currently, the link points to https://github.com/mockito/shipkit/blob/master/docs/features/docs/gradle-plugins/release-needed-plugin.md.
After merging this one the link is no longer broken and points to https://github.com/mockito/shipkit/blob/master/docs/gradle-plugins/release-needed-plugin.md.