### PR TITLE
Fixed GitHub authorization

### DIFF
--- a/subprojects/shipkit/src/main/groovy/org/shipkit/internal/notes/contributors/github/GitHubContributorsFetcher.java
+++ b/subprojects/shipkit/src/main/groovy/org/shipkit/internal/notes/contributors/github/GitHubContributorsFetcher.java
@@ -66,8 +66,8 @@ class GitHubContributorsFetcher {
             return new GitHubProjectContributorsBuilder(apiUrl, repository, readOnlyAuthToken);
         }
 
-        private GitHubProjectContributors(String nextPageUrl) {
-            fetcher = new GitHubListFetcher(nextPageUrl);
+        private GitHubProjectContributors(String nextPageUrl, String readOnlyAuthToken) {
+            fetcher = new GitHubListFetcher(nextPageUrl, readOnlyAuthToken);
         }
 
         public boolean hasNextPage() {
@@ -95,9 +95,8 @@ class GitHubContributorsFetcher {
         GitHubProjectContributors build() {
             // see API doc: https://developer.github.com/v3/repos/#list-contributors
             String nextPageUrl = apiUrl + "/repos/" + repository + "/contributors" +
-                    "?access_token=" + readOnlyAuthToken +
-                    "&per_page=100";
-            return new GitHubProjectContributors(nextPageUrl);
+                    "?&per_page=100";
+            return new GitHubProjectContributors(nextPageUrl, readOnlyAuthToken);
         }
     }
 }

--- a/subprojects/shipkit/src/main/groovy/org/shipkit/internal/notes/contributors/github/RecentContributorsFetcher.java
+++ b/subprojects/shipkit/src/main/groovy/org/shipkit/internal/notes/contributors/github/RecentContributorsFetcher.java
@@ -72,8 +72,8 @@ class RecentContributorsFetcher {
         private final GitHubListFetcher fetcher;
         private List<JsonObject> lastFetchedPage;
 
-        private GitHubCommits(String nextPageUrl) {
-            fetcher = new GitHubListFetcher(nextPageUrl);
+        private GitHubCommits(String nextPageUrl, String readOnlyAuthToken) {
+            fetcher = new GitHubListFetcher(nextPageUrl, readOnlyAuthToken);
         }
 
         boolean hasNextPage() {
@@ -108,11 +108,10 @@ class RecentContributorsFetcher {
             GitHubCommits build() {
                 // see API doc: https://developer.github.com/v3/repos/commits/#list-commits-on-a-repository
                 String nextPageUrl = apiUrl + "/repos/" + repository + "/commits"
-                        + "?access_token=" + readOnlyAuthToken
-                        + "&since=" + forGitHub(dateSince)
+                        + "?&since=" + forGitHub(dateSince)
                         + ((dateUntil != null) ? "&until=" + forGitHub(dateUntil) : "")
                         + "&page=1&per_page=100";
-                return new GitHubCommits(nextPageUrl);
+                return new GitHubCommits(nextPageUrl, readOnlyAuthToken);
             }
         }
     }

--- a/subprojects/shipkit/src/main/groovy/org/shipkit/internal/notes/improvements/GitHubTicketFetcher.java
+++ b/subprojects/shipkit/src/main/groovy/org/shipkit/internal/notes/improvements/GitHubTicketFetcher.java
@@ -95,8 +95,8 @@ class GitHubTicketFetcher {
 
         private final GitHubListFetcher fetcher;
 
-        private GitHubIssues(String nextPageUrl) {
-            fetcher = new GitHubListFetcher(nextPageUrl);
+        private GitHubIssues(String nextPageUrl, String readOnlyAuthToken) {
+            fetcher = new GitHubListFetcher(nextPageUrl, readOnlyAuthToken);
         }
 
         boolean hasNextPage() {
@@ -156,10 +156,12 @@ class GitHubTicketFetcher {
                         .append("/issues?page=1");
 
                 for (Map.Entry<String, String> parameter : parameters.entrySet()) {
+                    if (parameter.getKey().equals("access_token")) continue;
                     urlBuilder.append("&").append(parameter.getKey()).append("=").append(parameter.getValue());
                 }
 
-                return new GitHubIssues(urlBuilder.toString());
+                String readOnlyAuthToken = parameters.get("access_token");
+                return new GitHubIssues(urlBuilder.toString(), readOnlyAuthToken);
             }
         }
     }

--- a/subprojects/shipkit/src/main/groovy/org/shipkit/internal/notes/improvements/GitHubTicketFetcher.java
+++ b/subprojects/shipkit/src/main/groovy/org/shipkit/internal/notes/improvements/GitHubTicketFetcher.java
@@ -114,15 +114,16 @@ class GitHubTicketFetcher {
         private static class GitHubIssuesBuilder {
             private final String apiUrl;
             private final String repository;
+            private final String readOnlyAuthToken;
 
             private Map<String, String> parameters;
 
             GitHubIssuesBuilder(String apiUrl, String repository, String readOnlyAuthToken) {
                 this.apiUrl = apiUrl;
                 this.repository = repository;
+                this.readOnlyAuthToken = readOnlyAuthToken;
 
                 parameters = new HashMap<>();
-                parameters.put("access_token", readOnlyAuthToken);
             }
 
             GitHubIssuesBuilder state(String state) {
@@ -156,11 +157,9 @@ class GitHubTicketFetcher {
                         .append("/issues?page=1");
 
                 for (Map.Entry<String, String> parameter : parameters.entrySet()) {
-                    if (parameter.getKey().equals("access_token")) continue;
                     urlBuilder.append("&").append(parameter.getKey()).append("=").append(parameter.getValue());
                 }
 
-                String readOnlyAuthToken = parameters.get("access_token");
                 return new GitHubIssues(urlBuilder.toString(), readOnlyAuthToken);
             }
         }

--- a/subprojects/shipkit/src/main/groovy/org/shipkit/internal/notes/util/GitHubListFetcher.java
+++ b/subprojects/shipkit/src/main/groovy/org/shipkit/internal/notes/util/GitHubListFetcher.java
@@ -23,10 +23,12 @@ public class GitHubListFetcher {
     private static final Logger LOG = Logging.getLogger(GitHubListFetcher.class);
 
     private static final String RELATIVE_LINK_NOT_FOUND = "none";
+    private final String readOnlyAuthToken;
     private String nextPageUrl;
 
-    public GitHubListFetcher(String nextPageUrl) {
+    public GitHubListFetcher(String nextPageUrl, String readOnlyAuthToken) {
         this.nextPageUrl = nextPageUrl;
+        this.readOnlyAuthToken = readOnlyAuthToken;
     }
 
     public boolean hasNextPage() {
@@ -41,6 +43,7 @@ public class GitHubListFetcher {
         LOG.info("GitHub API querying page {}", queryParamValue(url, "page"));
         LOG.lifecycle("GET " + nextPageUrl);
         URLConnection urlConnection = url.openConnection();
+        urlConnection.setRequestProperty("Authorization", "token " + readOnlyAuthToken);
         LOG.info("Established connection to GitHub API");
 
         String resetInLocalTime = resetLimitInLocalTimeOrEmpty(urlConnection);

--- a/subprojects/shipkit/src/main/groovy/org/shipkit/internal/notes/util/GitHubObjectFetcher.java
+++ b/subprojects/shipkit/src/main/groovy/org/shipkit/internal/notes/util/GitHubObjectFetcher.java
@@ -27,10 +27,11 @@ public class GitHubObjectFetcher {
     }
 
     public JsonObject getPage(String pageUrl) throws IOException, DeserializationException {
-        URL url = new URL(String.format("%s%s%s", pageUrl, "?access_token=", authToken));
+        URL url = new URL(pageUrl);
         LOG.info("GitHub API querying page {}", url);
         LOG.lifecycle("GET {}", url);
         URLConnection urlConnection = url.openConnection();
+        urlConnection.setRequestProperty("Authorization", "token " + authToken);
 
         String resetInLocalTime = resetLimitInLocalTimeOrEmpty(urlConnection);
 


### PR DESCRIPTION
GitHub will no longer support authentication through query parameters (reported in issue #864; more info: https://developer.github.com/changes/2019-11-05-deprecated-passwords-and-authorizations-api/#authenticating-using-query-parameters, https://developer.github.com/changes/2020-02-10-deprecating-auth-through-query-param/).
To deal with this issue there was a need to move authentication to the connection header.
It was done in GitHubListFetcher and GitHubObjectFetcher classes. Followed by this refactor there was also a necessity to refactor GitHubContributorsFetcher, RecentContributorsFetcher and
GitHubTicketFetcher classes.