### PR TITLE
Bumped version of publishing plugin

### DIFF
--- a/subprojects/shipkit/shipkit.gradle
+++ b/subprojects/shipkit/shipkit.gradle
@@ -22,7 +22,7 @@ dependencies {
 
     compile "com.github.cliftonlabs:json-simple:2.1.2"
     compile 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.4'
-    compile "com.gradle.publish:plugin-publish-plugin:0.9.10"
+    compile "com.gradle.publish:plugin-publish-plugin:0.12.0"
     compile 'com.googlecode.java-diff-utils:diffutils:1.3.0'
 
     testCompile("org.spockframework:spock-core:1.3-groovy-2.4") {


### PR DESCRIPTION
We need to use newer version of Gradle Plugin Portal publishing plugin. Otherwise Shipkit won't be able to publish to Gradle Plugin Portal. The error message from Travis CI:

This version of the com.gradle.plugin-publish plugin is no longer supported due to a critical security vulnerability. Please update to the latest version of the com.gradle.plugin-publish plugin (...)