### PR TITLE
Fixed the build issue preventing releases

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,6 +8,7 @@ buildscript {
         classpath 'org.shipkit:shipkit:2.3.1'
         classpath 'com.gradle:build-scan-plugin:1.16'
         classpath 'ru.vyarus:gradle-animalsniffer-plugin:1.4.6'
+        classpath "com.gradle.publish:plugin-publish-plugin:0.12.0"
     }
 }
 


### PR DESCRIPTION
We need to use newer version of Gradle Plugin Portal publishing plugin. The error message from Travis CI:

This version of the com.gradle.plugin-publish plugin is no longer supported due to a critical security vulnerability. Please update to the latest version of the com.gradle.plugin-publish plugin (...)