### PR TITLE
Fixed the pom packaging bug

### DIFF
--- a/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/util/PomCustomizer.java
+++ b/subprojects/shipkit/src/main/groovy/org/shipkit/internal/gradle/util/PomCustomizer.java
@@ -1,5 +1,6 @@
 package org.shipkit.internal.gradle.util;
 
+import groovy.xml.QName;
 import org.gradle.api.Action;
 import org.gradle.api.Project;
 import org.gradle.api.XmlProvider;
@@ -67,8 +68,12 @@ public class PomCustomizer {
                              String projectName, String projectDescription,
                              ProjectContributorsSet contributorsFromGitHub) {
         //Assumes project has java plugin applied. Pretty safe assumption
+        //TODO: we need to conditionally append nodes because given node may already be on the root (issue 847)
+        //TODO: all root.appendNode() need to be conditional
         root.appendNode("name", projectName);
-        root.appendNode("packaging", "jar");
+        if (root.getAt(new QName("packaging")).isEmpty()) {
+            root.appendNode("packaging", "jar");
+        }
 
         String repoLink = conf.getGitHub().getUrl() + "/" + conf.getGitHub().getRepository();
         root.appendNode("url", repoLink);

--- a/subprojects/shipkit/src/test/groovy/org/shipkit/internal/gradle/util/PomCustomizerTest.groovy
+++ b/subprojects/shipkit/src/test/groovy/org/shipkit/internal/gradle/util/PomCustomizerTest.groovy
@@ -5,6 +5,7 @@ import org.gradle.testfixtures.ProjectBuilder
 import org.shipkit.gradle.configuration.ShipkitConfiguration
 import org.shipkit.internal.notes.contributors.DefaultProjectContributor
 import org.shipkit.internal.notes.contributors.DefaultProjectContributorsSet
+import spock.lang.Issue
 import spock.lang.Specification
 
 class PomCustomizerTest extends Specification {
@@ -230,6 +231,41 @@ class PomCustomizerTest extends Specification {
         printXml(node) == """<project>
   <name>foo</name>
   <packaging>jar</packaging>
+  <url>https://github.com/repo</url>
+  <description>Foo library</description>
+  <licenses>
+    <license>
+      <name>The MIT License</name>
+      <url>https://github.com/repo/blob/master/LICENSE</url>
+      <distribution>repo</distribution>
+    </license>
+  </licenses>
+  <scm>
+    <url>https://github.com/repo.git</url>
+  </scm>
+  <issueManagement>
+    <url>https://github.com/repo/issues</url>
+    <system>GitHub issues</system>
+  </issueManagement>
+  <ciManagement>
+    <url>https://travis-ci.org/repo</url>
+    <system>TravisCI</system>
+  </ciManagement>
+</project>
+"""
+    }
+
+    @Issue("847")
+    def "preconfigured pom"() {
+        conf.gitHub.repository = "repo"
+        node.appendNode("packaging", "unbundled");
+
+        PomCustomizer.customizePom(node, conf, "foo", "Foo library", new DefaultProjectContributorsSet())
+
+        expect:
+        printXml(node) == """<project>
+  <packaging>unbundled</packaging>
+  <name>foo</name>
   <url>https://github.com/repo</url>
   <description>Foo library</description>
   <licenses>


### PR DESCRIPTION
Fixes #847 - users can configure pom in the build.file so our logic cannot blindly add XML nodes - we need to check for existence of nodes.

This is a wider problem - this PR fixes one instance - see the TODO in the code.

Happy New Year everybody :-)